### PR TITLE
Improved Dependency Injection support when activating pages for .NET Framework 4.8, .NET 3 and above

### DIFF
--- a/src/Wpf.Ui/Controls/ControlsServices.cs
+++ b/src/Wpf.Ui/Controls/ControlsServices.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 
-namespace Wpf.Ui
+namespace Wpf.Ui.Controls
 {
     /// <summary>
-    /// Used to initialize the library with static values.
+    /// Used to initialize the library controls with static values.
     /// </summary>
-    public static class WpfUi
+    public static class ControlsServices
     {
 #if NET48_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-        internal static IServiceProvider ServiceProvider { get; private set; }
+        internal static IServiceProvider ControlsServiceProvider { get; private set; }
 
         /// <summary>
         /// Accepts a ServiceProvider for configuring dependency injection.
@@ -20,7 +20,7 @@ namespace Wpf.Ui
             if (serviceProvider == null)
                 throw new ArgumentNullException(nameof(serviceProvider));
 
-            ServiceProvider = serviceProvider;
+            ControlsServiceProvider = serviceProvider;
         }
 #endif
     }

--- a/src/Wpf.Ui/Services/Internal/NavigationServiceActivator.cs
+++ b/src/Wpf.Ui/Services/Internal/NavigationServiceActivator.cs
@@ -61,7 +61,7 @@ internal static class NavigationServiceActivator
                     var parameters = ctor.GetParameters();
                     var argumentResolution = parameters.Select(prm =>
                     {
-                        var resolved = ResolveArgument(pageType, prm.ParameterType, dataContext);
+                        var resolved = ResolveArgument(prm.ParameterType, dataContext);
                         return resolved != null;
                     });
                     var fullyResolved = argumentResolution.All(resolved => resolved == true);
@@ -82,7 +82,7 @@ internal static class NavigationServiceActivator
 
                 var arguments = maximalCtor
                     .Constructor.GetParameters()
-                    .Select(prm => ResolveArgument(pageType, prm.ParameterType, dataContext));
+                    .Select(prm => ResolveArgument(prm.ParameterType, dataContext));
 
                 instance = maximalCtor.Constructor.Invoke(arguments.ToArray()) as FrameworkElement;
 
@@ -125,13 +125,11 @@ internal static class NavigationServiceActivator
         return instance;
     }
 
-    private static object ResolveArgument(Type pageType, Type tParam, object dataContext)
+    private static object ResolveArgument(Type tParam, object dataContext)
     {
         if (dataContext != null && dataContext.GetType() == tParam)
         {
-            var dataContextCtor = pageType.GetConstructor(new[] { dataContext.GetType() });
-            if (dataContextCtor != null)
-                return dataContextCtor.Invoke(new[] { dataContext });
+            return dataContext;
         }
 
         return WpfUi.ServiceProvider.GetService(tParam);

--- a/src/Wpf.Ui/Services/Internal/NavigationServiceActivator.cs
+++ b/src/Wpf.Ui/Services/Internal/NavigationServiceActivator.cs
@@ -80,7 +80,7 @@ internal static class NavigationServiceActivator
                 .FirstOrDefault();
 
                 if (maximalCtor == null)
-                    throw new InvalidOperationException($"The {pageType} page does not have a parameterless constructor or the required services have not been configured for dependency injection. Use the static WpfUi class to initialize the GUI library with your service provider. If you are using {typeof(Mvvm.Contracts.IPageService)} do not navigate initially and don't use Cache or Precache.");
+                    throw new InvalidOperationException($"The {pageType} page does not have a parameterless constructor or the required services have not been configured for dependency injection. Use the static {nameof(ControlsServices)} class to initialize the GUI library with your service provider. If you are using {typeof(Mvvm.Contracts.IPageService)} do not navigate initially and don't use Cache or Precache.");
 
                 var arguments = maximalCtor
                     .Constructor.GetParameters()

--- a/src/Wpf.Ui/WpfUi.cs
+++ b/src/Wpf.Ui/WpfUi.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Wpf.Ui
+{
+    public static class WpfUi
+    {
+#if NET48_OR_GREATER
+        internal static IServiceProvider ServiceProvider { get; private set; }
+
+        public static void Initialize(IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+                throw new ArgumentNullException(nameof(serviceProvider));
+
+            ServiceProvider = serviceProvider;
+        }
+#endif
+
+#if NETCOREAPP3_0_OR_GREATER
+        internal static IServiceProvider ServiceProvider { get; private set; }
+
+        public static void Initialize(IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+                throw new ArgumentNullException(nameof(serviceProvider));
+
+            ServiceProvider = serviceProvider;
+        }
+#endif
+    }
+}

--- a/src/Wpf.Ui/WpfUi.cs
+++ b/src/Wpf.Ui/WpfUi.cs
@@ -2,23 +2,19 @@
 
 namespace Wpf.Ui
 {
+    /// <summary>
+    /// Used to initialize the library with static values.
+    /// </summary>
     public static class WpfUi
     {
-#if NET48_OR_GREATER
+#if NET48_OR_GREATER || NETCOREAPP3_0_OR_GREATER
         internal static IServiceProvider ServiceProvider { get; private set; }
 
-        public static void Initialize(IServiceProvider serviceProvider)
-        {
-            if (serviceProvider == null)
-                throw new ArgumentNullException(nameof(serviceProvider));
-
-            ServiceProvider = serviceProvider;
-        }
-#endif
-
-#if NETCOREAPP3_0_OR_GREATER
-        internal static IServiceProvider ServiceProvider { get; private set; }
-
+        /// <summary>
+        /// Accepts a ServiceProvider for configuring dependency injection.
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         public static void Initialize(IServiceProvider serviceProvider)
         {
             if (serviceProvider == null)


### PR DESCRIPTION
Added support for dependency injection when activating pages for navigation.

There is a static field which may be initialized by the library user to supply an instance of a IServiceProvider, which if configured will be used to try to resolve non-parameterless constructors for a page which the navigation service requested.

Only works in .NET Framework 4.8 or greater and .NET Core (.NET) versions above 3.0.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently only parameterless constructors and constructors accepting a single parameter of the type matching the passed dataContext are supported.

Issue Number: N/A

## What is the new behavior?

The original behaviour is preserved if no service provider has been configured, otherwise the activation is modified in such a way that the activiation service also tries to find a non-parameterless constructor, and if there are more then one, the maximal such constructor, by the number of resolvable parameters and uses that one to construct an instance. If there was a data context passed, it is set to the new instance.

## Other information

Introduces a static class at the project files root level, this could be placed elsewhere.