### PR TITLE
Image Control

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Pages/Media/ImagePage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Media/ImagePage.xaml
@@ -41,10 +41,13 @@
                     <controls:GalleryControlPresenter
                         Grid.Row="0"
                         Margin="0"
-                        CodeText="&lt;Image Height=&quot;100&quot; Source=&quot;Assets\MyImage.jpg&quot; /&gt;"
-                        HeaderText="A basic Image from a local file">
+                        CodeText="&lt;ui:Image CornerRadius=&quot;4&quot; BorderBrush=&quot;#33000000&quot; Height=&quot;100&quot; Source=&quot;Assets\MyImage.jpg&quot; /&gt;"
+                        HeaderText="A basic Image with rounded corners from a local file">
                         <controls:GalleryControlPresenter.Content>
-                            <Image
+                            <ui:Image
+                                CornerRadius="4"
+                                BorderBrush="#33000000"
+                                BorderThickness="2"
                                 Height="200"
                                 HorizontalAlignment="Left"
                                 Source="pack://application:,,,/Assets/pexels-johannes-plenio-1103970.jpg" />

--- a/src/Wpf.Ui.Gallery/Views/Pages/Media/ImagePage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Media/ImagePage.xaml
@@ -11,7 +11,7 @@
     Title="ImagePage"
     d:DataContext="{d:DesignInstance local:ImagePage,
                                      IsDesignTimeCreatable=False}"
-    d:DesignHeight="450"
+    d:DesignHeight="700"
     d:DesignWidth="800"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -41,8 +41,21 @@
                     <controls:GalleryControlPresenter
                         Grid.Row="0"
                         Margin="0"
+                        CodeText="&lt;Image Height=&quot;100&quot; Source=&quot;Assets\MyImage.jpg&quot; /&gt;"
+                        HeaderText="Standand Image from a local file.">
+                        <controls:GalleryControlPresenter.Content>
+                            <Image
+                                Height="200"
+                                HorizontalAlignment="Left"
+                                Source="pack://application:,,,/Assets/pexels-johannes-plenio-1103970.jpg" />
+                        </controls:GalleryControlPresenter.Content>
+                    </controls:GalleryControlPresenter>
+
+                    <controls:GalleryControlPresenter
+                        Grid.Row="1"
+                        Margin="0,32,0,0"
                         CodeText="&lt;ui:Image CornerRadius=&quot;4&quot; BorderBrush=&quot;#33000000&quot; Height=&quot;100&quot; Source=&quot;Assets\MyImage.jpg&quot; /&gt;"
-                        HeaderText="A basic Image with rounded corners from a local file">
+                        HeaderText="WPF UI Image with rounded corners from a local file">
                         <controls:GalleryControlPresenter.Content>
                             <ui:Image
                                 CornerRadius="4"

--- a/src/Wpf.Ui/Controls/Image.cs
+++ b/src/Wpf.Ui/Controls/Image.cs
@@ -1,3 +1,8 @@
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 using System;
 using System.Windows;
 using System.Windows.Controls;
@@ -5,69 +10,117 @@ using System.Windows.Media;
 
 namespace Wpf.Ui.Controls;
 
+/// <summary>
+/// Represents an image with additional proproties for Borders and Rounded corners
+/// </summary>
 public class Image : Control
 {
-	public static readonly DependencyProperty SourceProperty =
-		DependencyProperty.Register(nameof(Source), typeof(ImageSource), typeof(Image),
-			new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, null, null),
-			null);
+    #region DependencyPropreties
+    /// <summary>
+    /// Gets/Sets the Source on this Image.
+    /// The Source property is the ImageSource that holds the actual image drawn.
+    /// </summary>
+    public static readonly DependencyProperty SourceProperty =
+        DependencyProperty.Register(nameof(Source), typeof(ImageSource), typeof(Image),
+            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, null, null),
+            null);
 
