### PR TITLE
Fix FluentWindow behaviour

### DIFF
--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -97,10 +97,6 @@ public class FluentWindow : System.Windows.Window
     static FluentWindow()
     {
         DefaultStyleKeyProperty.OverrideMetadata(typeof(FluentWindow), new FrameworkPropertyMetadata(typeof(FluentWindow)));
-        HeightProperty.OverrideMetadata(typeof(FluentWindow), new FrameworkPropertyMetadata(600d));
-        WidthProperty.OverrideMetadata(typeof(FluentWindow), new FrameworkPropertyMetadata(1100d));
-        MinHeightProperty.OverrideMetadata(typeof(FluentWindow), new FrameworkPropertyMetadata(320d));
-        MinWidthProperty.OverrideMetadata(typeof(FluentWindow), new FrameworkPropertyMetadata(460d));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The window dimensions do not change in runtime. Direct set width or height does not work

## What is the new behavior?

Removing the default values from the `.cs` file solves the problem. The values themselves are already set in the style, so the window behaviour is not changed in any way https://github.com/lepoco/wpfui/blob/36890748630f9abbbb0561b6eeacf082b610650d/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.xaml#L29-L32 

