### PR TITLE
Fix Theming in SimpleDemo App

### DIFF
--- a/src/Wpf.Ui.SimpleDemo/MainWindow.xaml
+++ b/src/Wpf.Ui.SimpleDemo/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<ui:UiWindow
     x:Class="Wpf.Ui.SimpleDemo.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -12,34 +12,48 @@
     d:DesignHeight="650"
     d:DesignWidth="900"
     Background="{DynamicResource ApplicationBackgroundBrush}"
+    ExtendsContentIntoTitleBar="True"
+    WindowBackdropType="Mica"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <Grid Margin="8">
+    <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ui:NavigationStore
-            Grid.Column="0"
-            Frame="{Binding ElementName=MainFrame}"
-            SelectedPageIndex="0">
-            <ui:NavigationStore.Items>
-                <ui:NavigationItem
-                    Content="Home"
-                    Icon="Home24"
-                    PageTag="home"
-                    PageType="{x:Type local:DashboardPage}" />
-                <ui:NavigationItem Content="Apps" Icon="AppFolder24" />
-                <ui:NavigationItem Content="Mail" Icon="Mail24" />
-            </ui:NavigationStore.Items>
-            <ui:NavigationStore.Footer>
-                <ui:NavigationItem Content="Library" Icon="Library24" />
-                <ui:NavigationItem Content="Settings" Icon="Settings24" />
-            </ui:NavigationStore.Footer>
-        </ui:NavigationStore>
-        <Frame
-            x:Name="MainFrame"
-            Grid.Column="1"
-            Margin="8,0,0,0" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <ui:TitleBar Title="WPF UI - Simple Demo" />
+
+        <Grid Grid.Row="1" Margin="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <ui:NavigationStore
+                Grid.Column="0"
+                Frame="{Binding ElementName=MainFrame}"
+                SelectedPageIndex="0">
+                <ui:NavigationStore.Items>
+                    <ui:NavigationItem
+                        Content="Home"
+                        Icon="Home24"
+                        PageTag="home"
+                        PageType="{x:Type local:DashboardPage}" />
+                    <ui:NavigationItem Content="Apps" Icon="AppFolder24" />
+                    <ui:NavigationItem Content="Mail" Icon="Mail24" />
+                </ui:NavigationStore.Items>
+                <ui:NavigationStore.Footer>
+                    <ui:NavigationItem Content="Library" Icon="Library24" />
+                    <ui:NavigationItem Content="Settings" Icon="Settings24" />
+                </ui:NavigationStore.Footer>
+            </ui:NavigationStore>
+            <Frame
+                x:Name="MainFrame"
+                Grid.Column="1"
+                Margin="8,0,0,0" />
+        </Grid>
     </Grid>
-</Window>
+</ui:UiWindow>

--- a/src/Wpf.Ui.SimpleDemo/MainWindow.xaml.cs
+++ b/src/Wpf.Ui.SimpleDemo/MainWindow.xaml.cs
@@ -14,9 +14,6 @@ public partial class MainWindow
     {
         InitializeComponent();
 
-        Wpf.Ui.Appearance.Accent.ApplySystemAccent();
-
-        // Wpf.Ui.Appearance.Theme.ApplyDarkThemeToWindow(this);
-        // Wpf.Ui.Appearance.Background.Apply(this, Wpf.Ui.Appearance.BackgroundType.Mica);
+        Watcher.Watch(this, BackgroundType.Mica, true);
     }
 }


### PR DESCRIPTION
This PR fixes themes not being correctly applied to the SimpleDemo app, as well as prevents the application from flashing white during initialization if the user is applying a dark theme.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, running the SimpleDemo does not respect the users theme settings. Manually setting the theme to "Dark" causes the app to still flash white during initialization.

Issue Number: #388

## What is the new behavior?

The SimpleDemo now utilizes UiWindow and dynamic theming to prevent the previously mentioned issues.

![image](https://user-images.githubusercontent.com/7614507/189665287-a1f3604f-481a-481f-aa3c-b40a0a59a4a8.png)


## Other information

In its current state, SimpleDemo no longer displays the icon in the title bar. If requested, I can add one of the ICO files as a reference and handle it the same way the current Demo app does. Alternatively, if an SVG version of the icon exists, we could use it to create a DrawingImage, and render that in the title bar.
