### PR TITLE
Fix NullReferenceException in AutoSuggestBox ReleaseTemplateResources, add event resubscription after unloading and loading.

### DIFF
--- a/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -255,7 +255,7 @@ public class AutoSuggestBox : System.Windows.Controls.ItemsControl, IIconControl
 
     protected Popup SuggestionsPopup = null!;
 
-    protected ListView SuggestionsList = null!;
+    protected ListView? SuggestionsList = null!;
 
     private bool _changingTextAfterSuggestionChosen;
 
@@ -315,14 +315,20 @@ public class AutoSuggestBox : System.Windows.Controls.ItemsControl, IIconControl
 
     protected virtual void ReleaseTemplateResources()
     {
-        TextBox.PreviewKeyDown -= TextBoxOnPreviewKeyDown;
-        TextBox.TextChanged -= TextBoxOnTextChanged;
-        TextBox.LostKeyboardFocus -= TextBoxOnLostKeyboardFocus;
+        if (TextBox != null)
+        {
+            TextBox.PreviewKeyDown -= TextBoxOnPreviewKeyDown;
+            TextBox.TextChanged -= TextBoxOnTextChanged;
+            TextBox.LostKeyboardFocus -= TextBoxOnLostKeyboardFocus;
+        }
 
-        SuggestionsList.SelectionChanged -= SuggestionsListOnSelectionChanged;
-        SuggestionsList.PreviewKeyDown -= SuggestionsListOnPreviewKeyDown;
-        SuggestionsList.LostKeyboardFocus -= SuggestionsListOnLostKeyboardFocus;
-        SuggestionsList.PreviewMouseLeftButtonUp -= SuggestionsListOnPreviewMouseLeftButtonUp;
+        if (SuggestionsList != null)
+        {
+            SuggestionsList.SelectionChanged -= SuggestionsListOnSelectionChanged;
+            SuggestionsList.PreviewKeyDown -= SuggestionsListOnPreviewKeyDown;
+            SuggestionsList.LostKeyboardFocus -= SuggestionsListOnLostKeyboardFocus;
+            SuggestionsList.PreviewMouseLeftButtonUp -= SuggestionsListOnPreviewMouseLeftButtonUp;
+        }
 
         if (PresentationSource.FromVisual(this) is HwndSource source)
         {


### PR DESCRIPTION
Exception occurs, when AutoSuggestBox has initial visibility state Collapsed, OnApplyTemplate() is not being called and TextBox and SuggestionsList properties are not initialized. 

- Change `SuggestionsList` to nullable type.
- Add NULL checks for `TextBox` and `SuggestionsList` properties to `ReleaseTemplateResources()` function.
- Move event subscriptions to separate `AcquireTemplateResources()` method.
- Call `AcquireTemplateResources()` in both `OnApplyTemplate()` method and `Loaded` event handler.

Fixes #811, #813.

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

NullReferenceException is being thrown.
Events are not resubscribed after component reloading.

Issue Number: #811,#813

## What is the new behavior?

NullReferenceException is not being thrown.
Events are resubscribed.

## Other information

This code in `ReleaseTemplateResources()`

```cs
if(PresentationSource.FromVisual(this) is HwndSource source) 
{
    source.RemoveHook(Hook);
}
```

doesn't work for me, source is not of HwndSource type and code inside `if` block never executes.

This was happening before my changes.
