### PR TITLE
Fix raise max button before releases the mouse when use snap.

### DIFF
--- a/WPFUI/Common/SnapLayout.cs
+++ b/WPFUI/Common/SnapLayout.cs
@@ -84,12 +84,10 @@ namespace WPFUI.Common
                     break;
 
                 case User32.WM.NCLBUTTONUP:
-                    if (!_isButtonClicked) { break; }
+                    if (!_isButtonClicked) break;
 
                     if (IsOverButton(wParam, lParam))
-                    {
                         RaiseButtonClick();
-                    }
 
                     _isButtonClicked = false;
                     handled = true;

--- a/WPFUI/Common/SnapLayout.cs
+++ b/WPFUI/Common/SnapLayout.cs
@@ -84,15 +84,16 @@ namespace WPFUI.Common
                     break;
 
                 case User32.WM.NCLBUTTONUP:
-                    if (_isButtonClicked)
+                    if (!_isButtonClicked) { break; }
+
+                    if (IsOverButton(wParam, lParam))
                     {
-                        if (IsOverButton(wParam, lParam))
-                        {
-                            RaiseButtonClick();
-                        }
-                        _isButtonClicked = false;
-                        handled = true;
+                        RaiseButtonClick();
                     }
+
+                    _isButtonClicked = false;
+                    handled = true;
+
                     break;
 
                 case User32.WM.NCHITTEST:

--- a/WPFUI/Common/SnapLayout.cs
+++ b/WPFUI/Common/SnapLayout.cs
@@ -25,6 +25,8 @@ namespace WPFUI.Common
 
         private bool _isButtonFocused;
 
+        private bool _isButtonClicked;
+
         private double _dpiScale;
 
         private Button _button;
@@ -69,7 +71,7 @@ namespace WPFUI.Common
                 case User32.WM.NCLBUTTONDOWN:
                     if (IsOverButton(wParam, lParam))
                     {
-                        RaiseButtonClick();
+                        _isButtonClicked = true;
 
                         handled = true;
                     }
@@ -79,6 +81,18 @@ namespace WPFUI.Common
                 case User32.WM.NCMOUSELEAVE:
                     DefocusButton();
 
+                    break;
+
+                case User32.WM.NCLBUTTONUP:
+                    if (_isButtonClicked)
+                    {
+                        if (IsOverButton(wParam, lParam))
+                        {
+                            RaiseButtonClick();
+                        }
+                        _isButtonClicked = false;
+                        handled = true;
+                    }
                     break;
 
                 case User32.WM.NCHITTEST:


### PR DESCRIPTION
I move the "RaiseButtonClick()" to the NCLBUTTONUP message. It will raise button after releases mouse now.
![动画](https://user-images.githubusercontent.com/27689196/161069222-fdcfa752-0450-4968-935d-f58f1b2ac1b4.gif)
