### PR TITLE
`IconElement` implementation

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Pages/DashboardPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/DashboardPage.xaml
@@ -214,6 +214,8 @@
                 </ContentControl.Content>
             </ContentControl>
 
+            <iconElements:ImageIcon Width="40" Source="pack://application:,,,/Assets/WinUiGallery/MenuBar.png" />
+
             <TextBlock
                 FontSize="18"
                 FontWeight="DemiBold"

--- a/src/Wpf.Ui.Gallery/Views/Pages/DashboardPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/DashboardPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:iconElements="clr-namespace:Wpf.Ui.Controls.IconElements;assembly=Wpf.Ui"
     xmlns:local="clr-namespace:Wpf.Ui.Gallery.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
@@ -206,6 +207,13 @@
         </Grid>
 
         <StackPanel Grid.Row="2" Margin="0,24,0,0">
+
+            <ContentControl Foreground="Green">
+                <ContentControl.Content>
+                    <iconElements:SymbolIcon Symbol="AccessTime24" />
+                </ContentControl.Content>
+            </ContentControl>
+
             <TextBlock
                 FontSize="18"
                 FontWeight="DemiBold"

--- a/src/Wpf.Ui/Controls/IconElements/FontIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/FontIcon.cs
@@ -8,6 +8,8 @@
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
 using System.Windows.Media;
 
 namespace Wpf.Ui.Controls.IconElements;
@@ -131,58 +133,58 @@ public class FontIcon : IconElement
         set => SetValue(GlyphProperty, value);
     }
 
-    private TextBlock? _textBlock;
+    protected TextBlock? TextBlock;
 
     private static void OnFontFamilyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var self = (FontIcon)d;
-        if (self._textBlock is null)
+        if (self.TextBlock is null)
             return;
 
-        self._textBlock.FontFamily = (FontFamily)e.NewValue;
+        self.TextBlock.FontFamily = (FontFamily)e.NewValue;
     }
 
     private static void OnFontSizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var self = (FontIcon)d;
-        if (self._textBlock is null)
+        if (self.TextBlock is null)
             return;
 
-        self._textBlock.FontSize = (double)e.NewValue;
+        self.TextBlock.FontSize = (double)e.NewValue;
     }
 
     private static void OnFontStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var self = (FontIcon)d;
-        if (self._textBlock is null)
+        if (self.TextBlock is null)
             return;
 
-        self._textBlock.FontStyle = (FontStyle)e.NewValue;
+        self.TextBlock.FontStyle = (FontStyle)e.NewValue;
     }
 
     private static void OnFontWeightChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var self = (FontIcon)d;
-        if (self._textBlock is null)
+        if (self.TextBlock is null)
             return;
 
-        self._textBlock.FontWeight = (FontWeight)e.NewValue;
+        self.TextBlock.FontWeight = (FontWeight)e.NewValue;
     }
 
     private static void OnGlyphChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var self = (FontIcon)d;
-        if (self._textBlock is null)
+        if (self.TextBlock is null)
             return;
 
-        self._textBlock.Text = (string)e.NewValue;
+        self.TextBlock.Text = (string)e.NewValue;
     }
 
-    protected override void InitializeChildren()
+    protected override UIElement InitializeChildren()
     {
         SetResourceReference(FontSizeProperty, "DefaultIconFontSize");
 
-        _textBlock = new TextBlock
+        TextBlock = new TextBlock
         {
             Style = null,
             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -195,34 +197,26 @@ public class FontIcon : IconElement
             Text = Glyph
         };
 
-        if (ShouldInheritForegroundFromVisualParent)
-        {
-            _textBlock.Foreground = VisualParentForeground;
-        }
-
-        Children.Add(_textBlock);
+        return TextBlock;
     }
 
     protected override void OnShouldInheritForegroundFromVisualParentChanged()
     {
-        if (_textBlock is null)
+        if (TextBlock is null)
             return;
 
         if (ShouldInheritForegroundFromVisualParent)
         {
-            _textBlock.Foreground = VisualParentForeground;
+            TextBlock.SetBinding(TextBlock.ForegroundProperty,
+                new Binding
+                {
+                    Path = new PropertyPath(TextElement.ForegroundProperty),
+                    Source = VisualParent,
+                });
         }
         else
         {
-            _textBlock.ClearValue(TextBlock.ForegroundProperty);
-        }
-    }
-
-    protected override void OnVisualParentForegroundPropertyChanged(DependencyPropertyChangedEventArgs args)
-    {
-        if (ShouldInheritForegroundFromVisualParent && _textBlock is not null)
-        {
-            _textBlock.Foreground = (Brush)args.NewValue;
+            TextBlock.ClearValue(TextBlock.ForegroundProperty);
         }
     }
 }