-	public static readonly DependencyProperty CornerRadiusProperty =
-		DependencyProperty.Register(nameof(CornerRadius), typeof(CornerRadius), typeof(Image), new PropertyMetadata(new CornerRadius(0), new PropertyChangedCallback(OnCornerRadiusChanged)));
+    /// <summary>
+    /// DependencyProperty for CornerRadius property.
+    /// </summary>
+    public static readonly DependencyProperty CornerRadiusProperty =
+        DependencyProperty.Register(nameof(CornerRadius), typeof(CornerRadius), typeof(Image), new PropertyMetadata(new CornerRadius(0), new PropertyChangedCallback(OnCornerRadiusChanged)));
 
-	private static void OnCornerRadiusChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-	{
-		var thickness = (Thickness)d.GetValue(BorderThicknessProperty);
-		var outerRarius = (CornerRadius)e.NewValue;
+    /// <summary>
+    /// DependencyProperty for StretchDirection property.
+    /// </summary>
+    /// <seealso cref="Viewbox.Stretch" />
+    public static readonly DependencyProperty StretchProperty = DependencyProperty.Register(
+        nameof(Stretch), typeof(Stretch), typeof(Image), new FrameworkPropertyMetadata(Stretch.Uniform, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender), null);
 
-		//Inner radius = Outer radius - thickenss/2
-		d.SetValue(InnerCornerRadiusPropertyKey,
-			new CornerRadius(
-				topLeft: Math.Max(0, (int)Math.Round(outerRarius.TopLeft - thickness.Left / 2, 0)),
-				topRight: Math.Max(0, (int)Math.Round(outerRarius.TopRight - thickness.Top / 2, 0)),
-				bottomRight: Math.Max(0, (int)Math.Round(outerRarius.BottomRight - thickness.Right / 2, 0)),
-				bottomLeft: Math.Max(0, (int)Math.Round(outerRarius.BottomLeft - thickness.Bottom / 2, 0)))
-			);
-	}
+    /// <summary>
+    /// DependencyProperty for Stretch property.
+    /// </summary>
+    public static readonly DependencyProperty StretchDirectionProperty = DependencyProperty.Register(
+        nameof(StretchDirection), typeof(StretchDirection), typeof(Image), new FrameworkPropertyMetadata(StretchDirection.Both, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender), null);
 
-	public static readonly DependencyProperty StretchProperty = DependencyProperty.Register(
-		nameof(Stretch), typeof(Stretch), typeof(Image), new FrameworkPropertyMetadata(Stretch.Uniform, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender), null);
+    /// <summary>
+    /// DependencyPropertyKey for InnerCornerRadius property.
+    /// </summary>
+    public static readonly DependencyPropertyKey InnerCornerRadiusPropertyKey = DependencyProperty.RegisterReadOnly(
+        nameof(InnerCornerRadius), typeof(CornerRadius), typeof(Image), new PropertyMetadata(new CornerRadius(0)));
 
-	public static readonly DependencyProperty StretchDirectionProperty = DependencyProperty.Register(
-		nameof(StretchDirection), typeof(StretchDirection), typeof(Image), new FrameworkPropertyMetadata(StretchDirection.Both, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender), null);
+    /// <summary>
+    /// DependencyProperty for InnerCornerRadius property.
+    /// </summary>
+    public static readonly DependencyProperty InnerCornerRadiusProperty =
+    InnerCornerRadiusPropertyKey.DependencyProperty;
+    #endregion
 
-	//Corner radius for inner Image
-	public static readonly DependencyPropertyKey InnerCornerRadiusPropertyKey = DependencyProperty.RegisterReadOnly(
-		nameof(InnerCornerRadius), typeof(CornerRadius), typeof(Image), new PropertyMetadata(new CornerRadius(0)));
+    #region Propreties
+    /// <summary>
+    /// Gets/Sets the Source on this Image.
+    /// The Source property is the ImageSource that holds the actual image drawn.
+    /// </summary>
+    public ImageSource Source
+    {
+        get => (ImageSource)GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
+    }
 
