### PR TITLE
Fix hover over the `MenuItems` in the `NavigationViewItem`

### DIFF
--- a/src/Wpf.Ui/Styles/Controls/NavigationView.xaml
+++ b/src/Wpf.Ui/Styles/Controls/NavigationView.xaml
@@ -363,9 +363,10 @@
                                         Height="40"
                                         Margin="0"
                                         Padding="0"
+                                        HorizontalAlignment="Stretch"
                                         BorderThickness="1"
                                         CornerRadius="4">
-                                        <Grid Margin="0">
+                                        <Grid Margin="0" HorizontalAlignment="Stretch">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="40" />
                                                 <ColumnDefinition Width="*" MinWidth="180" />
@@ -388,7 +389,7 @@
                                             <ContentPresenter
                                                 x:Name="ElementContentPresenter"
                                                 Grid.Column="1"
-                                                HorizontalAlignment="Left"
+                                                HorizontalAlignment="Stretch"
                                                 VerticalAlignment="Center"
                                                 Content="{TemplateBinding Content}"
                                                 TextElement.FontSize="14"


### PR DESCRIPTION
## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
- If you hover the cursor over the `NavigationViewItem'` `MenuItems` you will not be able to click on it.
![image](https://user-images.githubusercontent.com/42055372/216224344-eb06f487-9546-4fce-bb3a-02e1bbe49fe8.png)


## What is the new behavior?
![image](https://user-images.githubusercontent.com/42055372/216223907-61e7325b-a357-443d-b4a6-622ec190c992.png)

