### PR TITLE
Remove ContentAlignment bindings from TreeViewItem

### DIFF
--- a/src/Wpf.Ui/Controls/TreeView/TreeViewItem.xaml
+++ b/src/Wpf.Ui/Controls/TreeView/TreeViewItem.xaml
@@ -84,8 +84,6 @@
                 <SolidColorBrush Opacity="0.0" Color="{DynamicResource ControlFillColorDefault}" />
             </Setter.Value>
         </Setter>
-        <Setter Property="HorizontalContentAlignment" Value="{Binding Path=HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
-        <Setter Property="VerticalContentAlignment" Value="{Binding Path=VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
         <Setter Property="Padding" Value="4" />
         <Setter Property="FontSize" Value="{StaticResource TreeViewItemFontSize}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -211,8 +209,6 @@
                 <SolidColorBrush Opacity="0.0" Color="{DynamicResource ControlFillColorDefault}" />
             </Setter.Value>
         </Setter>
-        <Setter Property="HorizontalContentAlignment" Value="{Binding Path=HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
-        <Setter Property="VerticalContentAlignment" Value="{Binding Path=VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
         <Setter Property="Padding" Value="4" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}" />
         <Setter Property="OverridesDefaultStyle" Value="True" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Remove `Vertical/HorizontalContentAlignment` properties from `TreeViewItem` as it tightly couples `TreeView` to `TreeViewItem` through an ancestor binding which can lead to binding failures under certain conditions.
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [x] Bugfix

## What is the current behavior?
ContentAlignment style setters such in `TreeViewItem.xaml` such as: `<Setter Property="HorizontalContentAlignment" Value="{Binding Path=HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type TreeView}}}" />`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The alignment setters have been removed. To re-style the `TreeViewItem` controls I advise styling the control itself rather than doing so on `TreeView`.
<!-- Please describe the behavior or changes that are being added by this PR. -->
