### PR TITLE
Fix reveal functionality of PasswordBox

### DIFF
--- a/src/Wpf.Ui/Controls/PasswordBox.cs
+++ b/src/Wpf.Ui/Controls/PasswordBox.cs
@@ -201,18 +201,10 @@ public sealed class PasswordBox : Wpf.Ui.Controls.TextBox
     }
 
     /// <summary>
-    /// Change the display of the password if rules are supported.
+    /// Change the display of the password.
     /// </summary>
-    private void UpdateRevealIfPossible(bool isPasswordRevealed)
+    private void UpdateReveal(bool isPasswordRevealed)
     {
-        // TODO: I don't know if it's a good method, but somehow works
-
-        if (isPasswordRevealed && Password.Length > 0)
-        {
-            IsPasswordRevealed = false;
-            return;
-        }
-
         SetValue(TextProperty,
             isPasswordRevealed ? Password : new String(PasswordChar, Password.Length));
     }
@@ -269,6 +261,6 @@ public sealed class PasswordBox : Wpf.Ui.Controls.TextBox
         if (d is not PasswordBox control)
             return;
 
-        control.UpdateRevealIfPossible(control.IsPasswordRevealed);
+        control.UpdateReveal(control.IsPasswordRevealed);
     }
 }


### PR DESCRIPTION
Close #270 

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

PasswordBox does not switch to revealed mode unless password is empty

Issue Number: 270

Reveal mode toggles on and off as expected.