### PR TITLE
Fix TreeView virtualization.

### DIFF
--- a/src/Wpf.Ui/Styles/Controls/TreeView.xaml
+++ b/src/Wpf.Ui/Styles/Controls/TreeView.xaml
@@ -47,7 +47,7 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
+            <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="True">
                 <Setter Property="ItemsPanel">
                     <Setter.Value>
                         <ItemsPanelTemplate>

--- a/src/Wpf.Ui/Styles/Controls/TreeView.xaml
+++ b/src/Wpf.Ui/Styles/Controls/TreeView.xaml
@@ -46,6 +46,17 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style BasedOn="{StaticResource DefaultTreeViewStyle}" TargetType="{x:Type TreeView}" />


### PR DESCRIPTION
I have a TreeView with more than 10000 items. When I click to expand an item it expands in more than 5 seconds. So we have to add the virtualization supports for the TreeView.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The performance is very poor.

Issue Number: 1

## What is the new behavior?

- When we enable the virtualization using `VirtualizingPanel.IsVirtualizing="True"`, it can now works in a better performance as the original WPF TreeView does.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
