### PR TITLE
More Faithful Recreation of Menu

### DIFF
--- a/WPFUI.Demo/Views/Pages/Controls.xaml
+++ b/WPFUI.Demo/Views/Pages/Controls.xaml
@@ -410,7 +410,7 @@
 
             <ToolBarTray Margin="0,0,0,12">
                 <ToolBar>
-                    <Button Content="New" />
+                    <Button Content="New"/>
                     <Button Content="Open" />
                 </ToolBar>
                 <ToolBar>
@@ -446,20 +446,20 @@
 
             <Menu Margin="0,0,0,12">
                 <MenuItem Header="File">
-                    <MenuItem Header="New" />
-                    <MenuItem Header="Open" />
+                    <MenuItem Header="New" InputGestureText="Ctrl+N"/>
+                    <MenuItem Header="Open" InputGestureText="Ctrl+O"/>
                     <MenuItem Header="Disabled" IsEnabled="False" />
-                    <MenuItem Header="Save" />
+                    <MenuItem Header="Save" Icon="{x:Static wpfuiCommon:Icon.Save24}" InputGestureText="Ctrl+S"/>
                     <Separator />
-                    <MenuItem Header="Exit" />
+                    <MenuItem Header="Exit" InputGestureText="Ctrl+Q"/>
                 </MenuItem>
                 <MenuItem Header="With icon" Icon="{x:Static wpfuiCommon:Icon.StoreMicrosoft24}" />
                 <MenuItem Header="Save as" Icon="{x:Static wpfuiCommon:Icon.Save24}">
                     <MenuItem Header="Word Document" Icon="{x:Static wpfuiCommon:Icon.AlertUrgent24}" />
-                    <MenuItem Header="PDF" />
+                    <MenuItem Header="PDF" InputGestureText="Ctrl+Alt+P"/>
                     <MenuItem Header="Text File" />
                     <Separator />
-                    <MenuItem Header="Print" />
+                    <MenuItem Header="Print" InputGestureText="Ctrl+P"/>
                 </MenuItem>
                 <MenuItem Header="With submenu">
                     <MenuItem
@@ -467,6 +467,13 @@
                         IsCheckable="True"
                         IsChecked="True" />
                     <MenuItem Header="Word wrap" IsCheckable="True" />
+                    <MenuItem Header="NormalItem"/>
+                    <MenuItem Header="SubMenu">
+                        <MenuItem Header="SubMenu 2">
+                            <MenuItem Header="SubItem 2.1"/>
+                        </MenuItem>
+                        <MenuItem Header="SubItem 1"/>
+                    </MenuItem>
                 </MenuItem>
                 <MenuItem Header="Disabled" IsEnabled="False" />
                 <Separator />

--- a/WPFUI/Styles/Assets/Brushes.xaml
+++ b/WPFUI/Styles/Assets/Brushes.xaml
@@ -104,6 +104,8 @@
     <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{DynamicResource CardBackgroundFillColorDefault}" />
     <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{DynamicResource CardBackgroundFillColorSecondary}" />
 
+    <SolidColorBrush x:Key="MenuBorderColorDefaultBrush" Color="{DynamicResource MenuBorderColorDefault}"/>
+
     <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{DynamicResource SmokeFillColorDefault}" />
 
     <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{DynamicResource LayerFillColorDefault}" />

--- a/WPFUI/Styles/Controls/Menu.xaml
+++ b/WPFUI/Styles/Controls/Menu.xaml
@@ -109,7 +109,7 @@
                         PopupAnimation="Slide">
                     <Grid IsSharedSizeScope="True">
                         <Border x:Name="SubmenuBorder"
-                                Margin="12,11,20,12"
+                                Margin="12,11,12,18"
                                 Padding="0,3,0,3"
                                 BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
                                 BorderThickness="1"
@@ -351,13 +351,14 @@
                 AllowsTransparency="True"
                 Focusable="False"
                 HorizontalOffset="-16"
+                VerticalOffset="-2"
                 IsOpen="{TemplateBinding IsSubmenuOpen}"
                 Placement="Right"
                 PopupAnimation="Slide">
                 <Grid>
                     <Border
                         x:Name="SubmenuBorder"
-                        Margin="12,0,20,12"
+                        Margin="12,11,12,18"
                         Padding="0,3,0,3"
                         BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
                         BorderThickness="1"

--- a/WPFUI/Styles/Controls/Menu.xaml
+++ b/WPFUI/Styles/Controls/Menu.xaml
@@ -71,16 +71,18 @@
     <!--  TopLevelHeader  -->
     <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
         <Border x:Name="Border" Background="Transparent" CornerRadius="6" Margin="4">
