### PR TITLE
Fix CardAction cursor flicker referenced by #39

### DIFF
--- a/WPFUI/Styles/Controls/CardAction.xaml
+++ b/WPFUI/Styles/Controls/CardAction.xaml
@@ -11,6 +11,7 @@
     xmlns:controls="clr-namespace:WPFUI.Controls">
 
     <Style TargetType="{x:Type controls:CardAction}">
+        <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Foreground">
             <Setter.Value>
                 <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
@@ -34,8 +35,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="1"
-                        CornerRadius="4"
-                        Cursor="Hand">
+                        CornerRadius="4">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
To fix #39 the `Cursor` property of the base control (e.g. `Button`) is now set, rather than explicitly setting `Hand="Cursor"` in the `CardBorder` element (part of the `ControlTemplate`).

This fix has an added benefit of letting a developer change the `Cursor` property for a `CardAction` control in the designer (previous implementation would ignore whatever `Cursor` value was set in the designer).