### PR TITLE
Fix double-click maximize issue referenced by #43

### DIFF
--- a/WPFUI/Win32/User32.cs
+++ b/WPFUI/Win32/User32.cs
@@ -274,6 +274,31 @@ namespace WPFUI.Win32
         }
 
         /// <summary>
+        /// The POINT structure defines the x- and y-coordinates of a point.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct POINT
+        {
+            /// <summary>
+            /// Specifies the x-coordinate of the point.
+            /// </summary>
+            public int X;
+            /// <summary>
+            /// Specifies the y-coordinate of the point.
+            /// </summary>
+            public int Y;
+        }
+
+        /// <summary>
+        /// Retrieves the position of the mouse cursor, in screen coordinates.
+        /// </summary>
+        /// <param name="lpPoint">A <see cref="POINT"/> structure that receives the screen coordinates of the cursor.</param>
+        /// <returns></returns>
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetCursorPos(out POINT lpPoint);
+
+        /// <summary>
         /// Sets various information regarding DWM window attributes.
         /// </summary>
         [DllImport("user32.dll", CharSet = CharSet.Auto)]


### PR DESCRIPTION
This PR fixes the bug where double clicking a `TitleBar` was not maximizing the window (fix #43).

The issue was caused by the `RootGrid.MouseMove` being triggered from the double-click maximize functionality (to reproduce, the window `TitleBar` needed be at the top of the screen such that the mouse was over it when the window is maximized by the double click event). It appears that since the window dimensions change when the state changes, this affects the mouse coordinates and thus fires the `MouseMove` event for the `RootGrid` element.

This PR fixes the issue with the following logic:

- Cursor position is tracked in a private field when the double-click maximize fires (via Win32 `GetCursorPos`)
- The cursor position is compared in the `MouseMove` event, after appropriate logic passes (e.g. left button is down and parent window is not null)
- If their X and Y are equal (meaning the mouse has not moved) the method simply returns and does nothing

This workaround doesn't necessarily feel "great" (e.g. resorting to Win32 calls for the cursor position) -- however this is necessary due to how the mouse coordinates are calculated in WPF (e.g. via visual to screen coordinates). I was still able to reproduce this issue when using `PointToScreen` calculations (albeit less frequently). For this fix, we want to track the absolute coordinates of the cursor independent of the application and this is primary functionality provided by `GetCursorPos`.

**NOTE:** This fix was tested with 125% and 150% DPI scaling, however it really should not have any dependence on DPI scaling. Since the coordinates are being compared in absolutes on whatever scale is provided by Win32, as long as that scale doesn't change between comparisons (essentially immediately), then the scaling is not needed.

EDIT: The consolidation of the `RootGrid.MouseDown` handler into `RootGrid.MouseMove` (mentioned in [this comment](https://github.com/lepoco/wpfui/issues/43#issuecomment-1021721497)) has been implemented in this PR as well. It was not necessarily causing the particular issue but should be deconflicted nonetheless.