-            <Grid Margin="10">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+            <Grid>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <TextBlock
+
+                <Grid Margin="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
                         x:Name="Icon"
                         Grid.Column="0"
                         Margin="0,0,6,0"
@@ -89,27 +91,30 @@
                         FontSize="16"
                         Text="{TemplateBinding Icon,
                                                Converter={StaticResource IconToStringConverter}}" />
-                <ContentPresenter
+                    <ContentPresenter
                         x:Name="HeaderPresenter"
                         Grid.Column="1"
                         VerticalAlignment="Center"
                         ContentSource="Header"
                         RecognizesAccessKey="True"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
-                <Popup
-                        x:Name="Popup"
-                        Grid.Row="1"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="2"
-                        AllowsTransparency="True"
-                        Focusable="False"
-                        HorizontalOffset="-22"
-                        IsOpen="{TemplateBinding IsSubmenuOpen}"
-                        Placement="Bottom"
-                        PopupAnimation="Slide">
-                    <Grid IsSharedSizeScope="True">
+                </Grid>
+
+                <Popup x:Name="Popup"
+                       Grid.Row="1"
+                       Grid.Column="0"
+                       Grid.ColumnSpan="2"
+                       AllowsTransparency="True"
+                       Focusable="False"
+                       IsOpen="{TemplateBinding IsSubmenuOpen}"
+                       Placement="Bottom"
+                       PlacementTarget="{Binding ElementName=Border}"
+                       VerticalOffset="1"
+                       HorizontalOffset="-12"
+                       PopupAnimation="Slide">
+                    <Grid>
                         <Border x:Name="SubmenuBorder"
-                                Margin="12,11,12,18"
+                                Margin="12,0,12,18"
                                 Padding="0,3,0,3"
                                 BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
                                 BorderThickness="1"
@@ -130,6 +135,7 @@
                         </Border>
                     </Grid>
                 </Popup>
+                
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -313,7 +319,7 @@
                 Margin="4,1,4,1"
                 Grid.Row="1"
                 BorderThickness="1">
-                <Grid Margin="8,6,8,6">
+                <Grid Margin="8,6,8,6" x:Name="MenuItemContent">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
@@ -349,16 +355,16 @@
                 x:Name="Popup"
                 Grid.Row="1"
                 AllowsTransparency="True"
+                VerticalOffset="-20"
                 Focusable="False"
-                HorizontalOffset="-16"
-                VerticalOffset="-2"
                 IsOpen="{TemplateBinding IsSubmenuOpen}"
                 Placement="Right"
+                PlacementTarget="{Binding ElementName=MenuItemContent}"
                 PopupAnimation="Slide">
                 <Grid>
                     <Border
                         x:Name="SubmenuBorder"
-                        Margin="12,11,12,18"
+                        Margin="12,10,12,18"
                         Padding="0,3,0,3"
                         BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
                         BorderThickness="1"

--- a/WPFUI/Styles/Controls/Menu.xaml
+++ b/WPFUI/Styles/Controls/Menu.xaml
@@ -28,8 +28,6 @@
                 <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
             </Setter.Value>
         </Setter>
-        <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
-        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
@@ -52,7 +50,7 @@
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="{x:Type Separator}">
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Margin" Value="4" />
+        <Setter Property="Margin" Value="0,1,0,1" />
         <Setter Property="BorderThickness" Value="1,1,0,0" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -72,18 +70,17 @@
 
     <!--  TopLevelHeader  -->
     <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
-        <Border x:Name="Border" Background="Transparent">
-            <Grid>
+        <Border x:Name="Border" Background="Transparent" CornerRadius="6" Margin="4">
+            <Grid Margin="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-                <Grid Margin="12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock
+                <TextBlock
                         x:Name="Icon"
                         Grid.Column="0"
                         Margin="0,0,6,0"
@@ -92,38 +89,44 @@
                         FontSize="16"
                         Text="{TemplateBinding Icon,
                                                Converter={StaticResource IconToStringConverter}}" />
-                    <ContentPresenter
+                <ContentPresenter
                         x:Name="HeaderPresenter"
                         Grid.Column="1"
                         VerticalAlignment="Center"
                         ContentSource="Header"
                         RecognizesAccessKey="True"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
-                </Grid>
                 <Popup
