### PR TITLE
Formalize indentation settings for XamlStyler

### DIFF
--- a/Settings.XamlStyler
+++ b/Settings.XamlStyler
@@ -7,7 +7,7 @@
     "SeparateByGroups": false,
     "AttributeIndentation": 0,
     "AttributeIndentationStyle": 1,
-    "RemoveDesignTimeReferences":  false,
+    "RemoveDesignTimeReferences": false,
     "IgnoreDesignTimeReferencePrefix": false,
     "EnableAttributeReordering": true,
     "AttributeOrderingRuleGroups": [
@@ -38,5 +38,7 @@
     "ThicknessSeparator": 2,
     "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
     "FormatOnSave": true,
-    "CommentPadding": 2
+    "CommentPadding": 2,
+    "IndentSize": 4,
+    "IndentWithTabs": false
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Simple update to formalize indentation settings to 4 spaces/ no tabs.
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Code style update (formatting, renaming)

## What is the current behavior?
In VisualStudio, XamlStyler indentation defaults to user preferences over traditional project settings like .editorconfig. There are, however, [additional properties](https://github.com/Xavalon/XamlStyler/wiki/External-Configurations) that can be configured.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