--- a/src/Wpf.Ui/Controls/IconElements/FontIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/FontIcon.cs
@@ -1,0 +1,228 @@
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Based on FontIcon created by Yimeng Wu licensed under MIT license.
+// https://github.com/Kinnara/ModernWpf/blob/master/ModernWpf/IconElement/FontIcon.cs
+// Copyright (C) Ivan Dmitryiyev, Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace Wpf.Ui.Controls.IconElements;
+
+/// <summary>
+/// Represents an icon that uses a glyph from the specified font.
+/// </summary>
+public class FontIcon : IconElement
+{
+    /// <summary>
+    /// Property for <see cref="FontFamily"/>.
+    /// </summary>
+    public static readonly DependencyProperty FontFamilyProperty =
+        DependencyProperty.Register(
+            nameof(FontFamily),
+            typeof(FontFamily),
+            typeof(FontIcon),
+            new FrameworkPropertyMetadata(
+                SystemFonts.MessageFontFamily,
+                OnFontFamilyChanged));
+
+    /// <summary>
+    /// Property for <see cref="FontSize"/>.
+    /// </summary>
+    public static readonly DependencyProperty FontSizeProperty =
+        DependencyProperty.Register(
+            nameof(FontSize),
+            typeof(double),
+            typeof(FontIcon),
+            new FrameworkPropertyMetadata(SystemFonts.MessageFontSize, OnFontSizeChanged));
+
+    /// <summary>
+    /// Property for <see cref="FontStyle"/>.
+    /// </summary>
+    public static readonly DependencyProperty FontStyleProperty =
+        DependencyProperty.Register(
+            nameof(FontStyle),
+            typeof(FontStyle),
+            typeof(FontIcon),
+            new FrameworkPropertyMetadata(FontStyles.Normal, OnFontStyleChanged));
+
+    /// <summary>
+    /// Property for <see cref="FontWeight"/>.
+    /// </summary>
+    public static readonly DependencyProperty FontWeightProperty =
+        DependencyProperty.Register(
+            nameof(FontWeight),
+            typeof(FontWeight),
+            typeof(FontIcon),
+            new FrameworkPropertyMetadata(FontWeights.Normal, OnFontWeightChanged));
+
+    /// <summary>
+    /// Property for <see cref="Glyph"/>.
+    /// </summary>
+    public static readonly DependencyProperty GlyphProperty =
+        DependencyProperty.Register(
+            nameof(Glyph),
+            typeof(string),
+            typeof(FontIcon),
+            new FrameworkPropertyMetadata(string.Empty, OnGlyphChanged));
+
+    /// <summary>
+    /// Gets or sets the font used to display the icon glyph.
+    /// </summary>
+    /// <returns>The font used to display the icon glyph.</returns>
+    [Bindable(true), Category("Appearance")]
+    [Localizability(LocalizationCategory.Font)]
+    public FontFamily FontFamily
+    {
+        get => (FontFamily)GetValue(FontFamilyProperty);
+        set => SetValue(FontFamilyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the size of the icon glyph.
+    /// </summary>
+    /// <returns>A non-negative value that specifies the font size, measured in pixels.</returns>
+    [TypeConverter(typeof(FontSizeConverter))]
+    [Bindable(true), Category("Appearance")]
+    [Localizability(LocalizationCategory.None)]
+    public double FontSize
+    {
+        get => (double)GetValue(FontSizeProperty);
+        set => SetValue(FontSizeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font style for the icon glyph.
+    /// </summary>
+    /// <returns>
+    /// A named constant of the enumeration that specifies the style in which the icon
+    /// glyph is rendered. The default is **Normal**.
+    /// </returns>
+    [Bindable(true), Category("Appearance")]
+    public FontStyle FontStyle
+    {
+        get => (FontStyle)GetValue(FontStyleProperty);
+        set => SetValue(FontStyleProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the thickness of the icon glyph.
+    /// </summary>
+    /// <returns>
+    /// A value that specifies the thickness of the icon glyph. The default is **Normal**.
+    /// </returns>
+    [Bindable(true), Category("Appearance")]
+    public FontWeight FontWeight
+    {
+        get => (FontWeight)GetValue(FontWeightProperty);
+        set => SetValue(FontWeightProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the character code that identifies the icon glyph.
+    /// </summary>
+    /// <returns>The hexadecimal character code for the icon glyph.</returns>
+    public string Glyph
+    {
+        get => (string)GetValue(GlyphProperty);
+        set => SetValue(GlyphProperty, value);
+    }
+
+    private TextBlock? _textBlock;
+
+    private static void OnFontFamilyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (FontIcon)d;
+        if (self._textBlock is null)
+            return;
+
+        self._textBlock.FontFamily = (FontFamily)e.NewValue;
+    }
+
+    private static void OnFontSizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (FontIcon)d;
+        if (self._textBlock is null)
+            return;
+
+        self._textBlock.FontSize = (double)e.NewValue;
+    }
+
+    private static void OnFontStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (FontIcon)d;
+        if (self._textBlock is null)
+            return;
+
+        self._textBlock.FontStyle = (FontStyle)e.NewValue;
+    }
+
+    private static void OnFontWeightChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (FontIcon)d;
+        if (self._textBlock is null)
+            return;
+
+        self._textBlock.FontWeight = (FontWeight)e.NewValue;
+    }
+
+    private static void OnGlyphChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (FontIcon)d;
+        if (self._textBlock is null)
+            return;
+
+        self._textBlock.Text = (string)e.NewValue;
+    }
+
+    protected override void InitializeChildren()
+    {
+        SetResourceReference(FontSizeProperty, "DefaultIconFontSize");
+
+        _textBlock = new TextBlock
+        {
+            Style = null,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextAlignment = TextAlignment.Center,
+            FontFamily = FontFamily,
+            FontSize = FontSize,
+            FontStyle = FontStyle,
+            FontWeight = FontWeight,
+            Text = Glyph
+        };
+
+        if (ShouldInheritForegroundFromVisualParent)
+        {
+            _textBlock.Foreground = VisualParentForeground;
+        }
+
+        Children.Add(_textBlock);
+    }
+
+    protected override void OnShouldInheritForegroundFromVisualParentChanged()
+    {
+        if (_textBlock is null)
+            return;
+
+        if (ShouldInheritForegroundFromVisualParent)
+        {
+            _textBlock.Foreground = VisualParentForeground;
+        }
+        else
+        {
+            _textBlock.ClearValue(TextBlock.ForegroundProperty);
+        }
+    }
+
+    protected override void OnVisualParentForegroundPropertyChanged(DependencyPropertyChangedEventArgs args)
+    {
+        if (ShouldInheritForegroundFromVisualParent && _textBlock is not null)
+        {
+            _textBlock.Foreground = (Brush)args.NewValue;
+        }
+    }
+}

--- a/src/Wpf.Ui/Controls/IconElements/FontIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/FontIcon.cs
@@ -1,8 +1,6 @@
 ﻿// This Source Code Form is subject to the terms of the MIT License.
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
-// Based on FontIcon created by Yimeng Wu licensed under MIT license.
-// https://github.com/Kinnara/ModernWpf/blob/master/ModernWpf/IconElement/FontIcon.cs
-// Copyright (C) Ivan Dmitryiyev, Leszek Pomianowski and WPF UI Contributors.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
 using System.ComponentModel;
@@ -19,6 +17,8 @@ namespace Wpf.Ui.Controls.IconElements;
 /// </summary>
 public class FontIcon : IconElement
 {
+    #region Static properties
+
     /// <summary>
     /// Property for <see cref="FontFamily"/>.
     /// </summary>
@@ -71,10 +71,11 @@ public class FontIcon : IconElement
             typeof(FontIcon),
             new FrameworkPropertyMetadata(string.Empty, OnGlyphChanged));
 
-    /// <summary>
-    /// Gets or sets the font used to display the icon glyph.
-    /// </summary>
-    /// <returns>The font used to display the icon glyph.</returns>
+    #endregion
+
+    #region Properties
+
+    /// <inheritdoc cref="Control.FontFamily"/>
     [Bindable(true), Category("Appearance")]
     [Localizability(LocalizationCategory.Font)]
     public FontFamily FontFamily
@@ -83,10 +84,7 @@ public class FontIcon : IconElement
         set => SetValue(FontFamilyProperty, value);
     }
 
-    /// <summary>
-    /// Gets or sets the size of the icon glyph.
-    /// </summary>
-    /// <returns>A non-negative value that specifies the font size, measured in pixels.</returns>
+    /// <inheritdoc cref="Control.FontSize"/>
     [TypeConverter(typeof(FontSizeConverter))]
     [Bindable(true), Category("Appearance")]
     [Localizability(LocalizationCategory.None)]
@@ -96,13 +94,7 @@ public class FontIcon : IconElement
         set => SetValue(FontSizeProperty, value);
     }
 
-    /// <summary>
-    /// Gets or sets the font style for the icon glyph.
-    /// </summary>
-    /// <returns>
-    /// A named constant of the enumeration that specifies the style in which the icon
-    /// glyph is rendered. The default is **Normal**.
-    /// </returns>
+    /// <inheritdoc cref="Control.FontStyle"/>
     [Bindable(true), Category("Appearance")]
     public FontStyle FontStyle
     {
@@ -110,12 +102,7 @@ public class FontIcon : IconElement
         set => SetValue(FontStyleProperty, value);
     }
 
-    /// <summary>
-    /// Gets or sets the thickness of the icon glyph.
-    /// </summary>
-    /// <returns>
-    /// A value that specifies the thickness of the icon glyph. The default is **Normal**.
-    /// </returns>
+    /// <inheritdoc cref="Control.FontWeight"/>
     [Bindable(true), Category("Appearance")]
     public FontWeight FontWeight
     {
@@ -133,7 +120,51 @@ public class FontIcon : IconElement
         set => SetValue(GlyphProperty, value);
     }
 
+    #endregion
+
     protected TextBlock? TextBlock;
+
+    protected override UIElement InitializeChildren()
+    {
+        SetResourceReference(FontSizeProperty, "DefaultIconFontSize");
+
+        TextBlock = new TextBlock
+        {
+            Style = null,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextAlignment = TextAlignment.Center,
+            FontFamily = FontFamily,
+            FontSize = FontSize,
+            FontStyle = FontStyle,
+            FontWeight = FontWeight,
+            Text = Glyph
+        };
+
+        return TextBlock;
+    }
+
+    protected override void OnShouldInheritForegroundFromVisualParentChanged()
+    {
+        if (TextBlock is null)
+            return;
+
+        if (ShouldInheritForegroundFromVisualParent)
+        {
+            TextBlock.SetBinding(TextBlock.ForegroundProperty,
+                new Binding
+                {
+                    Path = new PropertyPath(TextElement.ForegroundProperty),
+                    Source = VisualParent,
+                });
+        }
+        else
+        {
+            TextBlock.ClearValue(TextBlock.ForegroundProperty);
+        }
+    }
+
+    #region Static methods
 
     private static void OnFontFamilyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -180,43 +211,5 @@ public class FontIcon : IconElement
         self.TextBlock.Text = (string)e.NewValue;
     }
 
