### PR TITLE
Updated the NumberBox.Value Default UpdateSourceTrigger to LostFocus

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -5,6 +5,7 @@
 
 // This Source Code is partially based on the source code provided by the .NET Foundation.
 
+using System.Windows.Data;
 using System.Windows.Input;
 
 // ReSharper disable once CheckNamespace
@@ -13,7 +14,6 @@ namespace Wpf.Ui.Controls;
 // TODO: Mask (with placeholder); Clipboard paste;
 // TODO: Constant decimals when formatting. Although this can actually be done with NumberFormatter.
 // TODO: Disable expression by default
-// TODO: Fix when exiting with TAB, try to organize the OnTextChanged
 // TODO: Lock to digit characters only by property
 
 /// <summary>
@@ -34,7 +34,7 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
         nameof(Value),
         typeof(double?),
         typeof(NumberBox),
-        new FrameworkPropertyMetadata((double?)null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnValuePropertyChanged)
+        new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnValuePropertyChanged, null, false, UpdateSourceTrigger.LostFocus)
     );
 
     /// <summary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the `NumberBox.ValueProperty` default `UpdateSourceTrigger` for bindings is `UpdateSourceTrigger.Default`.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The `NumberBox.ValueProperty` default `UpdateSourceTrigger` for bindings is now `UpdateSourceTrigger.LostFocus`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Since the `Value` for the `NumberBox` is a text-based property, Microsoft recommends the default `UpdateSourceTrigger` should be `LostFocus`.

- [Binding.UpdateSourceTrigger Property](https://learn.microsoft.com/en-us/dotnet/api/system.windows.data.binding.updatesourcetrigger?view=windowsdesktop-7.0)

The `System.Windows.Controls.TextBox` documentation says:

> When used in data-binding scenarios, this property uses the default update behavior of [UpdateSourceTrigger.LostFocus](https://learn.microsoft.com/en-us/dotnet/api/system.windows.data.updatesourcetrigger?view=windowsdesktop-7.0#system-windows-data-updatesourcetrigger-lostfocus). ([source](https://learn.microsoft.com/en-us/dotnet/api/system.windows.data.binding.updatesourcetrigger?view=windowsdesktop-7.0))