### PR TITLE
Maximize and Restore icon update fix

### DIFF
--- a/WPFUI/Controls/TitleBar.cs
+++ b/WPFUI/Controls/TitleBar.cs
@@ -492,6 +492,22 @@ namespace WPFUI.Controls
                 rootGrid.MouseDown += RootGrid_MouseDown;
                 rootGrid.MouseLeftButtonDown += RootGrid_MouseLeftButtonDown;
             }
+
+            if (ParentWindow != null)
+            {
+                ParentWindow.StateChanged += ParentWindow_StateChanged;
+            }
+        }
+
+        private void ParentWindow_StateChanged(object sender, EventArgs e)
+        {
+            if (ParentWindow != null)
+            {
+                if (IsMaximized != (ParentWindow.WindowState == WindowState.Maximized))
+                {
+                    IsMaximized = ParentWindow.WindowState == WindowState.Maximized;
+                }
+            }
         }
 
         private void RootGrid_MouseDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
This PR fixes #37 where the maximize/restore icons in the `TitleBar` control are not updating if the `MaximizeWindow` method is not called.
- The fix implements a sanity check on the `ParentWindow.StateChanged` event
- If the `IsMaximized` value does not match what it should be after the `ParentWindow` changes its `WindowState` value, it is assigned the proper value

**Considerations for accepting this PR:** the solution provided here does not take into account if the `ParentWindow` changes after the `TitleBar` is loaded (since the subscription is done in `TitleBar_Loaded` method). This could result in undefined behavior for those cases (e.g. the TitleBar control could be subscribed to a window event that it shouldn't be, doesn't subscribe to the new window event). I'm not sure if this is reasonable use case to support so I didn't want to overengineer the solution in this PR. If we want to handle that, please let me know and I will try to tackle that.

_P.S. I apologize for the merge commit after the fix commit, I forgot to fetch after my previous PR was accepted. I'm not super comfortable with rebasing so I didn't want to mess with it too much -- if this is an issue for mucking up the commit history on the main branch please let me know, I'll simply nuke the branch and redo the commits on another branch for a clean history._