### PR TITLE
Replace MenuBorderColorDefaultBrush

### DIFF
--- a/src/Wpf.Ui/Styles/Controls/ContextMenu.xaml
+++ b/src/Wpf.Ui/Styles/Controls/ContextMenu.xaml
@@ -23,7 +23,7 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Background" Value="{DynamicResource SystemFillColorSolidNeutralBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource MenuBorderColorDefaultBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
         <Setter Property="MinWidth" Value="140" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Margin" Value="0" />

--- a/src/Wpf.Ui/Styles/Controls/MenuItem.xaml
+++ b/src/Wpf.Ui/Styles/Controls/MenuItem.xaml
@@ -93,7 +93,7 @@
                             x:Name="SubmenuBorder"
                             Margin="12,0,12,18"
                             Padding="0,3,0,3"
-                            BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
+                            BorderBrush="{DynamicResource ControlElevationBorderBrush}"
                             BorderThickness="1"
                             CornerRadius="8"
                             SnapsToDevicePixels="True">
@@ -365,7 +365,7 @@
                         x:Name="SubmenuBorder"
                         Margin="12,10,12,18"
                         Padding="0,3,0,3"
-                        BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
+                        BorderBrush="{DynamicResource ControlElevationBorderBrush}"
                         BorderThickness="1"
                         CornerRadius="8"
                         SnapsToDevicePixels="True">
@@ -523,7 +523,7 @@
                             x:Name="SubmenuBorder"
                             Margin="12,0,12,18"
                             Padding="0,3,0,3"
-                            BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
+                            BorderBrush="{DynamicResource ControlElevationBorderBrush}"
                             BorderThickness="1"
                             CornerRadius="8"
                             SnapsToDevicePixels="True">
@@ -808,7 +808,7 @@
                         x:Name="SubmenuBorder"
                         Margin="12,10,12,18"
                         Padding="0,3,0,3"
-                        BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
+                        BorderBrush="{DynamicResource ControlElevationBorderBrush}"
                         BorderThickness="1"
                         CornerRadius="8"
                         SnapsToDevicePixels="True">

--- a/src/Wpf.Ui/Styles/Controls/Navigation/NavigationViewTop.xaml
+++ b/src/Wpf.Ui/Styles/Controls/Navigation/NavigationViewTop.xaml
@@ -191,7 +191,7 @@
                     x:Name="SubMenuBorder"
                     Margin="12,0,12,18"
                     Padding="0,3,0,3"
-                    BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
+                    BorderBrush="{DynamicResource ControlElevationBorderBrush}"
                     BorderThickness="1"
                     CornerRadius="8"
                     SnapsToDevicePixels="True">

--- a/src/Wpf.Ui/Styles/Controls/ToolBar.xaml
+++ b/src/Wpf.Ui/Styles/Controls/ToolBar.xaml
@@ -239,7 +239,7 @@
                                         x:Name="DropDownBorder"
                                         Margin="12,0,12,18"
                                         Padding="0,3,0,3"
-                                        BorderBrush="{DynamicResource MenuBorderColorDefaultBrush}"
+                                        BorderBrush="{DynamicResource ControlElevationBorderBrush}"
                                         BorderThickness="1"
                                         CornerRadius="8"
                                         SnapsToDevicePixels="True">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

MenuBorderColorDefaultBrush does not exist in the project and the brush is set transparent. We should either add this brush or replace it with one of the existing brushes. 
![изображение](https://github.com/lepoco/wpfui/assets/20504884/b866a42c-ae1b-4f14-8418-046e7bda0327)

Issue Number: N/A

## What is the new behavior?

MenuBorderColorDefaultBrush replaced with ControlElevationBorderBrush

As you know the code better than me, it is acceptable to choose a different brush

