### PR TITLE
fix bug open message box when MainWindow is null

### DIFF
--- a/src/Wpf.Ui/Controls/MessageBox.cs
+++ b/src/Wpf.Ui/Controls/MessageBox.cs
@@ -230,9 +230,7 @@ public class MessageBox : System.Windows.Window
     //    System.Diagnostics.Debug.WriteLine(newContent.GetType());
 
     //    if (newContent != null && newContent.GetType() == typeof(System.Windows.Controls.Grid))
-    //    {
     //        Height = (newContent as System.Windows.Controls.Grid).ActualHeight;
-    //    }
 
     //    base.OnContentChanged(oldContent, newContent);
     //}
@@ -240,21 +238,15 @@ public class MessageBox : System.Windows.Window
     private void SetWindowStartupLocation()
     {
         if (Application.Current?.MainWindow != null)
-        {
             Owner = Application.Current.MainWindow;
-        }
         else
-        {
             WindowStartupLocation = WindowStartupLocation.CenterScreen;
-        }
     }
 
     private void Button_OnClick(object sender, object parameter)
     {
         if (parameter == null)
-        {
             return;
-        }
 
         string param = parameter as string ?? String.Empty;
 

--- a/src/Wpf.Ui/Controls/MessageBox.cs
+++ b/src/Wpf.Ui/Controls/MessageBox.cs
@@ -239,7 +239,7 @@ public class MessageBox : System.Windows.Window
 
     private void SetWindowStartupLocation()
     {
-        if (Application.Current.MainWindow != null)
+        if (Application.Current?.MainWindow != null)
         {
             Owner = Application.Current.MainWindow;
         }

--- a/src/Wpf.Ui/Controls/MessageBox.cs
+++ b/src/Wpf.Ui/Controls/MessageBox.cs
@@ -188,8 +188,7 @@ public class MessageBox : System.Windows.Window
     /// </summary>
     public MessageBox()
     {
-        Owner = Application.Current.MainWindow;
-
+        SetWindowStartupLocation();
         Topmost = true;
 
         Height = 200;
@@ -237,6 +236,18 @@ public class MessageBox : System.Windows.Window
 
     //    base.OnContentChanged(oldContent, newContent);
     //}
+
+    private void SetWindowStartupLocation()
+    {
+        if (Application.Current.MainWindow != null)
+        {
+            Owner = Application.Current.MainWindow;
+        }
+        else
+        {
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        }
+    }
 
     private void Button_OnClick(object sender, object parameter)
     {


### PR DESCRIPTION
fix bug open message box when MainWindow is null

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When MainWindow is null. a message box is not opened.

Issue Number: #396 

## What is the new behavior?

When MainWindow is null. a message box is opened on center screen
