### PR TITLE
Use ItemsPresenter instead of panel, so that the ItemsPanel property can work.

### DIFF
--- a/WPFUI/Styles/Controls/ListBox.xaml
+++ b/WPFUI/Styles/Controls/ListBox.xaml
@@ -125,7 +125,7 @@
                             Focusable="False"
                             HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                             VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <VirtualizingStackPanel Margin="2" IsItemsHost="True" />
+                            <ItemsPresenter Margin="2" />
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>


### PR DESCRIPTION
The ItemsPanel property is used for developers to customize the Panel without rewriting the whole ControlTemplate. If we use the ItemsPresenter instead of a concrete panel, this property will work correctly, otherwise, it does nothing.

```diff
    <ListBox>
++      <ItemsControl.ItemsPanel>
++          <ItemsPanelTemplate>
++              <VirtualizingStackPanel IsItemsHost="True" Margin="0 4" />
++          </ItemsPanelTemplate>
++      </ItemsControl.ItemsPanel>
        <d:ItemsControl.ItemsSource>
            <x:Array Type="steps:StepViewModel">
                <steps:StepViewModel />
                <steps:StepViewModel />
                <steps:StepViewModel />
                <steps:StepViewModel />
            </x:Array>
        </d:ItemsControl.ItemsSource>
    </ListBox>
```