### PR TITLE
Fixed app published as singleFile not running (issue #483)

### DIFF
--- a/src/Wpf.Ui.Demo.Mvvm/App.xaml.cs
+++ b/src/Wpf.Ui.Demo.Mvvm/App.xaml.cs
@@ -26,7 +26,7 @@ public partial class App
     // https://docs.microsoft.com/dotnet/core/extensions/logging
     private static readonly IHost _host = Host
         .CreateDefaultBuilder()
-        .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)); })
+        .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(AppContext.BaseDirectory)); })
         .ConfigureServices((context, services) =>
         {
             // App Host


### PR DESCRIPTION
Currently executables published as singleFile are not running. (See Issue #483)
The problem is in setting the Host object's Base Path as "Assembly.GetEntryAssembly()!.Location" returns null.
Based @MrCosmo suggestion changing it to "AppContext.BaseDirectory" works perfectly.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- Executables published as singleFile are not running.

Issue Number: #483

## What is the new behavior?

- Executables published as singleFile run fine.
