### PR TITLE
Update TextBox control

### DIFF
--- a/src/Wpf.Ui/Styles/Controls/TextBox.xaml
+++ b/src/Wpf.Ui/Styles/Controls/TextBox.xaml
@@ -323,6 +323,10 @@
                             <Setter TargetName="ClearButton" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="ClearButton" Property="Margin" Value="0" />
                         </Trigger>
+                        <Trigger Property="IsReadOnly" Value="True">
+                            <Setter TargetName="ClearButton" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="ClearButton" Property="Margin" Value="0" />
+                        </Trigger>
                         <Trigger Property="IconPlacement" Value="Left">
                             <Setter TargetName="ControlIconRight" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="ControlIconRight" Property="Margin" Value="0" />


### PR DESCRIPTION
Don't show ClearButton when textbox is read only.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When using the TextBox control in ReadOnly mode it will show the ClearButton.

Issue Number: N/A

## What is the new behavior?

Now When you use the TextBox control in ReadOnly mode it will no longer show the ClearButton

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
