### PR TITLE
Fix the client area margin at High DPI devices.

### DIFF
--- a/WPFUI/Controls/ClientAreaBorder.cs
+++ b/WPFUI/Controls/ClientAreaBorder.cs
@@ -1,0 +1,103 @@
+﻿#nullable enable
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Shell;
+
+using static WPFUI.Win32.User32;
+
+using WPFUI.Common;
+
+namespace WPFUI.Controls
+{
+    /// <summary>
+    /// If you use <see cref="WindowChrome"/> to extend the UI elements to the non-client area, you can include this container in the template of <see cref="Window"/> so that the content inside automatically fills the client area.
+    /// Using this container can let you get rid of various margin adaptations done in Setter/Trigger of the style of <see cref="Window"/> when the window state changes.
+    /// </summary>
+    public class ClientAreaBorder : Border
+    {
+        private const int SM_CXFRAME = 32;
+        private const int SM_CYFRAME = 33;
+        private const int SM_CXPADDEDBORDER = 92;
+
+        private Window? _oldWindow;
+        private static Thickness? _paddedBorderThickness;
+        private static Thickness? _resizeFrameBorderThickness;
+        private static Thickness? _windowChromeNonClientFrameThickness;
+
+        /// <inheritdoc />
+        protected override void OnVisualParentChanged(DependencyObject oldParent)
+        {
+            base.OnVisualParentChanged(oldParent);
+
+            if (_oldWindow is { } oldWindow)
+            {
+                oldWindow.StateChanged -= Window_StateChanged;
+            }
+
+            var newWindow = (Window?)Window.GetWindow(this);
+            if (newWindow is not null)
+            {
+                newWindow.StateChanged -= Window_StateChanged;
+                newWindow.StateChanged += Window_StateChanged;
+            }
+
+            _oldWindow = newWindow;
+        }
+
+        private void Window_StateChanged(object? sender, EventArgs e)
+        {
+            var window = (Window)sender!;
+            Padding = window.WindowState switch
+            {
+                WindowState.Maximized => WindowChromeNonClientFrameThickness,
+                _ => default,
+            };
+        }
+
+        /// <summary>
+        /// Get the system <see cref="SM_CXPADDEDBORDER"/> value in WPF units.
+        /// </summary>
+        public Thickness PaddedBorderThickness
+        {
+            get
+            {
+                if (_paddedBorderThickness is null)
+                {
+                    var paddedBorder = GetSystemMetrics(SM_CXPADDEDBORDER);
+                    var (factorX, factorY) = GetDpi();
+                    var frameSize = new Size(paddedBorder, paddedBorder);
+                    var frameSizeInDips = new Size(frameSize.Width / factorX, frameSize.Height / factorY);
+                    _paddedBorderThickness = new Thickness(frameSizeInDips.Width, frameSizeInDips.Height, frameSizeInDips.Width, frameSizeInDips.Height);
+                }
+
+                return _paddedBorderThickness.Value;
+            }
+        }
+
+        /// <summary>
+        /// Get the system <see cref="SM_CXFRAME"/> and <see cref="SM_CYFRAME"/> values in WPF units.
+        /// </summary>
+        public Thickness ResizeFrameBorderThickness => _resizeFrameBorderThickness ??= new Thickness(
+            SystemParameters.ResizeFrameVerticalBorderWidth,
+            SystemParameters.ResizeFrameHorizontalBorderHeight,
+            SystemParameters.ResizeFrameVerticalBorderWidth,
+            SystemParameters.ResizeFrameHorizontalBorderHeight);
+
+        /// <summary>
+        /// If you use a <see cref="WindowChrome"/> to extend the client area of a window to the non-client area, you need to handle the edge margin issue when the window is maximized.
+        /// Use this property to get the correct margin value when the window is maximized, so that when the window is maximized, the client area can completely cover the screen client area by no less than a single pixel at any DPI.
+        /// The<see cref="GetSystemMetrics"/> method cannot obtain this value directly.
+        /// </summary>
+        public Thickness WindowChromeNonClientFrameThickness => _windowChromeNonClientFrameThickness ??= new Thickness(
+            ResizeFrameBorderThickness.Left + PaddedBorderThickness.Left,
+            ResizeFrameBorderThickness.Top + PaddedBorderThickness.Top,
+            ResizeFrameBorderThickness.Right + PaddedBorderThickness.Right,
+            ResizeFrameBorderThickness.Bottom + PaddedBorderThickness.Bottom);
+
+        private (double factorX, double factorY) GetDpi() => PresentationSource.FromVisual(this) is { } source
+            ? (source.CompositionTarget.TransformToDevice.M11,
+                source.CompositionTarget.TransformToDevice.M22)
+            : (Dpi.SystemDpiXScale(), Dpi.SystemDpiYScale());
+    }
+}