-    protected override UIElement InitializeChildren()
-    {
-        SetResourceReference(FontSizeProperty, "DefaultIconFontSize");
-
-        TextBlock = new TextBlock
-        {
-            Style = null,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Center,
-            TextAlignment = TextAlignment.Center,
-            FontFamily = FontFamily,
-            FontSize = FontSize,
-            FontStyle = FontStyle,
-            FontWeight = FontWeight,
-            Text = Glyph
-        };
-
-        return TextBlock;
-    }
-
-    protected override void OnShouldInheritForegroundFromVisualParentChanged()
-    {
-        if (TextBlock is null)
-            return;
-
-        if (ShouldInheritForegroundFromVisualParent)
-        {
-            TextBlock.SetBinding(TextBlock.ForegroundProperty,
-                new Binding
-                {
-                    Path = new PropertyPath(TextElement.ForegroundProperty),
-                    Source = VisualParent,
-                });
-        }
-        else
-        {
-            TextBlock.ClearValue(TextBlock.ForegroundProperty);
-        }
-    }
+    #endregion
 }

--- a/src/Wpf.Ui/Controls/IconElements/IconElement.cs
+++ b/src/Wpf.Ui/Controls/IconElements/IconElement.cs
@@ -1,8 +1,6 @@
 ﻿// This Source Code Form is subject to the terms of the MIT License.
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
-// Based on IconElement created by Yimeng Wu licensed under MIT license.
-// https://github.com/Kinnara/ModernWpf/blob/master/ModernWpf/IconElement/IconElement.cs
-// Copyright (C) Ivan Dmitryiyev, Leszek Pomianowski and WPF UI Contributors.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
 using System;
