### PR TITLE
Fix custom app theme detection

### DIFF
--- a/src/Wpf.Ui/Appearance/SystemThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/SystemThemeManager.cs
@@ -115,11 +115,15 @@ public static class SystemThemeManager
                 "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
                 "AppsUseLightTheme",
                 1
-            ) ?? 1;
+            );
 
         if (rawAppsUseLightTheme is 0)
         {
             return SystemTheme.Dark;
+        }
+        else if (rawAppsUseLightTheme is 1)
+        {
+            return SystemTheme.Light;
         }
 
         var rawSystemUsesLightTheme =


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

When windows theme is set to `Custom` with app theme `Light` the code fallback to windows mode and return the wrong theme.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![1](https://github.com/lepoco/wpfui/assets/25966642/8dd551ec-7a6e-4192-bc89-15bbb06ed149)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

![2](https://github.com/lepoco/wpfui/assets/25966642/7c5b771b-82d9-4da6-865e-2d05a1da02d0)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
