### PR TITLE
Don't let the button icons focusable.

### DIFF
--- a/src/WPFUI/Styles/Controls/TitleBar.xaml
+++ b/src/WPFUI/Styles/Controls/TitleBar.xaml
@@ -108,7 +108,7 @@
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         RenderOptions.BitmapScalingMode="HighQuality">
-                                        <ContentControl Content="{DynamicResource UiIconHelp}" />
+                                        <ContentControl Focusable="False" Content="{DynamicResource UiIconHelp}" />
                                     </Viewbox>
                                 </controls:Button>
                                 <controls:Button
@@ -123,7 +123,7 @@
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         RenderOptions.BitmapScalingMode="HighQuality">
-                                        <ContentControl Content="{DynamicResource UiIconMinimize}" />
+                                        <ContentControl Focusable="False" Content="{DynamicResource UiIconMinimize}" />
                                     </Viewbox>
                                 </controls:Button>
                                 <controls:Button
@@ -138,7 +138,7 @@
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         RenderOptions.BitmapScalingMode="HighQuality">
-                                        <ContentControl x:Name="ButtonMaximizeIcon" Content="{DynamicResource UiIconMaximize}" />
+                                        <ContentControl x:Name="ButtonMaximizeIcon" Focusable="False" Content="{DynamicResource UiIconMaximize}" />
                                     </Viewbox>
                                 </controls:Button>
                                 <controls:Button
@@ -153,7 +153,7 @@
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         RenderOptions.BitmapScalingMode="HighQuality">
-                                        <ContentControl Content="{DynamicResource UiIconClose}" />
+                                        <ContentControl Focusable="False" Content="{DynamicResource UiIconClose}" />
                                     </Viewbox>
                                 </controls:Button>
                             </StackPanel>


### PR DESCRIPTION
If you're trying the keyboard navigation using the `Tab` button, The icons of the title bar buttons will receive focus which is useless.

![image](https://user-images.githubusercontent.com/9959623/167791997-bb3e936a-502d-46b6-a866-d13ae491e7da.png)

![image](https://user-images.githubusercontent.com/9959623/167792394-ea198330-786f-4ece-9785-0607fbbc0b17.png)