@@ -29,7 +27,7 @@ public abstract class IconElement : FrameworkElement
                 FrameworkPropertyMetadataOptions.Inherits,
                 static (d, args) => ((IconElement)d).OnForegroundPropertyChanged(args)));
 
-    /// <inheritdoc cref="Control.Foreground"/>/>
+    /// <inheritdoc cref="Control.Foreground"/>
     [Bindable(true), Category("Appearance")]
     public Brush Foreground
     {
@@ -80,6 +78,13 @@ public abstract class IconElement : FrameworkElement
             Parent != VisualParent;
     }
 
+    protected override void OnVisualParentChanged(DependencyObject oldParent)
+    {
+        base.OnVisualParentChanged(oldParent);
+
+        UpdateShouldInheritForegroundFromVisualParent();
+    }
+
     #region Layout methods
 
     private void EnsureLayoutRoot()
@@ -120,13 +125,6 @@ public abstract class IconElement : FrameworkElement
 
         _layoutRoot!.Arrange(new Rect(new Point(), finalSize));
         return finalSize;
-    }
-
-    protected override void OnVisualParentChanged(DependencyObject oldParent)
-    {
-        base.OnVisualParentChanged(oldParent);
-
-        UpdateShouldInheritForegroundFromVisualParent();
     }
 
     #endregion

