### PR TITLE
Fix TextBox icon issue when fontsize is larger

### DIFF
--- a/src/Wpf.Ui/Styles/Controls/TextBox.xaml
+++ b/src/Wpf.Ui/Styles/Controls/TextBox.xaml
@@ -16,8 +16,8 @@
 
     <Thickness x:Key="TextBoxBorderThemeThickness">1,1,1,0</Thickness>
     <Thickness x:Key="TextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
-    <Thickness x:Key="TextBoxLeftIconMargin">10,8,0,0</Thickness>
-    <Thickness x:Key="TextBoxRightIconMargin">0,8,10,0</Thickness>
+    <Thickness x:Key="TextBoxLeftIconMargin">10,0,0,0</Thickness>
+    <Thickness x:Key="TextBoxRightIconMargin">0,0,10,0</Thickness>
     <Thickness x:Key="TextBoxClearButtonMargin">0,5,4,0</Thickness>
     <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness>
     <system:Double x:Key="TextBoxClearButtonHeight">24</system:Double>
@@ -240,7 +240,9 @@
                                     Grid.Column="0"
                                     Margin="{StaticResource TextBoxLeftIconMargin}"
                                     Padding="0"
-                                    VerticalAlignment="Top"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Center"
+                                    FontSize="{TemplateBinding FontSize}"
                                     Filled="{TemplateBinding IconFilled}"
                                     Foreground="{TemplateBinding IconForeground}"
                                     Symbol="{TemplateBinding Icon}" />
@@ -295,7 +297,9 @@
                                     Grid.Column="3"
                                     Margin="{StaticResource TextBoxRightIconMargin}"
                                     Padding="0"
-                                    VerticalAlignment="Top"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Center"
+                                    FontSize="{TemplateBinding FontSize}"
                                     Filled="{TemplateBinding IconFilled}"
                                     Foreground="{TemplateBinding IconForeground}"
                                     Symbol="{TemplateBinding Icon}" />


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
FontSize="20"
![`W%D7{}OST8H75GBV90HL66](https://user-images.githubusercontent.com/35869804/179222629-4be67c5d-6c40-4fa3-9634-54af0fa9b048.png)


## What is the new behavior?
FontSize="20"
![image](https://user-images.githubusercontent.com/35869804/179222741-4eadffc6-9343-495a-ae90-30a093326ebf.png)

Default Fontsize
![image](https://user-images.githubusercontent.com/35869804/179222885-dd3bbeca-faa0-42fa-a0f5-7dd80d4f3cbe.png)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
