### PR TITLE
update watcher let the auto update theme can be canceled

### DIFF
--- a/src/Wpf.Ui/Appearance/Theme.cs
+++ b/src/Wpf.Ui/Appearance/Theme.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Windows;
+
 using Wpf.Ui.Controls.Window;
 using Wpf.Ui.Interop;
 
@@ -49,7 +50,7 @@ public static class Theme
                 false
             );
 
-        if (themeType == ThemeType.Unknown || themeType == AppearanceData.ApplicationTheme)
+        if (themeType == ThemeType.Unknown)
             return;
 
         var appDictionaries = new ResourceDictionaryManager(AppearanceData.LibraryNamespace);

--- a/src/Wpf.Ui/Styles/Controls/ListViewItem.xaml
+++ b/src/Wpf.Ui/Styles/Controls/ListViewItem.xaml
@@ -4,9 +4,7 @@
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
     All Rights Reserved.
 -->
-
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
     <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
         <Setter Property="Foreground">
             <Setter.Value>
@@ -54,7 +52,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border" Property="Background">
                                 <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource ControlFillColorSecondary}" />
+                                    <SolidColorBrush Color="{DynamicResource SubtleFillColorSecondary}" />
                                 </Setter.Value>
                             </Setter>
                         </MultiTrigger>
@@ -62,7 +60,7 @@
                             <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
                             <Setter TargetName="Border" Property="Background">
                                 <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource ControlFillColorSecondary}" />
+                                    <SolidColorBrush Color="{DynamicResource SubtleFillColorSecondary}" />
                                 </Setter.Value>
                             </Setter>
                         </Trigger>
@@ -71,7 +69,5 @@
             </Setter.Value>
         </Setter>
     </Style>
-
     <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="{x:Type ListViewItem}" />
-
 </ResourceDictionary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Please check the type of change your PR introduces:

- [x] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- There is no method to cancel a watch in the watcher class.
- It is not possible to modify the background style independently without modifying the overall theme.
- The background color of the listviewitem is too light.

Issue Number: N/A

## What is the new behavior?

- Added the unwatch method for canceling the watch.
- Deleted the judgment of whether the themetype is equal.
- Changed the background color of the listviewitem.

## Other information

<div align="center">
<img src="https://github.com/lepoco/wpfui/assets/127822326/44c31f39-2473-4d2d-b088-5f478186d829"  width="45%" />
<img src="https://github.com/lepoco/wpfui/assets/127822326/e176d43f-ec1c-481f-b5ae-eff1f7573c1a"  width="45%" />
</div>

<div align="center">
<img src="https://github.com/lepoco/wpfui/assets/127822326/b188cf5c-eeb0-448b-81c9-c846a0af7ffd" 
 width="45%" />
<img src="https://github.com/lepoco/wpfui/assets/127822326/09a5f06f-0a93-40d9-82d9-614d14137dcd" 
 width="45%" />
</div>

