### PR TITLE
TitleBar Drag Crash Fix

### DIFF
--- a/WPFUI/Controls/TitleBar.cs
+++ b/WPFUI/Controls/TitleBar.cs
@@ -501,8 +501,10 @@ namespace WPFUI.Controls
 
             // Call drag move only when mouse down, check again
             // if()
-
-            ParentWindow.DragMove();
+            if(e.LeftButton == MouseButtonState.Pressed)
+            {
+                ParentWindow.DragMove();
+            }
         }
 
         private void ParentWindow_StateChanged(object sender, EventArgs e)


### PR DESCRIPTION
Fix for Issue #100 (Interestingly there was already a Comment for fixing this issue but not actual code):
- Fixing a Crash where when dragging the TitleBar for a very short time when in Maximized the Program will crash