### PR TITLE
Fix ResizeMode of NoResize

### DIFF
--- a/src/Wpf.Ui/Controls/UiWindow.cs
+++ b/src/Wpf.Ui/Controls/UiWindow.cs
@@ -258,7 +258,7 @@ public class UiWindow : System.Windows.Window
                 CaptionHeight = 1,
                 CornerRadius = new CornerRadius(4),
                 GlassFrameThickness = new Thickness(-1),
-                ResizeBorderThickness = new Thickness(4),
+                ResizeBorderThickness = this.ResizeMode == ResizeMode.NoResize ? new Thickness(0) : new Thickness(4),
                 UseAeroCaptionButtons = false
             });
     }


### PR DESCRIPTION
This PR fixes `ResizeMode` of `NoResize` not working when using `ui:UiWindow`.

## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, setting the `ResizeMode` to `NoResize` does not work without also setting the `WindowStyle` to `None`. However, doing so breaks theming.

Issue Number: [#324](https://github.com/lepoco/wpfui/issues/324), also possibly [#109](https://github.com/lepoco/wpfui/issues/109), [#202](https://github.com/lepoco/wpfui/issues/202), and [#207](https://github.com/lepoco/wpfui/issues/207)

## What is the new behavior?

A conditional check has been added to the `WindowChrome` initializer, which checks to see if the `ResizeMode` is set to `NoResize`. If it is, the `ResizeBorderThickness` on the new `WindowChrome` receives a thickness of 0, which prevents resizing. Otherwise, default behavior is maintained.