-                    x:Name="Popup"
-                    Grid.Row="1"
-                    Margin="0"
-                    AllowsTransparency="True"
-                    Focusable="False"
-                    IsOpen="{TemplateBinding IsSubmenuOpen}"
-                    Placement="Bottom"
-                    PopupAnimation="Slide">
+                        x:Name="Popup"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        AllowsTransparency="True"
+                        Focusable="False"
+                        HorizontalOffset="-22"
+                        IsOpen="{TemplateBinding IsSubmenuOpen}"
+                        Placement="Bottom"
+                        PopupAnimation="Slide">
                     <Grid IsSharedSizeScope="True">
-                        <Border
-                            x:Name="SubmenuBorder"
-                            Margin="0,4,0,0"
-                            Padding="0"
-                            BorderBrush="{DynamicResource ControlElevationBorderBrush}"
-                            BorderThickness="1"
-                            CornerRadius="4"
-                            SnapsToDevicePixels="True">
+                        <Border x:Name="SubmenuBorder"
+                                Margin="12,11,20,12"
+                                Padding="0,3,0,3"
+                                BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="8"
+                                SnapsToDevicePixels="True">
                             <Border.Background>
                                 <SolidColorBrush Color="{DynamicResource SystemFillColorSolidNeutralBackground}" />
                             </Border.Background>
                             <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuScrollViewer}">
                                 <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
                             </ScrollViewer>
+                            <Border.Effect>
+                                <DropShadowEffect ShadowDepth="6"
+                                                      BlurRadius="20"
+                                                      Direction="270"
+                                                      Opacity="0.25"/>
+                            </Border.Effect>
                         </Border>
                     </Grid>
                 </Popup>
@@ -143,7 +146,7 @@
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter TargetName="Border" Property="Background">
                     <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                        <SolidColorBrush Color="{DynamicResource SubtleFillColorSecondary}"/>
                     </Setter.Value>
                 </Setter>
             </Trigger>
@@ -159,8 +162,8 @@
 
     <!--  TopLevelItem  -->
     <ControlTemplate x:Key="{x:Static MenuItem.TopLevelItemTemplateKey}" TargetType="{x:Type MenuItem}">
-        <Border x:Name="Border" Background="Transparent">
-            <Grid Margin="12">
+        <Border x:Name="Border" Background="Transparent" CornerRadius="6" Margin="4">
+            <Grid Margin="10">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
@@ -187,7 +190,7 @@
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter TargetName="Border" Property="Background">
                     <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                        <SolidColorBrush Color="{DynamicResource SubtleFillColorSecondary}"/>
                     </Setter.Value>
                 </Setter>
             </Trigger>
@@ -210,8 +213,8 @@
 
     <!--  SubmenuItem  -->
     <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
-        <Border x:Name="Border" Background="Transparent">
-            <Grid Margin="8">
+        <Border x:Name="Border" Background="Transparent" CornerRadius="4" Margin="4,1,4,1">
+            <Grid Margin="8,6,8,6">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
@@ -257,8 +260,11 @@
                     TextElement.Foreground="{TemplateBinding Foreground}" />
                 <TextBlock
                     x:Name="InputGestureText"
+                    FontSize="11"
+                    Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                    VerticalAlignment="Bottom"
                     Grid.Column="2"
-                    Margin="6,0,0,0"
+                    Margin="25,0,0,0"
                     DockPanel.Dock="Right"
                     Text="{TemplateBinding InputGestureText}" />
             </Grid>
@@ -267,7 +273,7 @@
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter TargetName="Border" Property="Background">
                     <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                        <SolidColorBrush Color="{DynamicResource SubtleFillColorSecondary}"/>
                     </Setter.Value>
                 </Setter>
             </Trigger>
@@ -303,9 +309,11 @@
 
             <Border
                 x:Name="Border"
+                CornerRadius="4"
+                Margin="4,1,4,1"
                 Grid.Row="1"
                 BorderThickness="1">
-                <Grid Margin="8">
+                <Grid Margin="8,6,8,6">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
@@ -340,19 +348,20 @@
             <Popup
                 x:Name="Popup"
                 Grid.Row="1"
-                Margin="0"
                 AllowsTransparency="True"
                 Focusable="False"
+                HorizontalOffset="-16"
                 IsOpen="{TemplateBinding IsSubmenuOpen}"
                 Placement="Right"
                 PopupAnimation="Slide">
-                <Grid Margin="0,-1,0,0">
+                <Grid>
                     <Border
                         x:Name="SubmenuBorder"
-                        Padding="0"
-                        BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                        Margin="12,0,20,12"
+                        Padding="0,3,0,3"
+                        BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
                         BorderThickness="1"
