### PR TITLE
Fix Controls bug

### DIFF
--- a/src/Wpf.Ui/Controls/TextBox.cs
+++ b/src/Wpf.Ui/Controls/TextBox.cs
@@ -36,6 +36,22 @@ public class TextBox : System.Windows.Controls.TextBox
         new PropertyMetadata(ElementPlacement.Left));
 
     /// <summary>
+    /// Property for <see cref="TextBoxClearButtonIconSize"/>.
+    /// </summary>
+    public static readonly DependencyProperty TextBoxClearButtonIconSizeProperty = DependencyProperty.Register(
+        nameof(TextBoxClearButtonIconSize),
+        typeof(int), typeof(TextBox),
+        new FrameworkPropertyMetadata());
+
+    /// <summary>
+    /// Property for <see cref="TextBoxClearButtonHeight"/>.
+    /// </summary>
+    public static readonly DependencyProperty TextBoxClearButtonHeightProperty = DependencyProperty.Register(
+        nameof(TextBoxClearButtonHeight),
+        typeof(int), typeof(TextBox),
+        new FrameworkPropertyMetadata());
+
+    /// <summary>
     /// Property for <see cref="PlaceholderText"/>.
     /// </summary>
     public static readonly DependencyProperty PlaceholderTextProperty = DependencyProperty.Register(nameof(PlaceholderText),
@@ -88,7 +104,6 @@ public class TextBox : System.Windows.Controls.TextBox
         get => (ElementPlacement)GetValue(IconPlacementProperty);
         set => SetValue(IconPlacementProperty, value);
     }
-
     /// <summary>
     /// Gets or sets numbers pattern.
     /// </summary>
@@ -115,7 +130,22 @@ public class TextBox : System.Windows.Controls.TextBox
         get => (bool)GetValue(ClearButtonEnabledProperty);
         set => SetValue(ClearButtonEnabledProperty, value);
     }
-
+    /// <summary>
+    /// Defines size of TextBoxClearButton should be.
+    /// </summary>
+    public int TextBoxClearButtonIconSize
+    {
+        get => (int)GetValue(TextBoxClearButtonIconSizeProperty);
+        set => SetValue(TextBoxClearButtonIconSizeProperty, value);
+    }
+    /// <summary>
+    /// Defines height of TextBoxClearButton should be.
+    /// </summary>
+    public int TextBoxClearButtonHeight
+    {
+        get => (int)GetValue(TextBoxClearButtonHeightProperty);
+        set => SetValue(TextBoxClearButtonHeightProperty, value);
+    }
     /// <summary>
     /// Gets or sets a value determining whether to show the clear button when <see cref="TextBox"/> is focused.
     /// </summary>

--- a/src/Wpf.Ui/Styles/Controls/Button.xaml
+++ b/src/Wpf.Ui/Styles/Controls/Button.xaml
@@ -205,6 +205,7 @@
                                     VerticalAlignment="Center"
                                     Content="{TemplateBinding Icon}"
                                     Focusable="False"
+                                    TextElement.FontSize="{Binding Path=FontSize,RelativeSource={RelativeSource TemplatedParent}}"
                                     TextElement.Foreground="{TemplateBinding Foreground}" />
 
                                 <ContentPresenter

--- a/src/Wpf.Ui/Styles/Controls/Expander.xaml
+++ b/src/Wpf.Ui/Styles/Controls/Expander.xaml
@@ -3,7 +3,7 @@
     If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
     All Rights Reserved.
-    
+
     Based on Microsoft XAML for Win UI
     Copyright (c) Microsoft Corporation. All Rights Reserved.
 -->
@@ -134,6 +134,7 @@
                                 HorizontalContentAlignment="Stretch"
                                 VerticalContentAlignment="Center"
                                 Content="{TemplateBinding Header}"
+                                FontSize="{TemplateBinding FontSize}"
                                 Foreground="{TemplateBinding Foreground}"
                                 IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                 IsEnabled="{TemplateBinding IsEnabled}"

--- a/src/Wpf.Ui/Styles/Controls/NavigationView.xaml
+++ b/src/Wpf.Ui/Styles/Controls/NavigationView.xaml
@@ -879,7 +879,7 @@
                             x:Name="ElementContentPresenter"
                             HorizontalAlignment="Center"
                             Content="{TemplateBinding Content}"
-                            TextElement.FontSize="10"
+                            TextElement.FontSize="{TemplateBinding FontSize}"
                             TextElement.Foreground="{TemplateBinding Foreground}" />
                     </Grid>
                 </Grid>

--- a/src/Wpf.Ui/Styles/Controls/TextBox.xaml
+++ b/src/Wpf.Ui/Styles/Controls/TextBox.xaml
@@ -21,8 +21,6 @@
     <Thickness x:Key="TextBoxRightIconMargin">0,8,10,0</Thickness>
     <Thickness x:Key="TextBoxClearButtonMargin">0,5,4,0</Thickness>
     <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness>
-    <system:Double x:Key="TextBoxClearButtonHeight">24</system:Double>
-    <system:Double x:Key="TextBoxClearButtonIconSize">14</system:Double>
 
     <!--  TODO: Rework TextBox ScrollViewer  -->
     <Style x:Key="DefaultTextBoxScrollViewerStyle" TargetType="{x:Type ScrollViewer}">