-	public static readonly DependencyProperty InnerCornerRadiusProperty =
-		InnerCornerRadiusPropertyKey.DependencyProperty;
+    /// <summary>
+    /// Gets/Sets the Stretch on this Image.
+    /// The Stretch property determines how large the Image will be drawn.
+    /// </summary>
+    public Stretch Stretch
+    {
+        get => (Stretch)GetValue(StretchProperty);
+        set => SetValue(StretchProperty, value);
+    }
 
+    /// <summary>
+    /// Gets/Sets the stretch direction of the Viewbox, which determines the restrictions on
+    /// scaling that are applied to the content inside the Viewbox.  For instance, this property
+    /// can be used to prevent the content from being smaller than its native size or larger than
+    /// its native size.
+    /// </summary>
+    public StretchDirection StretchDirection
+    {
+        get => (StretchDirection)GetValue(StretchDirectionProperty);
+        set => SetValue(StretchDirectionProperty, value);
+    }
 
+    /// <summary>
+    /// The CornerRadius property allows users to control the roundness of the corners independently by
+    /// setting a radius value for each corner.  Radius values that are too large are scaled so that they
+    /// smoothly blend from corner to corner.
+    /// </summary>
+    public CornerRadius CornerRadius
+    {
+        get => (CornerRadius)GetValue(CornerRadiusProperty);
+        set => SetValue(CornerRadiusProperty, value);
+    }
 
-	//Propreties
-	public ImageSource Source
-	{
-		get => (ImageSource)GetValue(SourceProperty);
-		set => SetValue(SourceProperty, value);
-	}
+    /// <summary>
+    /// The CornerRadius for the inner image's Mask.
+    /// </summary>
+    internal CornerRadius InnerCornerRadius => (CornerRadius)GetValue(InnerCornerRadiusProperty);
+    #endregion
 
-	public Stretch Stretch
-	{
-		get => (Stretch)GetValue(StretchProperty);
-		set => SetValue(StretchProperty, value);
-	}
+    #region Methods
+    private static void OnCornerRadiusChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var thickness = (Thickness)d.GetValue(BorderThicknessProperty);
+        var outerRarius = (CornerRadius)e.NewValue;
 
-	public StretchDirection StretchDirection
-	{
-		get => (StretchDirection)GetValue(StretchDirectionProperty);
-		set => SetValue(StretchDirectionProperty, value);
-	}
-
-	public CornerRadius CornerRadius
-	{
-		get => (CornerRadius)GetValue(CornerRadiusProperty);
-		set => SetValue(CornerRadiusProperty, value);
-	}
-	public CornerRadius InnerCornerRadius => (CornerRadius)GetValue(InnerCornerRadiusProperty);
+        //Inner radius = Outer radius - thickenss/2
+        d.SetValue(InnerCornerRadiusPropertyKey,
+            new CornerRadius(
+                topLeft: Math.Max(0, (int)Math.Round(outerRarius.TopLeft - thickness.Left / 2, 0)),
+                topRight: Math.Max(0, (int)Math.Round(outerRarius.TopRight - thickness.Top / 2, 0)),
+                bottomRight: Math.Max(0, (int)Math.Round(outerRarius.BottomRight - thickness.Right / 2, 0)),
+                bottomLeft: Math.Max(0, (int)Math.Round(outerRarius.BottomLeft - thickness.Bottom / 2, 0)))
+        );
+    }
+    #endregion
 }

