### PR TITLE
Fix wrong xaml namespace of the tutorial example code

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -43,7 +43,7 @@ First, let's modify MainWindow.xaml
 ```xml
 <Window
   xmlns:pages="clr-namespace:MyNewApp.Pages"
-  xmlns:wpfui="http://schemas.lepo.co/wpfui/2022/xaml"
+  xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
   Style="{StaticResource UiWindow}"
   WindowStartupLocation="CenterScreen"
   mc:Ignorable="d">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
The tutorial page had a wrong xaml namespace on the first example. This pr replaces "wpfui" with "ui"


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```xml
xmlns:wpfui="http://schemas.lepo.co/wpfui/2022/xaml"
```

## What is the new behavior?

```xml
xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
```
