### PR TITLE
Fix DPI scaling issue with restore-drag functionality

### DIFF
--- a/WPFUI/Common/Dpi.cs
+++ b/WPFUI/Common/Dpi.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace WPFUI.Common
+{
+    /// <summary>
+    /// Provides access to various DPI-related methods.
+    /// </summary>
+    internal static class Dpi
+    {
+        // TODO: look into utilizing preprocessor symbols for more functionality
+        // ----
+        // There is an opportunity to check against NET46 if we can use
+        // VisualTreeHelper in this class. We are currently not utilizing
+        // it because it is not available in .NET Framework 4.6 (available
+        // starting 4.6.2). For now, there is no need to overcomplicate this
+        // solution for some infrequent DPI calculations. However, if this
+        // becomes more central to various implementations, we may want to
+        // look into fleshing it out a bit further.
+        // ----
+        // Reference: https://docs.microsoft.com/en-us/dotnet/standard/frameworks
+
+        /// <summary>
+        /// Gets the horizontal DPI value from <see cref="SystemParameters"/>.
+        /// </summary>
+        /// <returns>The horizontal DPI value from <see cref="SystemParameters"/>. If the property cannot be accessed, the default value 96 is returned.</returns>
+        internal static int SystemDpiX()
+        {
+            var dpiProperty = typeof(SystemParameters).GetProperty("DpiX", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            if (dpiProperty == null)
+                return 96;
+
+            return (int)dpiProperty.GetValue(null, null);
+        }
+
+        /// <summary>
+        /// Calculates the horizontal DPI scale factor based on the DpiX <see cref="SystemParameters"/> property value.
+        /// </summary>
+        /// <returns>The horizontal DPI scale factor.</returns>
+        internal static double SystemDpiXScale()
+        {
+            return SystemDpiX() / 96.0;
+        }
+
+        /// <summary>
+        /// Gets the vertical DPI value from <see cref="SystemParameters"/>.
+        /// </summary>
+        /// <returns>The vertical DPI value from <see cref="SystemParameters"/>. If the property cannot be accessed, the default value 96 is returned.</returns>
+        internal static int SystemDpiY()
+        {
+            var dpiProperty = typeof(SystemParameters).GetProperty("Dpi", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            if (dpiProperty == null)
+                return 96;
+
+            return (int)dpiProperty.GetValue(null, null);
+        }
+
+        /// <summary>
+        /// Calculates the vertical DPI scale factor based on the "Dpi" <see cref="SystemParameters"/> property value.
+        /// </summary>
+        /// <returns>The vertical DPI scale factor.</returns>
+        internal static double SystemDpiYScale()
+        {
+            return SystemDpiY() / 96.0;
+        }
+    }
+}

--- a/WPFUI/Common/Dpi.cs
+++ b/WPFUI/Common/Dpi.cs
@@ -38,7 +38,7 @@ namespace WPFUI.Common
         }
 
         /// <summary>
-        /// Calculates the horizontal DPI scale factor based on the DpiX <see cref="SystemParameters"/> property value.
+        /// Gets the horizontal DPI scale factor based on <see cref="SystemParameters"/>.
         /// </summary>
         /// <returns>The horizontal DPI scale factor.</returns>
         internal static double SystemDpiXScale()
@@ -60,7 +60,7 @@ namespace WPFUI.Common
         }
 
         /// <summary>
-        /// Calculates the vertical DPI scale factor based on the "Dpi" <see cref="SystemParameters"/> property value.
+        /// Gets the vertical DPI scale factor based on <see cref="SystemParameters"/>.
         /// </summary>
         /// <returns>The vertical DPI scale factor.</returns>
         internal static double SystemDpiYScale()

--- a/WPFUI/Controls/TitleBar.cs
+++ b/WPFUI/Controls/TitleBar.cs
@@ -473,6 +473,8 @@ namespace WPFUI.Controls
             if (IsMaximized)
             {
                 var screenPoint = PointToScreen(e.MouseDevice.GetPosition(this));
+                screenPoint.X /= Common.Dpi.SystemDpiXScale();
+                screenPoint.Y /= Common.Dpi.SystemDpiYScale();
 
                 // TODO: refine the Left value to be more accurate
                 // - This calculation is good enough using the center
@@ -481,7 +483,7 @@ namespace WPFUI.Controls
                 // - It should be set as a % (e.g. screen X / maximized width),
                 //   then offset from the left to line up more naturally.
                 ParentWindow.Left = screenPoint.X - (ParentWindow.RestoreBounds.Width * 0.5);
-                ParentWindow.Top = 0d;
+                ParentWindow.Top = screenPoint.Y;
 
                 // style has to be quickly swapped to avoid restore animation delay
                 var style = ParentWindow.WindowStyle;


### PR DESCRIPTION
This PR fixes the DPI-scaling issue mentioned in [this comment](https://github.com/lepoco/wpfui/issues/36#issuecomment-1021161224). Part of this fix includes a new internal static `Dpi` helper class for various DPI-related functionality, as recommended [here](https://github.com/lepoco/wpfui/issues/36#issuecomment-1021230812). The DPI-scale taken into account by this restore-drag functionality will now be determined by what monitor the application is on while the window drag started.

Visual testing/verification for this implementation included:

- Dragging demo application across monitors with different DPI scaling and non-standard layout
- Dragging demo application from maximized state to another monitor with different DPI scaling
- Dragging demo application from pinned state to another monitor with different DPI scaling

_Note: Implementation tested on Windows 10 machine_