--- a/src/Wpf.Ui/Controls/Image.cs
+++ b/src/Wpf.Ui/Controls/Image.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace Wpf.Ui.Controls;
+
+public class Image : Control
+{
+	public static readonly DependencyProperty SourceProperty =
+		DependencyProperty.Register(nameof(Source), typeof(ImageSource), typeof(Image),
+			new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, null, null),
+			null);
+
+	public static readonly DependencyProperty CornerRadiusProperty =
+		DependencyProperty.Register(nameof(CornerRadius), typeof(CornerRadius), typeof(Image), new PropertyMetadata(new CornerRadius(0), new PropertyChangedCallback(OnCornerRadiusChanged)));
+
+	private static void OnCornerRadiusChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		var thickness = (Thickness)d.GetValue(BorderThicknessProperty);
+		var outerRarius = (CornerRadius)e.NewValue;
+
+		//Inner radius = Outer radius - thickenss/2
+		d.SetValue(InnerCornerRadiusPropertyKey,
+			new CornerRadius(
+				topLeft: Math.Max(0, (int)Math.Round(outerRarius.TopLeft - thickness.Left / 2, 0)),
+				topRight: Math.Max(0, (int)Math.Round(outerRarius.TopRight - thickness.Top / 2, 0)),
+				bottomRight: Math.Max(0, (int)Math.Round(outerRarius.BottomRight - thickness.Right / 2, 0)),
+				bottomLeft: Math.Max(0, (int)Math.Round(outerRarius.BottomLeft - thickness.Bottom / 2, 0)))
+			);
+	}
+
+	public static readonly DependencyProperty StretchProperty = DependencyProperty.Register(
+		nameof(Stretch), typeof(Stretch), typeof(Image), new FrameworkPropertyMetadata(Stretch.Uniform, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender), null);
+
+	public static readonly DependencyProperty StretchDirectionProperty = DependencyProperty.Register(
+		nameof(StretchDirection), typeof(StretchDirection), typeof(Image), new FrameworkPropertyMetadata(StretchDirection.Both, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender), null);
+
+	//Corner radius for inner Image
+	public static readonly DependencyPropertyKey InnerCornerRadiusPropertyKey = DependencyProperty.RegisterReadOnly(
+		nameof(InnerCornerRadius), typeof(CornerRadius), typeof(Image), new PropertyMetadata(new CornerRadius(0)));
+
+	public static readonly DependencyProperty InnerCornerRadiusProperty =
+		InnerCornerRadiusPropertyKey.DependencyProperty;
+
+
+
+	//Propreties
+	public ImageSource Source
+	{
+		get => (ImageSource)GetValue(SourceProperty);
+		set => SetValue(SourceProperty, value);
+	}
+
+	public Stretch Stretch
+	{
+		get => (Stretch)GetValue(StretchProperty);
+		set => SetValue(StretchProperty, value);
+	}
+
+	public StretchDirection StretchDirection
+	{
+		get => (StretchDirection)GetValue(StretchDirectionProperty);
+		set => SetValue(StretchDirectionProperty, value);
+	}
+
+	public CornerRadius CornerRadius
+	{
+		get => (CornerRadius)GetValue(CornerRadiusProperty);
+		set => SetValue(CornerRadiusProperty, value);
+	}
+	public CornerRadius InnerCornerRadius => (CornerRadius)GetValue(InnerCornerRadiusProperty);
+}

--- a/src/Wpf.Ui/Styles/Controls/Image.xaml
+++ b/src/Wpf.Ui/Styles/Controls/Image.xaml
@@ -12,20 +12,28 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 	<Style x:Key="DefaultImageStyle"  TargetType="{x:Type controls:Image}">
-
-
-
-		<Setter Property="Template">
+        <Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type controls:Image}">
 					<Border VerticalAlignment="Center" HorizontalAlignment="Center"
-					        BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="{TemplateBinding CornerRadius}" ClipToBounds="True">
+					        BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Background="{TemplateBinding Background}"
+                            ClipToBounds="True">
 						
