### PR TITLE
Fix PasswordBox reveal button

### DIFF
--- a/src/Wpf.Ui/Controls/PasswordBox.cs
+++ b/src/Wpf.Ui/Controls/PasswordBox.cs
@@ -191,13 +191,8 @@ public class PasswordBox : Wpf.Ui.Controls.TextBox
     /// <param name="parameter">Additional parameters.</param>
     protected override void OnTemplateButtonClick(string parameter)
     {
-        base.OnTemplateButtonClick(parameter);
-
 #if DEBUG
-        System.Diagnostics.Debug.WriteLine(
-            $"INFO: {typeof(PasswordBox)} button clicked with param: {parameter}",
-            "Wpf.Ui.PasswordBox"
-        );
+        System.Diagnostics.Debug.WriteLine($"INFO: {typeof(PasswordBox)} button clicked with param: {parameter}", "Wpf.Ui.PasswordBox");
 #endif
 
         switch (parameter)
@@ -206,7 +201,9 @@ public class PasswordBox : Wpf.Ui.Controls.TextBox
                 IsPasswordRevealed = !IsPasswordRevealed;
                 Focus();
                 CaretIndex = Text.Length;
-
+                break;
+            default:
+                base.OnTemplateButtonClick(parameter);
                 break;
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

![изображение](https://github.com/lepoco/wpfui/assets/20504884/4370cedd-6266-4d73-b0e8-c3fb20bcf1b2)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When you click reveal, it deletes all text from the input field instead of showing the password

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now the Clear button deletes the text, and the Reveal button shows the password