### PR TITLE
Find back the lost scroll bar of the TreeView.

### DIFF
--- a/WPFUI/Styles/Controls/TreeView.xaml
+++ b/WPFUI/Styles/Controls/TreeView.xaml
@@ -35,7 +35,9 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="4">
-                        <ItemsPresenter />
+                        <ScrollViewer>
+                            <ItemsPresenter Margin="{TemplateBinding Padding}" />
+                        </ScrollViewer>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
See: https://docs.microsoft.com/en-us/dotnet/desktop/wpf/controls/treeview-styles-and-templates

![image](https://user-images.githubusercontent.com/9959623/155291784-9b9cdd9c-6b5e-4d6a-8198-60078744701a.png)