-							<Image Source="{TemplateBinding Source}" VerticalAlignment="Center" HorizontalAlignment="Center" Stretch="{TemplateBinding Stretch}" StretchDirection="{TemplateBinding StretchDirection}">
+							<Image Source="{TemplateBinding Source}"
+                                   VerticalAlignment="Center"
+                                   HorizontalAlignment="Center"
+                                   Stretch="{TemplateBinding Stretch}"
+                                   StretchDirection="{TemplateBinding StretchDirection}">
 							<Image.OpacityMask>
 								<VisualBrush>
 									<VisualBrush.Visual>
-										<Border Height="{TemplateBinding  ActualHeight}" Width="{TemplateBinding ActualWidth}" Background="White" CornerRadius="{TemplateBinding InnerCornerRadius}" />
+										<Border Height="{TemplateBinding  ActualHeight}"
+                                                Width="{TemplateBinding ActualWidth}"
+                                                Background="White"
+                                                CornerRadius="{TemplateBinding InnerCornerRadius}" />
 									</VisualBrush.Visual>
 								</VisualBrush>
 							</Image.OpacityMask>
@@ -33,10 +41,8 @@
 					</Border>
 				</ControlTemplate>
 			</Setter.Value>
-
-		</Setter>
+        </Setter>
 	</Style>
 
 	<Style BasedOn="{StaticResource DefaultImageStyle}" TargetType="{x:Type controls:Image}" />
-
 </ResourceDictionary>

--- a/src/Wpf.Ui/Styles/Controls/Image.xaml
+++ b/src/Wpf.Ui/Styles/Controls/Image.xaml
@@ -1,0 +1,32 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+	<Style x:Key="DefaultImageStyle"  TargetType="{x:Type controls:Image}">
+
+
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type controls:Image}">
+					<Border VerticalAlignment="Center" HorizontalAlignment="Center"
+					        BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="{TemplateBinding CornerRadius}" ClipToBounds="True">
+						
+							<Image Source="{TemplateBinding Source}" VerticalAlignment="Center" HorizontalAlignment="Center" Stretch="{TemplateBinding Stretch}" StretchDirection="{TemplateBinding StretchDirection}">
+							<Image.OpacityMask>
+								<VisualBrush>
+									<VisualBrush.Visual>
+										<Border Height="{TemplateBinding  ActualHeight}" Width="{TemplateBinding ActualWidth}" Background="White" CornerRadius="{TemplateBinding InnerCornerRadius}" />
+									</VisualBrush.Visual>
+								</VisualBrush>
+							</Image.OpacityMask>
+								</Image>
+					</Border>
+				</ControlTemplate>
+			</Setter.Value>
+
+		</Setter>
+	</Style>
+
+	<Style BasedOn="{StaticResource DefaultImageStyle}" TargetType="{x:Type controls:Image}" />
+
+</ResourceDictionary>

--- a/src/Wpf.Ui/Styles/Controls/Image.xaml
+++ b/src/Wpf.Ui/Styles/Controls/Image.xaml
@@ -1,4 +1,14 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+    
+    Based on Microsoft XAML for Win UI
+    Copyright (c) Microsoft Corporation. All Rights Reserved.
+-->
+
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 	<Style x:Key="DefaultImageStyle"  TargetType="{x:Type controls:Image}">

--- a/src/Wpf.Ui/Styles/Wpf.Ui.xaml
+++ b/src/Wpf.Ui/Styles/Wpf.Ui.xaml
@@ -56,6 +56,7 @@
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Controls/NavigationViewBreadcrumb.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Controls/BreadcrumbBar.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Controls/NavigationView.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Controls/Image.xaml" />
 
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Controls/TextBlock.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Controls/ScrollBar.xaml" />


### PR DESCRIPTION
Implements a `ui:Image` Control with CornerRadius, BorderThickness, BorderBrush and Background

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

No easy way for an image with rounded corners.


## What is the new behavior?

- `ui:Image` gives access all Image properties with border and corner properties.
For Transparent Images, you can set `Background` to fill the transparency 

## Other information

![image](https://user-images.githubusercontent.com/8873170/215366613-49e019ee-2eae-404e-a700-4ecb28a2c38d.png)