--- a/src/Wpf.Ui/Controls/IconElements/IconElement.cs
+++ b/src/Wpf.Ui/Controls/IconElements/IconElement.cs
@@ -1,0 +1,192 @@
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Based on IconElement created by Yimeng Wu licensed under MIT license.
+// https://github.com/Kinnara/ModernWpf/blob/master/ModernWpf/IconElement/IconElement.cs
+// Copyright (C) Ivan Dmitryiyev, Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace Wpf.Ui.Controls.IconElements;
+
+/// <summary>
+/// Represents the base class for an icon UI element.
+/// </summary>
+public abstract class IconElement : FrameworkElement
+{
+    /// <summary>
+    /// Property for <see cref="Foreground"/>.
+    /// </summary>
+    public static readonly DependencyProperty ForegroundProperty =
+        TextElement.ForegroundProperty.AddOwner(
+            typeof(IconElement),
+            new FrameworkPropertyMetadata(SystemColors.ControlTextBrush,
+                FrameworkPropertyMetadataOptions.Inherits,
+                static (d, args) => ((IconElement)d).OnForegroundPropertyChanged(args)));
+
+    private static readonly DependencyProperty VisualParentForegroundProperty =
+        DependencyProperty.Register(
+            nameof(VisualParentForeground),
+            typeof(Brush),
+            typeof(IconElement),
+            new PropertyMetadata(null,
+                static (d, args) => ((IconElement)d).OnVisualParentForegroundPropertyChanged(args)));
+
+    /// <summary>
+    /// Gets or sets a brush that describes the foreground color.
+    /// </summary>
+    /// <returns>
+    /// The brush that paints the foreground of the control.
+    /// </returns>
+    [Bindable(true), Category("Appearance")]
+    public Brush Foreground
+    {
+        get => (Brush)GetValue(ForegroundProperty);
+        set => SetValue(ForegroundProperty, value);
+    }
+
+    protected Brush VisualParentForeground
+    {
+        get => (Brush)GetValue(VisualParentForegroundProperty);
+        private set => SetValue(VisualParentForegroundProperty, value);
+    }
+
+    protected bool ShouldInheritForegroundFromVisualParent
+    {
+        get => _shouldInheritForegroundFromVisualParent;
+        private set
+        {
+            if (_shouldInheritForegroundFromVisualParent == value)
+                return;
+
+            _shouldInheritForegroundFromVisualParent = value;
+
+            if (_shouldInheritForegroundFromVisualParent)
+            {
+                SetBinding(VisualParentForegroundProperty,
+                    new Binding
+                    {
+                        Path = new PropertyPath(TextElement.ForegroundProperty),
+                        Source = VisualParent
+                    });
+            }
+            else
+            {
+                ClearValue(VisualParentForegroundProperty);
+            }
+
+            OnShouldInheritForegroundFromVisualParentChanged();
+        }
+    }
+
+    protected UIElementCollection Children
+    {
+        get
+        {
+            EnsureLayoutRoot();
+            return _layoutRoot!.Children;
+        }
+    }
+
+    protected override int VisualChildrenCount => 1;
+
+    private bool _shouldInheritForegroundFromVisualParent;
+    private Grid? _layoutRoot;
+    private bool _isForegroundDefaultOrInherited = true;
+
+    #region Protected methods
+
+    protected virtual void OnVisualParentForegroundPropertyChanged(DependencyPropertyChangedEventArgs e) { }
+
+    protected virtual void OnShouldInheritForegroundFromVisualParentChanged() { }
+
+    protected abstract void InitializeChildren();
+
+    #endregion
+
+    private void OnForegroundPropertyChanged(DependencyPropertyChangedEventArgs e)
+    {
+        if (e.NewValue is not Brush newForegroundBrush)
+            return;
+
+        if (newForegroundBrush == FindResource("TextFillColorPrimaryBrush"))
+            return;
+
+        var baseValueSource = DependencyPropertyHelper.GetValueSource(this, e.Property).BaseValueSource;
+        _isForegroundDefaultOrInherited = baseValueSource <= BaseValueSource.Inherited;
+        UpdateShouldInheritForegroundFromVisualParent();
+    }
+
+    private void UpdateShouldInheritForegroundFromVisualParent()
+    {
+        ShouldInheritForegroundFromVisualParent =
+            _isForegroundDefaultOrInherited &&
+            Parent != null &&
+            VisualParent != null &&
+            Parent != VisualParent;
+    }
+
+    protected override void OnInitialized(EventArgs e)
+    {
+        base.OnInitialized(e);
+
+        SetResourceReference(ForegroundProperty, "TextFillColorPrimaryBrush");
+    }
+
+    #region Layout methods
+
+    private void EnsureLayoutRoot()
+    {
+        if (_layoutRoot != null)
+            return;
+
+        _layoutRoot = new Grid
+        {
+            Background = Brushes.Transparent,
+            SnapsToDevicePixels = true,
+        };
+
+        InitializeChildren();
+        AddVisualChild(_layoutRoot);
+    }
+
+    protected override Visual GetVisualChild(int index)
+    {
+        if (index != 0)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        EnsureLayoutRoot();
+        return _layoutRoot!;
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        EnsureLayoutRoot();
+
+        _layoutRoot!.Measure(availableSize);
+        return _layoutRoot.DesiredSize;
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        EnsureLayoutRoot();
+
+        _layoutRoot!.Arrange(new Rect(new Point(), finalSize));
+        return finalSize;
+    }
+
+    protected override void OnVisualParentChanged(DependencyObject oldParent)
+    {
+        base.OnVisualParentChanged(oldParent);
+
+        UpdateShouldInheritForegroundFromVisualParent();
+    }
+
+    #endregion
+}