@@ -202,6 +200,8 @@
         <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="ClearButtonEnabled" Value="True" />
+        <Setter Property="TextBoxClearButtonIconSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+        <Setter Property="TextBoxClearButtonHeight" Value="24" />
         <Setter Property="IconPlacement" Value="Left" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -232,10 +232,10 @@
                                     x:Name="ControlIconLeft"
                                     Grid.Column="0"
                                     Margin="{StaticResource TextBoxLeftIconMargin}"
-                                    VerticalAlignment="Top"
+                                    VerticalAlignment="Center"
                                     Content="{TemplateBinding Icon}"
                                     Focusable="False"
-                                    TextElement.FontSize="16"
+                                    TextElement.FontSize="{TemplateBinding FontSize}"
                                     TextElement.Foreground="{TemplateBinding Foreground}"
                                     Visibility="Visible" />
 
@@ -266,12 +266,12 @@
                                 <controls:Button
                                     x:Name="ClearButton"
                                     Grid.Column="2"
-                                    Width="{StaticResource TextBoxClearButtonHeight}"
-                                    Height="{StaticResource TextBoxClearButtonHeight}"
+                                    Width="{Binding Path=TextBoxClearButtonHeight,RelativeSource={RelativeSource TemplatedParent}}"
+                                    Height="{Binding Path=TextBoxClearButtonHeight,RelativeSource={RelativeSource TemplatedParent}}"
                                     Margin="{StaticResource TextBoxClearButtonMargin}"
                                     Padding="{StaticResource TextBoxClearButtonPadding}"
                                     HorizontalAlignment="Center"
-                                    VerticalAlignment="Top"
+                                    VerticalAlignment="Center"
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Appearance="Secondary"
@@ -283,7 +283,7 @@
                                         <SolidColorBrush Color="{DynamicResource TextFillColorTertiary}" />
                                     </controls:Button.Foreground>
                                     <controls:Button.Icon>
-                                        <iconElements:SymbolIcon FontSize="{StaticResource TextBoxClearButtonIconSize}" Symbol="Dismiss24" />
+                                        <iconElements:SymbolIcon FontSize="{Binding Path=TextBoxClearButtonIconSize, RelativeSource={RelativeSource TemplatedParent}}" Symbol="Dismiss24" />
                                     </controls:Button.Icon>
                                 </controls:Button>
 
@@ -291,9 +291,9 @@
                                     x:Name="ControlIconRight"
                                     Grid.Column="3"
                                     Margin="{StaticResource TextBoxRightIconMargin}"
-                                    VerticalAlignment="Top"
+                                    VerticalAlignment="Center"
                                     Content="{TemplateBinding Icon}"
-                                    TextElement.FontSize="16"
+                                    TextElement.FontSize="{TemplateBinding FontSize}"
                                     TextElement.Foreground="{TemplateBinding Foreground}" />
                             </Grid>
                         </Border>

--- a/src/Wpf.Ui/Styles/Controls/TextBox.xaml
+++ b/src/Wpf.Ui/Styles/Controls/TextBox.xaml
@@ -283,7 +283,7 @@
                                         <SolidColorBrush Color="{DynamicResource TextFillColorTertiary}" />
                                     </controls:Button.Foreground>
                                     <controls:Button.Icon>
-                                        <iconElements:SymbolIcon FontSize="{Binding Path=TextBoxClearButtonIconSize, RelativeSource={RelativeSource TemplatedParent}}" Symbol="Dismiss24" />
+                                        <iconElements:SymbolIcon FontSize="{TemplateBinding TextBoxClearButtonIconSize}" Symbol="Dismiss24" />
                                     </controls:Button.Icon>
                                 </controls:Button>
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #635 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
1. Fix LeftFluentNavigationViewItemTemplate content fontsize binding
![image](https://github.com/lepoco/wpfui/assets/42534870/d3d78aa3-3196-41e9-bd1b-1481536f5436)
![image](https://github.com/lepoco/wpfui/assets/42534870/bbf061c2-631c-4a7b-ae81-8fb5dede4c5c)


2. Fix TextBox Icon size,Add two properties to define the icon size and width of the TextBoxClearButton
    Also make icon and the TextBoxClearButton at the center
 ![image](https://github.com/lepoco/wpfui/assets/42534870/09012d9b-6249-4379-a50b-50a7e52420c5)
 ![image](https://github.com/lepoco/wpfui/assets/42534870/7592320d-b258-4d37-8a27-ca8eb0215a34)
 ![image](https://github.com/lepoco/wpfui/assets/42534870/a76dbc75-0c1f-4653-8c0c-5711933997f7)
 It should be like this
 ![image](https://github.com/lepoco/wpfui/assets/42534870/1bddc3a8-ae56-4432-bb4d-3ac40c2cd1bb)
 but it is like this
  ![image](https://github.com/lepoco/wpfui/assets/42534870/a76dbc75-0c1f-4653-8c0c-5711933997f7)
 It only works when I hot reload the binding, I don't know how to fix this

3. Fix Expander Header fontsize
![image](https://github.com/lepoco/wpfui/assets/42534870/1bf0e2b5-8b21-4de7-b978-db7dc0124c63)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- There are some bugs that need help