### PR TITLE
fix(ComboBox): EditableTextBox respects Foreground

### DIFF
--- a/src/WPFUI/Styles/Controls/ComboBox.xaml
+++ b/src/WPFUI/Styles/Controls/ComboBox.xaml
@@ -178,6 +178,7 @@
                         <TextBox
                             x:Name="PART_EditableTextBox"
                             Margin="8"
+                            Foreground="{TemplateBinding Foreground}"
                             IsReadOnly="{TemplateBinding IsReadOnly}" />
                         <Popup
                             Name="Popup"


### PR DESCRIPTION
Currently this `TextBox` doesn't respect the `Foreground` property, causing weird behavior like this in Dark mode:
![image](https://user-images.githubusercontent.com/57174311/167295153-d5d24336-8fc9-4049-9f62-de633513a8ba.png)

After the fix, Dark mode `ComboBox` should be like this:
![image](https://user-images.githubusercontent.com/57174311/167295201-f9e12099-e284-4346-a709-c59ef69390a2.png)