--- a/src/Wpf.Ui/Controls/IconElements/ImageIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/ImageIcon.cs
@@ -1,6 +1,5 @@
 ﻿using System.Windows.Media;
 using System.Windows;
-using System.Windows.Controls;
 
 namespace Wpf.Ui.Controls.IconElements;
 
@@ -25,25 +24,30 @@ public class ImageIcon : IconElement
         set => SetValue(SourceProperty, value);
     }
 
-    private System.Windows.Controls.Image? _image;
+    protected System.Windows.Controls.Image? Image;
 
     private static void OnSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var self = (ImageIcon)d;
-        if (self._image is null)
+        if (self.Image is null)
             return;
 
-        self._image.Source = (ImageSource)e.NewValue;
+        self.Image.Source = (ImageSource)e.NewValue;
     }
 
-    protected override void InitializeChildren()
+    protected override void OnShouldInheritForegroundFromVisualParentChanged()
     {
-        _image = new System.Windows.Controls.Image()
+        
+    }
+
+    protected override UIElement InitializeChildren()
+    {
+        Image = new System.Windows.Controls.Image()
         {
             Source = Source,
             Stretch = Stretch.UniformToFill
         };
 
-        Children.Add(_image);
+        return Image;
     }
 }

--- a/src/Wpf.Ui/Controls/IconElements/ImageIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/ImageIcon.cs
@@ -1,4 +1,9 @@
-﻿using System.Windows.Media;
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.Windows.Media;
 using System.Windows;
 
 namespace Wpf.Ui.Controls.IconElements;
