### PR TITLE
Implement window dragging when maximized (fix #36)

### DIFF
--- a/WPFUI/Controls/TitleBar.cs
+++ b/WPFUI/Controls/TitleBar.cs
@@ -459,10 +459,38 @@ namespace WPFUI.Controls
             {
                 rootGrid.MouseDown += RootGrid_MouseDown;
                 rootGrid.MouseLeftButtonDown += RootGrid_MouseLeftButtonDown;
+                rootGrid.MouseMove += RootGrid_MouseMove;
             }
 
             if (ParentWindow != null)
                 ParentWindow.StateChanged += ParentWindow_StateChanged;
+        }
+
+        private void RootGrid_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.LeftButton != MouseButtonState.Pressed || ParentWindow == null) return;
+
+            if (IsMaximized)
+            {
+                var screenPoint = PointToScreen(e.MouseDevice.GetPosition(this));
+
+                // TODO: refine the Left value to be more accurate
+                // - This calculation is good enough using the center
+                //   of the titlebar, however this isn't quite accurate for
+                //   how the OS operates.
+                // - It should be set as a % (e.g. screen X / maximized width),
+                //   then offset from the left to line up more naturally.
+                ParentWindow.Left = screenPoint.X - (ParentWindow.RestoreBounds.Width * 0.5);
+                ParentWindow.Top = 0d;
+
+                // style has to be quickly swapped to avoid restore animation delay
+                var style = ParentWindow.WindowStyle;
+                ParentWindow.WindowStyle = WindowStyle.None;
+                ParentWindow.WindowState = WindowState.Normal;
+                ParentWindow.WindowStyle = style;
+
+                ParentWindow.DragMove();
+            }
         }
 
         private void ParentWindow_StateChanged(object sender, EventArgs e)
@@ -477,18 +505,6 @@ namespace WPFUI.Controls
         {
             if (e.ChangedButton != MouseButton.Left)
                 return;
-
-            // TODO: Restore on maximize and move when single click and hold
-
-            //if (e.ClickCount == 1 && e.ButtonState == MouseButtonState.Pressed && ParentWindow.WindowState == WindowState.Maximized)
-            //{
-            //    MaximizeWindow();
-            //    ParentWindow.DragMove();
-            //}
-            //else
-            //{
-            //    ParentWindow.DragMove();
-            //}
 
             ParentWindow.DragMove();
         }


### PR DESCRIPTION
This PR implements the functionality to allow restore-dragging from the TitleBar while the window is maximized (e.g. fix #36):
- Essentially subscribes to the `MouseMove` event from the `RootGrid` element
- Uses some basic logic to see if the window should be restored and dragged when the mouse is moved in the handler

**Additional info:** After further testing with the mentioned "janky" frame (e.g. in [this](https://github.com/lepoco/wpfui/issues/36#issuecomment-1020532402) comment), this was actually attributed to being in debug mode. The "restore-drag" implementation in this PR does not cause any resizing issues in Release mode without a debugger attached.

Edit: linked issue to PR