--- a/WPFUI/Styles/Controls/Window.xaml
+++ b/WPFUI/Styles/Controls/Window.xaml
@@ -5,7 +5,9 @@
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:WPFUI.Controls">
 
     <!--
         SingleBorderWindow preserves the animations and scaling properly.
@@ -58,16 +60,11 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Window}">
-                    <Grid Background="{TemplateBinding Background}">
-                        <AdornerDecorator>
+                    <AdornerDecorator>
+                        <controls:ClientAreaBorder Background="{TemplateBinding Background}">
                             <ContentPresenter x:Name="ContentPresenter" />
-                        </AdornerDecorator>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="WindowState" Value="Maximized">
-                            <Setter TargetName="ContentPresenter" Property="Margin" Value="8" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
+                        </controls:ClientAreaBorder>
+                    </AdornerDecorator>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -77,8 +74,23 @@
             </Trigger>
             <Trigger Property="WindowState" Value="Maximized">
                 <Setter Property="ResizeMode" Value="NoResize" />
-                <Setter Property="BorderThickness" Value="6,6,6,0" />
                 <Setter Property="Topmost" Value="False" />
+                <Setter Property="WindowChrome.WindowChrome">
+                    <Setter.Value>
+                        <!--
+                            1. ResizeBorderThickness should be set to 0 so that the mouse can get reach the title bar buttons
+                            even if the mouse is at the end 1-pixel line of the screen.
+                            2. On Windows 10, the CornerRadius should be set to 0 when the Window is maximized.
+                        -->
+                        <WindowChrome
+                            CaptionHeight="1"
+                            CornerRadius="0"
+                            GlassFrameThickness="-1"
+                            NonClientFrameEdges="None"
+                            ResizeBorderThickness="0"
+                            UseAeroCaptionButtons="False" />
+                    </Setter.Value>
+                </Setter>
                 <!-- <Setter Property="MaxHeight" Value="{Binding Source={x:Static SystemParameters.WorkArea}, Path=PrimaryScreenHeight}" /> -->
                 <!-- <Setter Property="MaxWidth" Value="{Binding Source={x:Static SystemParameters.WorkArea}, Path=Width}" /> -->
             </Trigger>

--- a/WPFUI/Win32/User32.cs
+++ b/WPFUI/Win32/User32.cs
@@ -312,6 +312,13 @@ namespace WPFUI.Win32
         public static extern bool SetForegroundWindow(HandleRef hWnd);
 
         /// <summary>
+        /// Retrieves the specified system metric or system configuration setting.
+        /// Note that all dimensions retrieved by GetSystemMetrics are in pixels.
+        /// </summary>
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern int GetSystemMetrics(int nIndex);
+
+        /// <summary>
         /// Retrieves information about the specified window.
         /// The function also retrieves the 32-bit (DWORD) value at the specified offset into the extra window memory.
         /// </summary>


### PR DESCRIPTION
## What does this pull request do?

In different DPIs, the margins of the client area are different. What is strange is that the values of the different margins are not a linear scale value of the DPI factors. If we use a constant value as the client area margin, the WPF will auto-scale it by using a linear function with the DPI value which is NOT CORRECT. What I'm doing is to fix the incorrect auto-scaling behavior of the client area margin.

The actual margin value parts in WPF units in different system DPI values:

| DPI  | WindowNonClientFrameThickness           | PaddedBorderThickness |
| ---- | --------------------------------------- | --------------------- |
| 100% | 4,4,4,4                                 | 4,4,4,4               |
| 125% | 3.2,3.2,3.2,3.2                         | 4,4,4,4               |
| 150% | 3.3333,3.3333,3.3333,3.3333             | 4,4,4,4               |
| 175% | 2.8571428,2.8571428,2.8571428,2.8571428 | 4,4,4,4               |
| 200% | 2.5,2.5,2.5,2.5                         | 4,4,4,4               |

If we do not match the correct client area margins, the user will see a space between the minimized/maximized/close button and the screen edges when the window is maximized.

## How does the source code work?

Thanks to my friend @DinoChan which is also a Microsoft MVP in Windows Development Area. He researched this behavior of the client area of Windows and teach me this by publishing his blog post. I've used this knowledge by writing a custom control named `ClientAreaBorder` which is the source code you can see in this pull request. This code has been tested in a widely published popular software for more than a year and works fine. The original source code is here:

https://github.com/walterlv/Walterlv.Packages/blob/master/src/Themes/Walterlv.Themes.FluentDesign/Controls/ClientAreaBorder.cs

## Extras

A screenshot of the fix of the margin of 150% DPI:

![image](https://user-images.githubusercontent.com/9959623/154603958-498f6cba-70e3-4098-b2a2-beefb362eca0.png)

## Related links

* [[WPF 自定义控件]使用WindowChrome的问题 - dino.c - 博客园](https://www.cnblogs.com/dino623/p/problems_of_WindowChrome.html)