@@ -6,8 +11,7 @@ namespace Wpf.Ui.Controls.IconElements;
 public class ImageIcon : IconElement
 {
     /// <summary>
-    /// Gets/Sets the Source on this Image.
-    /// The Source property is the ImageSource that holds the actual image drawn.
+    /// Property for <see cref="Source"/>.
     /// </summary>
     public static readonly DependencyProperty SourceProperty =
         DependencyProperty.Register(nameof(Source), typeof(ImageSource), typeof(ImageIcon),
@@ -15,8 +19,7 @@ public class ImageIcon : IconElement
                 FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, OnSourcePropertyChanged));
 
     /// <summary>
-    /// Gets/Sets the Source on this Image.
-    /// The Source property is the ImageSource that holds the actual image drawn.
+    /// Gets or sets the Source on this Image.
     /// </summary>
     public ImageSource? Source
     {
@@ -25,20 +28,6 @@ public class ImageIcon : IconElement
     }
 
     protected System.Windows.Controls.Image? Image;
-
-    private static void OnSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        var self = (ImageIcon)d;
-        if (self.Image is null)
-            return;
-
-        self.Image.Source = (ImageSource)e.NewValue;
-    }
-
-    protected override void OnShouldInheritForegroundFromVisualParentChanged()
-    {
-        
-    }
 
     protected override UIElement InitializeChildren()
     {
@@ -49,5 +38,19 @@ public class ImageIcon : IconElement
         };
 
         return Image;
+    }
+
+    protected override void OnShouldInheritForegroundFromVisualParentChanged()
+    {
+        
+    }
+
+    private static void OnSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (ImageIcon)d;
+        if (self.Image is null)
+            return;
+
+        self.Image.Source = (ImageSource)e.NewValue;
     }
 }

--- a/src/Wpf.Ui/Controls/IconElements/ImageIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/ImageIcon.cs
@@ -1,0 +1,49 @@
+﻿using System.Windows.Media;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Wpf.Ui.Controls.IconElements;
+
+public class ImageIcon : IconElement
+{
+    /// <summary>
+    /// Gets/Sets the Source on this Image.
+    /// The Source property is the ImageSource that holds the actual image drawn.
+    /// </summary>
+    public static readonly DependencyProperty SourceProperty =
+        DependencyProperty.Register(nameof(Source), typeof(ImageSource), typeof(ImageIcon),
+            new FrameworkPropertyMetadata(null,
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, OnSourcePropertyChanged));
+
+    /// <summary>
+    /// Gets/Sets the Source on this Image.
+    /// The Source property is the ImageSource that holds the actual image drawn.
+    /// </summary>
+    public ImageSource? Source
+    {
+        get => (ImageSource)GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
+    }
+
+    private System.Windows.Controls.Image? _image;
+
+    private static void OnSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (ImageIcon)d;
+        if (self._image is null)
+            return;
+
+        self._image.Source = (ImageSource)e.NewValue;
+    }
+
+    protected override void InitializeChildren()
+    {
+        _image = new System.Windows.Controls.Image()
+        {
+            Source = Source,
+            Stretch = Stretch.UniformToFill
+        };
+
+        Children.Add(_image);
+    }
+}

--- a/src/Wpf.Ui/Controls/IconElements/SymbolIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/SymbolIcon.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Windows;
-using System.Windows.Controls;
 using Wpf.Ui.Common;
 using Wpf.Ui.Extensions;
 
@@ -29,6 +28,9 @@ public sealed class SymbolIcon : FontIcon
     public static readonly DependencyProperty FilledProperty = DependencyProperty.Register(nameof(Filled),
         typeof(bool), typeof(SymbolIcon), new PropertyMetadata(false, OnFilledChanged));
 
+    /// <summary>
+    /// Gets or sets displayed <see cref="SymbolRegular"/>.
+    /// </summary>
     public SymbolRegular Symbol
     {
         get => (SymbolRegular)GetValue(SymbolProperty);
@@ -36,7 +38,7 @@ public sealed class SymbolIcon : FontIcon
     }
 
     /// <summary>