-                        CornerRadius="4"
+                        CornerRadius="8"
                         SnapsToDevicePixels="True">
                         <Border.Background>
                             <SolidColorBrush Color="{DynamicResource SystemFillColorSolidNeutralBackground}" />
@@ -360,6 +369,12 @@
                         <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuScrollViewer}">
                             <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
                         </ScrollViewer>
+                        <Border.Effect>
+                            <DropShadowEffect ShadowDepth="6"
+                                                  BlurRadius="20"
+                                                  Direction="270"
+                                                  Opacity="0.5"/>
+                        </Border.Effect>
                     </Border>
                 </Grid>
             </Popup>
@@ -371,7 +386,7 @@
             <Trigger Property="IsHighlighted" Value="true">
                 <Setter TargetName="Border" Property="Background">
                     <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                        <SolidColorBrush Color="{DynamicResource SubtleFillColorSecondary}"/>
                     </Setter.Value>
                 </Setter>
             </Trigger>

--- a/WPFUI/Styles/Controls/Menu.xaml
+++ b/WPFUI/Styles/Controls/Menu.xaml
@@ -10,7 +10,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:WPFUI.Controls"
     xmlns:converters="clr-namespace:WPFUI.Converters"
-    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+    x:Class="WPFUI.Styles.Controls.Menu"
+    x:ClassModifier="public">
 
     <converters:IconToStringConverter x:Key="IconToStringConverter" />
 

--- a/WPFUI/Styles/Controls/Menu.xaml.cs
+++ b/WPFUI/Styles/Controls/Menu.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+using System.Windows;
+
+namespace WPFUI.Styles.Controls
+{
+    partial class Menu : ResourceDictionary
+    {
+
+        public Menu()
+        {
+            Initialize();
+        }
+
+
+        private void Initialize()
+        {
+            if (SystemParameters.MenuDropAlignment)
+            {
+                FieldInfo fi = typeof(SystemParameters).GetField("_menuDropAlignment", BindingFlags.NonPublic | BindingFlags.Static);
+                fi.SetValue(null, false);
+            }
+        }
+
+    }
+}

--- a/WPFUI/Styles/Theme/Dark.xaml
+++ b/WPFUI/Styles/Theme/Dark.xaml
@@ -76,6 +76,8 @@
     <Color x:Key="CardStrokeColorDefault">#19000000</Color>
     <Color x:Key="CardStrokeColorDefaultSolid">#1C1C1C</Color>
 
+    <Color x:Key="MenuBorderColorDefault">#151515</Color>
+
     <Color x:Key="ControlStrongStrokeColorDefault">#8BFFFFFF</Color>
     <Color x:Key="ControlStrongStrokeColorDisabled">#28FFFFFF</Color>
 

--- a/WPFUI/Styles/Theme/HighContrast.xaml
+++ b/WPFUI/Styles/Theme/HighContrast.xaml
@@ -103,6 +103,8 @@
     <Color x:Key="CardBackgroundFillColorDefault">#0DFFFFFF</Color>
     <Color x:Key="CardBackgroundFillColorSecondary">#08FFFFFF</Color>
 
+    <Color x:Key="MenuBorderColorDefault">#12FFFFFF</Color>
+
     <Color x:Key="SmokeFillColorDefault">#4D000000</Color>
 
     <Color x:Key="LayerFillColorDefault">#4C3A3A3A</Color>

--- a/WPFUI/Styles/Theme/Light.xaml
+++ b/WPFUI/Styles/Theme/Light.xaml
@@ -74,6 +74,8 @@
     <Color x:Key="CardStrokeColorDefault">#0F000000</Color>
     <Color x:Key="CardStrokeColorDefaultSolid">#EBEBEB</Color>
 
+    <Color x:Key="MenuBorderColorDefault">#0F000000</Color>
+
     <Color x:Key="ControlStrongStrokeColorDefault">#72000000</Color>
     <Color x:Key="ControlStrongStrokeColorDisabled">#37000000</Color>
 


### PR DESCRIPTION
Added a more faithful recreation of the Windows 11 Menu. The Design is based on the Windows 11 Editor (TextEditor) as it is a Programm by Micrsoft using the Windows 11 Style that still features a Menu.


_I mainly developed it for a project of my own but it turned out good enough that I decided to create a Pull-Request out of it. I must however be very transparent and admit that WPF and XAML are still a bit new to me. Though I myself couldn't find any more problems with the code I don't have many years of experience quite yet and therefore can't be sure that I am not overlooking something important._