### PR TITLE
fix(NotifyIcon): Allow changing tray icon source

### DIFF
--- a/src/Wpf.Ui/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui/Controls/NotifyIcon.cs
@@ -404,7 +404,8 @@ public class NotifyIcon : System.Windows.FrameworkElement
         if (d is not NotifyIcon notifyIcon)
             return;
 
-        notifyIcon.Icon = e.NewValue as ImageSource;
+        notifyIcon._notifyIconService.Icon = e.NewValue as ImageSource;
+        notifyIcon._notifyIconService.ModifyIcon();
     }
 
     private static void OnFocusOnLeftClickChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/Wpf.Ui/Services/Internal/NotifyIconService.cs
+++ b/src/Wpf.Ui/Services/Internal/NotifyIconService.cs
@@ -108,6 +108,12 @@ internal class NotifyIconService : IDisposable, INotifyIcon
     }
 
     /// <inheritdoc />
+    public virtual bool ModifyIcon()
+    {
+        return TrayManager.ModifyIcon(this);
+    }
+
+    /// <inheritdoc />
     public virtual bool Unregister()
     {
         return TrayManager.Unregister(this);

--- a/src/Wpf.Ui/Tray/INotifyIcon.cs
+++ b/src/Wpf.Ui/Tray/INotifyIcon.cs
@@ -78,6 +78,11 @@ internal interface INotifyIcon
     bool Register(Window parentWindow);
 
     /// <summary>
+    /// Tries to modify the icon of the <see cref="INotifyIcon"/> in the shell.
+    /// </summary>
+    bool ModifyIcon();
+
+    /// <summary>
     /// Tries to remove the <see cref="INotifyIcon"/> from the shell.
     /// </summary>
     bool Unregister();

--- a/src/Wpf.Ui/Tray/TrayManager.cs
+++ b/src/Wpf.Ui/Tray/TrayManager.cs
@@ -81,19 +81,7 @@ internal static class TrayManager
             notifyIcon.ShellIconData.uFlags |= Interop.Shell32.NIF.TIP;
         }
 
-        var hIcon = IntPtr.Zero;
-
-        if (notifyIcon.Icon != null)
-            hIcon = Hicon.FromSource(notifyIcon.Icon);
-
-        if (hIcon == IntPtr.Zero)
-            hIcon = Hicon.FromApp();
-
-        if (hIcon != IntPtr.Zero)
-        {
-            notifyIcon.ShellIconData.hIcon = hIcon;
-            notifyIcon.ShellIconData.uFlags |= Interop.Shell32.NIF.ICON;
-        }
+        ReloadHicon(notifyIcon);
 
         notifyIcon.HookWindow.AddHook(notifyIcon.WndProc);
 
@@ -104,6 +92,16 @@ internal static class TrayManager
         notifyIcon.IsRegistered = true;
 
         return true;
+    }
+
+    public static bool ModifyIcon(INotifyIcon notifyIcon)
+    {
+        if (!notifyIcon.IsRegistered)
+            return true;
+
+        ReloadHicon(notifyIcon);
+
+        return Interop.Shell32.Shell_NotifyIcon(Interop.Shell32.NIM.MODIFY, notifyIcon.ShellIconData);
     }
 
     /// <summary>
@@ -132,5 +130,22 @@ internal static class TrayManager
             return null;
 
         return (HwndSource)PresentationSource.FromVisual(mainWindow);
+    }
+
+    private static void ReloadHicon(INotifyIcon notifyIcon)
+    {
+        var hIcon = IntPtr.Zero;
+
+        if (notifyIcon.Icon != null)
+            hIcon = Hicon.FromSource(notifyIcon.Icon);
+
+        if (hIcon == IntPtr.Zero)
+            hIcon = Hicon.FromApp();
+
+        if (hIcon != IntPtr.Zero)
+        {
+            notifyIcon.ShellIconData.hIcon = hIcon;
+            notifyIcon.ShellIconData.uFlags |= Interop.Shell32.NIF.ICON;
+        }
     }
 }


### PR DESCRIPTION
- Properly set `_notifyIconService.Icon` from `OnIconChanged` handler in `NotifyIcon`.
- Adds a new `ModifyIcon` function to `INotifyIcon`. Internally, this functions calls the Win32 `Shell_NotifyIcon` with the first argument being `NIM_MODIFY`.
- Edits the `Hicon.FromSource` to allow converting the more general `BitmapSource` class to a `Hicon`.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: See #408

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The tray icon changes properly if the `Icon` property of `NotifyIcon` is set to a valid `BitmapSource`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Should fix #408

The PR adds a new function to `INotifyIcon` and `TrayManager` to expose the Win32 functionality of modifying a ShellIcon.
The PR does not modify any public API and/or UI controls.