-    /// Defines whether or not we should use the <see cref="Common.SymbolFilled"/>.
+    /// Defines whether or not we should use the <see cref="SymbolFilled"/>.
     /// </summary>
     public bool Filled
     {

--- a/src/Wpf.Ui/Controls/IconElements/SymbolIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/SymbolIcon.cs
@@ -1,0 +1,62 @@
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.Windows;
+using Wpf.Ui.Common;
+using Wpf.Ui.Extensions;
+
+namespace Wpf.Ui.Controls.IconElements;
+
+/// <summary>
+/// Represents a text element containing an icon glyph.
+/// </summary>
+public sealed class SymbolIcon : FontIcon
+{
+    /// <summary>
+    /// Property for <see cref="Symbol"/>.
+    /// </summary>
+    public static readonly DependencyProperty SymbolProperty = DependencyProperty.Register(nameof(Symbol),
+        typeof(SymbolRegular), typeof(SymbolIcon),
+        new PropertyMetadata(SymbolRegular.Empty, OnGlyphChanged));
+
+    /// <summary>
+    /// Property for <see cref="Filled"/>.
+    /// </summary>
+    public static readonly DependencyProperty FilledProperty = DependencyProperty.Register(nameof(Filled),
+        typeof(bool), typeof(SymbolIcon), new PropertyMetadata(false, OnGlyphChanged));
+
+    public SymbolRegular Symbol
+    {
+        get => (SymbolRegular)GetValue(SymbolProperty);
+        set => SetValue(SymbolProperty, value);
+    }
+
+    /// <summary>
+    /// Defines whether or not we should use the <see cref="Common.SymbolFilled"/>.
+    /// </summary>
+    public bool Filled
+    {
+        get => (bool)GetValue(FilledProperty);
+        set => SetValue(FilledProperty, value);
+    }
+
+    protected override void InitializeChildren()
+    {
+        SetResourceReference(FontFamilyProperty, "FluentSystemIcons");
+
+        base.InitializeChildren();
+    }
+
+    private static void OnGlyphChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not SymbolIcon control)
+            return;
+
+        if (control.Filled)
+            control.Glyph = control.Symbol.Swap().GetString();
+        else
+            control.Glyph = control.Symbol.GetString();
+    }
+}

--- a/src/Wpf.Ui/Controls/IconElements/SymbolIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElements/SymbolIcon.cs
@@ -3,7 +3,9 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
+using System;
 using System.Windows;
+using System.Windows.Controls;
 using Wpf.Ui.Common;
 using Wpf.Ui.Extensions;
 
@@ -19,13 +21,13 @@ public sealed class SymbolIcon : FontIcon
     /// </summary>
     public static readonly DependencyProperty SymbolProperty = DependencyProperty.Register(nameof(Symbol),
         typeof(SymbolRegular), typeof(SymbolIcon),
-        new PropertyMetadata(SymbolRegular.Empty, OnGlyphChanged));
+        new PropertyMetadata(SymbolRegular.Empty, static (o, _) => ((SymbolIcon)o).OnGlyphChanged()));
 
     /// <summary>
     /// Property for <see cref="Filled"/>.
     /// </summary>
     public static readonly DependencyProperty FilledProperty = DependencyProperty.Register(nameof(Filled),
-        typeof(bool), typeof(SymbolIcon), new PropertyMetadata(false, OnGlyphChanged));
+        typeof(bool), typeof(SymbolIcon), new PropertyMetadata(false, OnFilledChanged));
 
     public SymbolRegular Symbol
     {
@@ -42,21 +44,30 @@ public sealed class SymbolIcon : FontIcon
         set => SetValue(FilledProperty, value);
     }
 
-    protected override void InitializeChildren()
+    protected override void OnInitialized(EventArgs e)
     {
-        SetResourceReference(FontFamilyProperty, "FluentSystemIcons");
+        base.OnInitialized(e);
 
-        base.InitializeChildren();
+        OnFilledChanged();
     }
 
-    private static void OnGlyphChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    private void OnGlyphChanged()
     {
-        if (d is not SymbolIcon control)
-            return;
-
-        if (control.Filled)
-            control.Glyph = control.Symbol.Swap().GetString();
+        if (Filled)
+            Glyph = Symbol.Swap().GetString();
         else
-            control.Glyph = control.Symbol.GetString();
+            Glyph = Symbol.GetString();
+    }
+
+    private void OnFilledChanged()
+    {
+        SetResourceReference(FontFamilyProperty, Filled ? "FluentSystemIconsFilled" : "FluentSystemIcons");
+    }
+
+    private static void OnFilledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var self = (SymbolIcon)d;
+        self.OnFilledChanged();
+        self.OnGlyphChanged();
     }
 }


### PR DESCRIPTION
Implements a `IconElement` control almost like in winui 3.
Replaces `SymbolIcon` with `IconElement`.

## Pull request type
- [x] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Other information
