### PR TITLE
Fix ContextMenu Theme-Changes

### DIFF
--- a/WPFUI.Demo/Views/Pages/Controls.xaml
+++ b/WPFUI.Demo/Views/Pages/Controls.xaml
@@ -529,7 +529,7 @@
                 Icon="Channel24"
                 Subtitle="Right-Click the Card (or use the Button) to show a ContextMenu">
                 <wpfui:CardControl.ContextMenu>
-                    <ContextMenu x:Name="ContextMenu">
+                    <ContextMenu>
                         <MenuItem Header="Normal Item"/>
                         <MenuItem Header="With Icon" Icon="{x:Static wpfuiCommon:Icon.TextBox16}"/>
                         <Separator/>

--- a/WPFUI.Demo/Views/Pages/Controls.xaml.cs
+++ b/WPFUI.Demo/Views/Pages/Controls.xaml.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.ObjectModel;
 using System.Windows.Controls;
-using WPFUI.Controls;
+using MessageBox = WPFUI.Controls.MessageBox;
 
 namespace WPFUI.Demo.Views.Pages
 {
@@ -95,7 +95,40 @@ namespace WPFUI.Demo.Views.Pages
 
         private void Button_ShowContextMenu_Click(object sender, System.Windows.RoutedEventArgs e)
         {
-            ContextMenu.IsOpen = true;
+            //CREATE PROGRAMMATICALLY
+            //Right now it is not possible to open the ContextMenu from CodeBehind (ContextMenu.IsOpen = true) because when it is not created again after a Theme-Change it will not use the new Theme
+            //Without creating it in CodeBehing the Theme-Change during Runtime would therefore not have any affect on the ContextMenu until you force it to rebuild by opening it through a Right-Click onto it's host-card
+            //Comment and temporary fix by https://github.com/ParzivalExe
+            ContextMenu contextMenu = new ContextMenu();
+            contextMenu.Items.Add(new MenuItem()
+            {
+                Header = "Normal Item"
+            });
+            contextMenu.Items.Add(new MenuItem()
+            {
+                Header = "With Icon",
+                Icon = WPFUI.Common.Icon.TextBox16
+            });
+            contextMenu.Items.Add(new MenuItem()
+            {
+                Header = "Deactivated",
+                IsEnabled = false
+            });
+            MenuItem subMenu = new MenuItem()
+            {
+                Header = "SubMenu"
+            };
+            subMenu.Items.Add(new MenuItem()
+            {
+                Header = "Item 1"
+            }); 
+            subMenu.Items.Add(new MenuItem()
+            {
+                Header = "Item 2"
+            });
+            contextMenu.Items.Add(subMenu);
+
+            contextMenu.IsOpen = true;
         }
 
         private void MessageBox_LeftButtonClick(object sender, System.Windows.RoutedEventArgs e)

--- a/WPFUI/Styles/Controls/ContextMenu.xaml
+++ b/WPFUI/Styles/Controls/ContextMenu.xaml
@@ -22,16 +22,8 @@
                 <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
             </Setter.Value>
         </Setter>
-        <Setter Property="Background">
-            <Setter.Value>
-                <SolidColorBrush Color="{DynamicResource SystemFillColorSolidNeutralBackground}" />
-            </Setter.Value>
-        </Setter>
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <SolidColorBrush Color="{DynamicResource MenuBorderColorDefault}" />
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Background" Value="{DynamicResource SystemFillColorSolidNeutralBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource MenuBorderColorDefaultBrush}"/>
         <Setter Property="MinWidth" Value="140" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Margin" Value="0" />

--- a/WPFUI/Styles/Controls/ContextMenu.xaml.cs
+++ b/WPFUI/Styles/Controls/ContextMenu.xaml.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;


### PR DESCRIPTION
Fixes for Issue #96:
- Fixing the BorderBrush of ContextMenu so that it changes with Theme-Changes during Runtime
- Fixing Demo-Show Button for ContextMenu-Demo so that Theme-Changes during runtime are properly applied (more info at Controls.xaml.cs#Button_ShowContextMenu_Click)