### PR TITLE
Optimizes the WindowBackdrop Settings before version 22H1

### DIFF
--- a/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
+++ b/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
@@ -90,12 +90,8 @@ public static class WindowBackdrop
         // 22H1
         if (!Win32.Utilities.IsOSWindows11Insider1OrNewer)
         {
-            if (backdropType == WindowBackdropType.Mica || backdropType == WindowBackdropType.Auto)
+            if (backdropType != WindowBackdropType.None )
                 return ApplyLegacyMicaBackdrop(hWnd);
-
-            if (backdropType == WindowBackdropType.Acrylic)
-                return ApplyLegacyAcrylicBackdrop(hWnd);
-
             return false;
         }
 

--- a/src/Wpf.Ui/Converters/IconSourceElementConverter.cs
+++ b/src/Wpf.Ui/Converters/IconSourceElementConverter.cs
@@ -8,7 +8,7 @@ using Wpf.Ui.Controls;
 
 namespace Wpf.Ui.Converters;
 
-internal class IconSourceElementConverter : IValueConverter
+public class IconSourceElementConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {


### PR DESCRIPTION
Optimizes the WindowBackdrop Settings before version 22H1,Thus automatically switches to a supported effect instead of an error in earlier versions
Sets the IconSourceElementConverter to public, sometimes need to use this converter

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

If the WindowBackdrop type Acrylic is not supported in an early version, it will fail and throw error.
Can,t use IconSourceElementConverter 

Issue Number: N/A

## What is the new behavior?

- automatically switches to a supported effect instead of an error in earlier versions
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
