### PR TITLE
Don't let the ItemsControls in Navigation Fluents focusable.

### DIFF
--- a/src/WPFUI/Styles/Controls/NavigationFluent.xaml
+++ b/src/WPFUI/Styles/Controls/NavigationFluent.xaml
@@ -267,6 +267,7 @@
                             <ItemsControl
                                 Grid.Row="0"
                                 Width="250"
+                                Focusable="False"
                                 ItemsSource="{TemplateBinding Items}"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
@@ -279,6 +280,7 @@
 
                             <ItemsControl
                                 Grid.Row="1"
+                                Focusable="False"
                                 ItemsSource="{TemplateBinding Footer}"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 ScrollViewer.VerticalScrollBarVisibility="Disabled">

--- a/src/WPFUI/Styles/Controls/NavigationStore.xaml
+++ b/src/WPFUI/Styles/Controls/NavigationStore.xaml
@@ -247,6 +247,7 @@
                             <ItemsControl
                                 Grid.Row="0"
                                 Width="250"
+                                Focusable="False"
                                 ItemsSource="{TemplateBinding Items}"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
@@ -262,6 +263,7 @@
 
                             <ItemsControl
                                 Grid.Row="1"
+                                Focusable="False"
                                 ItemsSource="{TemplateBinding Footer}"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 ScrollViewer.VerticalScrollBarVisibility="Disabled">


### PR DESCRIPTION
If you're trying the keyboard navigation using the Tab button, the ItemsControls of the Navigation Fluents will receive focus so that the navigation among the navigation items is not continuous.

![2022-05-11-navigation-fluent-focusable](https://user-images.githubusercontent.com/9959623/167796883-a321c670-d8ca-441f-9980-acadb63d5fe8.gif)

