### PR TITLE
Multiple HighContrast themes support

### DIFF
--- a/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
@@ -96,7 +96,6 @@ public static class ApplicationThemeManager
                 break;
             case ApplicationTheme.HighContrast:
                 themeDictionaryName = "HighContrast";
-                backgroundEffect = WindowBackdropType.None; // We want to disable the background effect in high contrast mode
                 break;
         }
 

--- a/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
@@ -95,7 +95,15 @@ public static class ApplicationThemeManager
                 themeDictionaryName = "Dark";
                 break;
             case ApplicationTheme.HighContrast:
-                themeDictionaryName = "HighContrast";
+                switch (ApplicationThemeManager.GetSystemTheme())
+                {
+                    case SystemTheme.HC1: themeDictionaryName = "HC1"; break;
+                    case SystemTheme.HC2: themeDictionaryName = "HC2"; break;
+                    case SystemTheme.HCBlack: themeDictionaryName = "HCBlack"; break;
+                    case SystemTheme.HCWhite:
+                    default: themeDictionaryName = "HCWhite"; break;
+                }
+
                 break;
         }
 

--- a/src/Wpf.Ui/Appearance/SystemThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/SystemThemeManager.cs
@@ -89,7 +89,7 @@ public static class SystemThemeManager
 
             if (currentTheme.Contains("hcblack.theme"))
             {
-                return SystemTheme.HC1;
+                return SystemTheme.HCBlack;
             }
 
             if (currentTheme.Contains("hcwhite.theme"))

--- a/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
+++ b/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
@@ -64,9 +64,18 @@ public static class WindowBackgroundManager
             return;
         }
 
-        //_ = WindowBackdrop.RemoveBackdrop(window);
-        _ = WindowBackdrop.ApplyBackdrop(window, backdrop);
+        _ = WindowBackdrop.RemoveBackdrop(window);
 
+        if (applicationTheme == ApplicationTheme.HighContrast)
+        {
+            backdrop = WindowBackdropType.None;
+        }
+        else
+        {
+            _ = WindowBackdrop.RemoveBackground(window);
+        }
+
+        _ = WindowBackdrop.ApplyBackdrop(window, backdrop);
         if (applicationTheme is ApplicationTheme.Dark)
         {
             ApplyDarkThemeToWindow(window);
@@ -75,8 +84,6 @@ public static class WindowBackgroundManager
         {
             RemoveDarkThemeFromWindow(window);
         }
-
-       
 
         foreach (var subWindow in window.OwnedWindows)
         {

--- a/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
+++ b/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
@@ -64,6 +64,7 @@ public static class WindowBackgroundManager
             return;
         }
 
+        //_ = WindowBackdrop.RemoveBackdrop(window);
         _ = WindowBackdrop.ApplyBackdrop(window, backdrop);
 
         if (applicationTheme is ApplicationTheme.Dark)
@@ -74,6 +75,8 @@ public static class WindowBackgroundManager
         {
             RemoveDarkThemeFromWindow(window);
         }
+
+       
 
         foreach (var subWindow in window.OwnedWindows)
         {
@@ -91,6 +94,7 @@ public static class WindowBackgroundManager
                 }
             }
         }
+
 
         // Do we really neeed this?
         //if (!Win32.Utilities.IsOSWindows11OrNewer)

--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -163,6 +163,11 @@ public class FluentWindow : System.Windows.Window
     /// </summary>
     protected virtual void OnBackdropTypeChanged(WindowBackdropType oldValue, WindowBackdropType newValue)
     {
+        if (Appearance.ApplicationThemeManager.GetAppTheme() == Appearance.ApplicationTheme.HighContrast)
+        {
+            newValue = WindowBackdropType.None;
+        }
+
         if (InteropHelper.Handle == IntPtr.Zero)
             return;
 

--- a/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
+++ b/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
@@ -316,7 +316,6 @@ public static class WindowBackdrop
                 case SystemTheme.HCWhite:
                 default: return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFA, 0xEF));
             }
-            ;
         }
         else if (ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Dark)
         {

--- a/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
+++ b/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
@@ -303,8 +303,17 @@ public static class WindowBackdrop
 
     private static Brush GetFallbackBackgroundBrush()
     {
-        return ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Dark
-            ? new SolidColorBrush(Color.FromArgb(0xFF, 0x20, 0x20, 0x20))
-            : new SolidColorBrush(Color.FromArgb(0xFF, 0xFA, 0xFA, 0xFA));
+        if (ApplicationThemeManager.GetAppTheme() == ApplicationTheme.HighContrast)
+        {
+            return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFA, 0xEF));
+        }
+        else if (ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Dark)
+        {
+            return new SolidColorBrush(Color.FromArgb(0xFF, 0x20, 0x20, 0x20));
+        }
+        else
+        {
+            return new SolidColorBrush(Color.FromArgb(0xFF, 0xFA, 0xFA, 0xFA));
+        }
     }
 }

--- a/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
+++ b/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
@@ -305,7 +305,18 @@ public static class WindowBackdrop
     {
         if (ApplicationThemeManager.GetAppTheme() == ApplicationTheme.HighContrast)
         {
-            return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFA, 0xEF));
+            switch (ApplicationThemeManager.GetSystemTheme())
+            {
+                case SystemTheme.HC1:
+                    return new SolidColorBrush(Color.FromArgb(0xFF, 0x2D, 0x32, 0x36));
+                case SystemTheme.HC2:
+                    return new SolidColorBrush(Color.FromArgb(0xFF, 0x00, 0x00, 0x00));
+                case SystemTheme.HCBlack:
+                    return new SolidColorBrush(Color.FromArgb(0xFF, 0x20, 0x20, 0x20));
+                case SystemTheme.HCWhite:
+                default: return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFA, 0xEF));
+            }
+            ;
         }
         else if (ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Dark)
         {

--- a/src/Wpf.Ui/Resources/Theme/HC1.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC1.xaml
@@ -1,0 +1,673 @@
+<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+    
+    Based on Microsoft XAML for Win UI
+    Copyright (c) Microsoft Corporation. All Rights Reserved.
+-->
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Microsoft UI XAML
+        
+        2.5 controls should not depends on brushes
+        https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/CommonStyles/Common_themeresources_any.xaml
+    -->
+
+    <!--  Colors depending on the theme should be changed by the Manager  -->
+    <Color x:Key="SystemAccentColor">#4cc2ff</Color>
+    <Color x:Key="SystemAccentColorSecondary">#4cc2ff</Color>
+    <Color x:Key="SystemAccentColorTertiary">#4cc2ff</Color>
+
+    <!--  Highcontrast theme: DUSK.  -->
+    <Color x:Key="SystemColorWindowTextColor">#FFFFFF</Color>
+    <Color x:Key="SystemColorWindowColor">#2D3236</Color>
+    <Color x:Key="SystemColorHighlightTextColor">#212D3B</Color>
+    <Color x:Key="SystemColorHighlightColor">#ABCFF2</Color>
+    <Color x:Key="SystemColorButtonTextColor">#B6F6F0</Color>
+    <Color x:Key="SystemColorButtonFaceColor">#2D3236</Color>
+    <Color x:Key="SystemColorHotlightColor">#70EBDE</Color>
+    <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>
+
+
+    <Color x:Key="ApplicationBackgroundColor">#FFFAEF</Color>
+    <!--  Same as SystemColorWindowColor  -->
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
+
+    <Color x:Key="KeyboardFocusBorderColor">#3D3D3D</Color>
+    <!--  Same as SystemColorWindowTextColor  -->
+    <SolidColorBrush x:Key="KeyboardFocusBorderColorBrush" Color="{StaticResource KeyboardFocusBorderColor}" />
+
+    <!--  Brushes  -->
+
+    <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorDisabledBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextPlaceholderColorBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorInverseBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlStrongFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlStrongFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlSolidFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="SubtleFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SubtleFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlAltFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="ControlAltFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorQuarternaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlOnImageFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="AccentFillColorDisabledBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorTertiaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDisabledBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="ControlStrokeColorForStrongFillWhenOnImageBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="CardStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CardStrokeColorDefaultSolidBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDisabledBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="SurfaceStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorFlyoutBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorInverseBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="DividerStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="FocusStrokeColorOuterBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="FocusStrokeColorInnerBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{StaticResource SystemFillColorSuccess}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBrush" Color="{StaticResource SystemFillColorCaution}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBrush" Color="{StaticResource SystemFillColorCritical}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBrush" Color="{StaticResource SystemFillColorNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidNeutralBrush" Color="{StaticResource SystemFillColorSolidNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorAttentionBackgroundBrush" Color="{StaticResource SystemFillColorAttentionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSuccessBackgroundBrush" Color="{StaticResource SystemFillColorSuccessBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBackgroundBrush" Color="{StaticResource SystemFillColorCautionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBackgroundBrush" Color="{StaticResource SystemFillColorCriticalBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBackgroundBrush" Color="{StaticResource SystemFillColorNeutralBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidAttentionBackgroundBrush" Color="{StaticResource SystemFillColorSolidAttentionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidNeutralBackgroundBrush" Color="{StaticResource SystemFillColorSolidNeutralBackground}" />
+
+    <!--  Elevation border brushes  -->
+
+    <SolidColorBrush x:Key="ControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CircleElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="AccentControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="SystemColorWindowTextColorBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SystemColorWindowColorBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SystemColorButtonFaceColorBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SystemColorButtonTextColorBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="SystemColorHighlightColorBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="SystemColorHighlightTextColorBrush" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="SystemColorHotlightColorBrush" Color="{StaticResource SystemColorHotlightColor}" />
+    <SolidColorBrush x:Key="SystemColorGrayTextColorBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <DrawingBrush
+        x:Key="StripedBackgroundBrush"
+        Stretch="UniformToFill"
+        TileMode="Tile"
+        Viewport="0,0,10,10"
+        ViewportUnits="Absolute">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#0DFFFFFF">
+                        <GeometryDrawing.Geometry>
+                            <GeometryGroup FillRule="Nonzero">
+                                <PathGeometry>
+                                    <PathFigure StartPoint="0,0">
+                                        <LineSegment Point="25,0" />
+                                        <LineSegment Point="100,75" />
+                                        <LineSegment Point="100,100" />
+                                        <LineSegment Point="75,100" />
+                                        <LineSegment Point="0,25" />
+                                        <LineSegment Point="0,0" />
+                                    </PathFigure>
+                                    <PathFigure StartPoint="75,0">
+                                        <LineSegment Point="100,25" />
+                                        <LineSegment Point="100,0" />
+                                    </PathFigure>
+                                    <PathFigure StartPoint="0,75">
+                                        <LineSegment Point="25,100" />
+                                        <LineSegment Point="0,100" />
+                                    </PathFigure>
+                                </PathGeometry>
+                            </GeometryGroup>
+                        </GeometryDrawing.Geometry>
+                    </GeometryDrawing>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+
+
+    <!--  Control brushes  -->
+
+    <!--  Badge  -->
+    <!--  TODO  -->
+
+    <!--  BreadcrumbBar  -->
+    <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="BreadcrumbBarHoverForegroundBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="BreadcrumbBarCurrentNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Button  -->
+    <SolidColorBrush x:Key="AccentButtonBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonBackgroundDisabled" ResourceKey="AccentFillColorDisabledBrush" />-->
+    <SolidColorBrush x:Key="AccentButtonForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPointerOver" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonForegroundDisabled" ResourceKey="TextOnAccentFillColorDisabled" />-->
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrush" Color="{StaticResource AccentControlElevationBorder}" />-->
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrushPointerOver" Color="{StaticResource AccentControlElevationBorder}" />-->
+    <SolidColorBrush x:Key="AccentButtonBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrushDisabled" Color="{StaticResource ControlFillColorTransparentBrush}" />-->
+    <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <!--<SolidColorBrush x:Key="ButtonBorderBrush" Color="{StaticResource ControlElevationBorder}" />-->
+    <!--<SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{StaticResource ControlElevationBorder}" />-->
+    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent" />
+    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Transparent" />
+
+    <!--  Calendar  -->
+    <SolidColorBrush x:Key="CalendarViewForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewSelectedBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewSelectedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CalendarViewTodayBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CalendarViewTodayForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Card / CardAction / CardColor / CardExpander  -->
+    <SolidColorBrush x:Key="CardBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CardBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CardBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CardForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CardForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CardForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <!--<SolidColorBrush x:Key="CardBorderBrushPointerOver" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="CardBorderBrushPressed" Color="Transparent" />
+    <SolidColorBrush x:Key="CardBorderBrushDisabled" Color="Transparent" />
+    <SolidColorBrush x:Key="CardFooterBackground" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  CheckBox  -->
+    <SolidColorBrush x:Key="CheckBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="CheckBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckGlyphForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillChecked" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillCheckedPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillUncheckedPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillUncheckedDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundStrokeUncheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxForegroundUncheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ColorPicker  -->
+    <!--  TODO  -->
+
+    <!--  ComboBox  -->
+    <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  ContentDialog  -->
+    <SolidColorBrush
+        x:Key="ContentDialogSmokeFill"
+        Opacity="0.8"
+        Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContentDialogBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContentDialogTopOverlay" Color="Transparent" />
+    <SolidColorBrush x:Key="ContentDialogBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContentDialogSeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContentDialogForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ContextMenu  -->
+    <SolidColorBrush x:Key="ContextMenuBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContextMenuBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContextMenuForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  DataGrid  -->
+    <!--  TODO  -->
+
+    <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Expander  -->
+    <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderBorderPointerOverBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderDisabledForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderDisabledBorderBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ExpanderContentBackground" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  FluentWindow  -->
+    <SolidColorBrush x:Key="WindowBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="WindowForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Flyout  -->
+    <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  HyperlinkButton  -->
+    <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForeground" Color="{StaticResource SystemColorHotlightColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  InfoBadge  -->
+    <!--  TODO  -->
+
+    <!--  InfoBar  -->
+    <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="InfoBarErrorSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  Label  -->
+    <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ListBox  -->
+    <SolidColorBrush x:Key="ListBoxItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ListBoxItemSelectedBackgroundThemeBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <!--  ListView  -->
+    <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  LoadingScreen  -->
+    <SolidColorBrush x:Key="LoadingScreenBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LoadingScreenForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Menu  -->
+    <SolidColorBrush x:Key="MenuBarBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  MessageDialog  -->
+    <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="MessageBoxForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="MessageBoxSeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="MessageBoxTopOverlay" Color="Transparent" />
+
+    <!--  NavigationView  -->
+    <SolidColorBrush x:Key="NavigationViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemSeparatorForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ProgressBar  -->
+    <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ProgressBarBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ProgressBarIndeterminateBackground" Color="Transparent" />
+
+    <!--  ProgressRing  -->
+    <SolidColorBrush x:Key="ProgressRingForegroundThemeBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="Transparent" />
+
+    <!--  RadioButton  -->
+    <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFill" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  RatingControl  -->
+    <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  Separator  -->
+    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Slider  -->
+    <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderTrackFillPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderTickBarFill" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderOuterThumbBackground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderThumbBackground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderThumbBackgroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  SnackBar  -->
+    <SolidColorBrush x:Key="SnackBarBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SnackBarForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SnackBarBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  StatusBar  -->
+    <!--  TO DO  -->
+
+    <!--  TabControl / TabView  -->
+    <SolidColorBrush x:Key="TabViewBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TabViewItemForegroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TabViewBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TabViewItemHeaderBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewSelectedItemBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  TextBox (same brushes are used for AutoSuggestBox / NumberBox / PasswordBox / RichSuggestBox)  -->
+    <SolidColorBrush x:Key="TextControlBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <!--<SolidColorBrush x:Key="TextControlBorderBrush" Color="{StaticResource TextControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="TextControlForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextControlForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlFocusedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ThumbRate  -->
+    <SolidColorBrush x:Key="ThumbRateForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  TimePicker  -->
+    <SolidColorBrush x:Key="TimePickerButtonBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundDisabled" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="TimePickerButtonBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="TimePickerButtonBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundDefault" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToggleButton  -->
+    <SolidColorBrush x:Key="ToggleButtonBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundChecked" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundCheckedPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundCheckedDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <!--<SolidColorBrush x:Key="ToggleButtonBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushCheckedPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushCheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundChecked" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToggleSwitch  -->
+    <SolidColorBrush x:Key="ToggleSwitchContentForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchContentForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOff" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOffPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOffDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOn" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOnPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOnDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOn" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOnPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOnDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOff" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOffPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOffDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOff" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOn" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnPressed" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToolTip  -->
+    <SolidColorBrush x:Key="ToolTipBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToolTipBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ToolBar  -->
+    <!--  TODO  -->
+
+    <!--  TreeGrid  -->
+    <!--  TODO  -->
+
+    <!--  TreeView  -->
+    <SolidColorBrush x:Key="TreeViewItemBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TreeViewItemSelectionIndicatorForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+
+
+
+
+    <!--  Colors  -->
+    <!--  Colors copied from Default theme to match list of keys. Should not be using these keys. These are set to Red to notify that.  -->
+    <Color x:Key="TextFillColorPrimary">#FF0000</Color>
+    <Color x:Key="TextFillColorSecondary">#FF0000</Color>
+    <Color x:Key="TextFillColorTertiary">#FF0000</Color>
+    <Color x:Key="TextFillColorDisabled">#FF0000</Color>
+    <Color x:Key="TextPlaceholderColor">#FF0000</Color>
+    <Color x:Key="TextFillColorInverse">#FF0000</Color>
+
+    <Color x:Key="AccentTextFillColorDisabled">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorSelectedText">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorPrimary">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorSecondary">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlFillColorDisabled">#FF0000</Color>
+    <Color x:Key="ControlFillColorTransparent">#FF0000</Color>
+    <Color x:Key="ControlFillColorInputActive">#FF0000</Color>
+
+    <Color x:Key="ControlStrongFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrongFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlSolidFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="SubtleFillColorTransparent">#FF0000</Color>
+    <Color x:Key="SubtleFillColorSecondary">#FF0000</Color>
+    <Color x:Key="SubtleFillColorTertiary">#FF0000</Color>
+    <Color x:Key="SubtleFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlAltFillColorTransparent">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorQuarternary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlOnImageFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="AccentFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDefault">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentSecondary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentTertiary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FF0000</Color>
+
+    <Color x:Key="CardStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="CardStrokeColorDefaultSolid">#FF0000</Color>
+
+    <Color x:Key="ControlStrongStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrongStrokeColorDisabled">#FF0000</Color>
+
+    <Color x:Key="SurfaceStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="SurfaceStrokeColorFlyout">#FF0000</Color>
+    <Color x:Key="SurfaceStrokeColorInverse">#FF0000</Color>
+
+    <Color x:Key="DividerStrokeColorDefault">#FF0000</Color>
+
+    <Color x:Key="FocusStrokeColorOuter">#FF0000</Color>
+    <Color x:Key="FocusStrokeColorInner">#FF0000</Color>
+
+    <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
+    <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
+
+    <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="LayerFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerFillColorAlt">#FF0000</Color>
+    <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+
+    <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
+    <Color x:Key="AcrylicBackgroundFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+
+    <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
+
+    <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
+    <Color x:Key="SystemFillColorCaution">#FF0000</Color>
+    <Color x:Key="SystemFillColorCritical">#FF0000</Color>
+    <Color x:Key="SystemFillColorNeutral">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
+    <Color x:Key="SystemFillColorAttentionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSuccessBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorCautionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorCriticalBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorNeutralBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidAttentionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+</ResourceDictionary>

--- a/src/Wpf.Ui/Resources/Theme/HC2.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC2.xaml
@@ -21,46 +21,15 @@
     <Color x:Key="SystemAccentColorSecondary">#4cc2ff</Color>
     <Color x:Key="SystemAccentColorTertiary">#4cc2ff</Color>
 
-    <!--  Highcontrast theme: AQUATIC . TO DO: MOVE TO SEPERATE FILE?  -->
-    <!-- <Color x:Key="SystemColorWindowTextColor">#FFFFFF</Color>
-    <Color x:Key="SystemColorWindowColor">#202020</Color>
-    <Color x:Key="SystemColorHighlightTextColor">#263B50</Color>
-    <Color x:Key="SystemColorHighlightColor">#8EE3F0</Color>
-    <Color x:Key="SystemColorButtonTextColor">#FFFFFF</Color>
-    <Color x:Key="SystemColorButtonFaceColor">#202020</Color>
-    <Color x:Key="SystemColorHotlightColor">#75E9FC</Color>
-    <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>-->
-
-    <!--  Highcontrast theme: DESERT  -->
-    <Color x:Key="SystemColorWindowTextColor">#3D3D3D</Color>
-    <Color x:Key="SystemColorWindowColor">#FFFAEF</Color>
-    <Color x:Key="SystemColorHighlightTextColor">#FFF5E3</Color>
-    <Color x:Key="SystemColorHighlightColor">#903909</Color>
-    <Color x:Key="SystemColorButtonTextColor">#202020</Color>
-    <Color x:Key="SystemColorButtonFaceColor">#FFFAEF</Color>
-    <Color x:Key="SystemColorHotlightColor">#1C5E75</Color>
-    <Color x:Key="SystemColorGrayTextColor">#676767</Color>
-
-    <!--  Highcontrast theme: DUSK. TO DO: MOVE TO SEPERATE FILE?  -->
-    <!-- <Color x:Key="SystemColorWindowTextColor">#FFFFFF</Color>
-    <Color x:Key="SystemColorWindowColor">#2D3236</Color>
-    <Color x:Key="SystemColorHighlightTextColor">#212D3B</Color>
-    <Color x:Key="SystemColorHighlightColor">#ABCFF2</Color>
-    <Color x:Key="SystemColorButtonTextColor">#B6F6F0</Color>
-    <Color x:Key="SystemColorButtonFaceColor">#2D3236</Color>
-    <Color x:Key="SystemColorHotlightColor">#70EBDE</Color>
-    <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>-->
-
-    <!--  Highcontrast theme: NIGHT SKY. TO DO: MOVE TO SEPERATE FILE?  -->
-    <!-- Color x:Key="SystemColorWindowTextColor">#FFFFFF</Color>
+    <!--  Highcontrast theme: NIGHT SKY.  -->
+    <Color x:Key="SystemColorWindowTextColor">#FFFFFF</Color>
     <Color x:Key="SystemColorWindowColor">#000000</Color>
     <Color x:Key="SystemColorHighlightTextColor">#2B2B2B</Color>
     <Color x:Key="SystemColorHighlightColor">#D6B4FD</Color>
     <Color x:Key="SystemColorButtonTextColor">#FFEE32</Color>
     <Color x:Key="SystemColorButtonFaceColor">#000000</Color>
     <Color x:Key="SystemColorHotlightColor">#8080FF</Color>
-    <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>-->
-
+    <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>
 
     <Color x:Key="ApplicationBackgroundColor">#FFFAEF</Color>
     <!--  Same as SystemColorWindowColor  -->

--- a/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
@@ -1,0 +1,672 @@
+<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+    
+    Based on Microsoft XAML for Win UI
+    Copyright (c) Microsoft Corporation. All Rights Reserved.
+-->
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Microsoft UI XAML
+        
+        2.5 controls should not depends on brushes
+        https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/CommonStyles/Common_themeresources_any.xaml
+    -->
+
+    <!--  Colors depending on the theme should be changed by the Manager  -->
+    <Color x:Key="SystemAccentColor">#4cc2ff</Color>
+    <Color x:Key="SystemAccentColorSecondary">#4cc2ff</Color>
+    <Color x:Key="SystemAccentColorTertiary">#4cc2ff</Color>
+
+    <!--  Highcontrast theme: AQUATIC.  -->
+    <Color x:Key="SystemColorWindowTextColor">#FFFFFF</Color>
+    <Color x:Key="SystemColorWindowColor">#202020</Color>
+    <Color x:Key="SystemColorHighlightTextColor">#263B50</Color>
+    <Color x:Key="SystemColorHighlightColor">#8EE3F0</Color>
+    <Color x:Key="SystemColorButtonTextColor">#FFFFFF</Color>
+    <Color x:Key="SystemColorButtonFaceColor">#202020</Color>
+    <Color x:Key="SystemColorHotlightColor">#75E9FC</Color>
+    <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>
+
+    <Color x:Key="ApplicationBackgroundColor">#FFFAEF</Color>
+    <!--  Same as SystemColorWindowColor  -->
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
+
+    <Color x:Key="KeyboardFocusBorderColor">#3D3D3D</Color>
+    <!--  Same as SystemColorWindowTextColor  -->
+    <SolidColorBrush x:Key="KeyboardFocusBorderColorBrush" Color="{StaticResource KeyboardFocusBorderColor}" />
+
+    <!--  Brushes  -->
+
+    <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorDisabledBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextPlaceholderColorBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorInverseBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlStrongFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlStrongFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlSolidFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="SubtleFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SubtleFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlAltFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="ControlAltFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorQuarternaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlOnImageFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="AccentFillColorDisabledBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorTertiaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDisabledBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="ControlStrokeColorForStrongFillWhenOnImageBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="CardStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CardStrokeColorDefaultSolidBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDisabledBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="SurfaceStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorFlyoutBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorInverseBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="DividerStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="FocusStrokeColorOuterBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="FocusStrokeColorInnerBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{StaticResource SystemFillColorSuccess}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBrush" Color="{StaticResource SystemFillColorCaution}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBrush" Color="{StaticResource SystemFillColorCritical}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBrush" Color="{StaticResource SystemFillColorNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidNeutralBrush" Color="{StaticResource SystemFillColorSolidNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorAttentionBackgroundBrush" Color="{StaticResource SystemFillColorAttentionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSuccessBackgroundBrush" Color="{StaticResource SystemFillColorSuccessBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBackgroundBrush" Color="{StaticResource SystemFillColorCautionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBackgroundBrush" Color="{StaticResource SystemFillColorCriticalBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBackgroundBrush" Color="{StaticResource SystemFillColorNeutralBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidAttentionBackgroundBrush" Color="{StaticResource SystemFillColorSolidAttentionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidNeutralBackgroundBrush" Color="{StaticResource SystemFillColorSolidNeutralBackground}" />
+
+    <!--  Elevation border brushes  -->
+
+    <SolidColorBrush x:Key="ControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CircleElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="AccentControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="SystemColorWindowTextColorBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SystemColorWindowColorBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SystemColorButtonFaceColorBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SystemColorButtonTextColorBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="SystemColorHighlightColorBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="SystemColorHighlightTextColorBrush" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="SystemColorHotlightColorBrush" Color="{StaticResource SystemColorHotlightColor}" />
+    <SolidColorBrush x:Key="SystemColorGrayTextColorBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <DrawingBrush
+        x:Key="StripedBackgroundBrush"
+        Stretch="UniformToFill"
+        TileMode="Tile"
+        Viewport="0,0,10,10"
+        ViewportUnits="Absolute">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#0DFFFFFF">
+                        <GeometryDrawing.Geometry>
+                            <GeometryGroup FillRule="Nonzero">
+                                <PathGeometry>
+                                    <PathFigure StartPoint="0,0">
+                                        <LineSegment Point="25,0" />
+                                        <LineSegment Point="100,75" />
+                                        <LineSegment Point="100,100" />
+                                        <LineSegment Point="75,100" />
+                                        <LineSegment Point="0,25" />
+                                        <LineSegment Point="0,0" />
+                                    </PathFigure>
+                                    <PathFigure StartPoint="75,0">
+                                        <LineSegment Point="100,25" />
+                                        <LineSegment Point="100,0" />
+                                    </PathFigure>
+                                    <PathFigure StartPoint="0,75">
+                                        <LineSegment Point="25,100" />
+                                        <LineSegment Point="0,100" />
+                                    </PathFigure>
+                                </PathGeometry>
+                            </GeometryGroup>
+                        </GeometryDrawing.Geometry>
+                    </GeometryDrawing>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+
+
+    <!--  Control brushes  -->
+
+    <!--  Badge  -->
+    <!--  TODO  -->
+
+    <!--  BreadcrumbBar  -->
+    <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="BreadcrumbBarHoverForegroundBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="BreadcrumbBarCurrentNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Button  -->
+    <SolidColorBrush x:Key="AccentButtonBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonBackgroundDisabled" ResourceKey="AccentFillColorDisabledBrush" />-->
+    <SolidColorBrush x:Key="AccentButtonForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPointerOver" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonForegroundDisabled" ResourceKey="TextOnAccentFillColorDisabled" />-->
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrush" Color="{StaticResource AccentControlElevationBorder}" />-->
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrushPointerOver" Color="{StaticResource AccentControlElevationBorder}" />-->
+    <SolidColorBrush x:Key="AccentButtonBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrushDisabled" Color="{StaticResource ControlFillColorTransparentBrush}" />-->
+    <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <!--<SolidColorBrush x:Key="ButtonBorderBrush" Color="{StaticResource ControlElevationBorder}" />-->
+    <!--<SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{StaticResource ControlElevationBorder}" />-->
+    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent" />
+    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Transparent" />
+
+    <!--  Calendar  -->
+    <SolidColorBrush x:Key="CalendarViewForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewSelectedBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewSelectedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CalendarViewTodayBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CalendarViewTodayForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Card / CardAction / CardColor / CardExpander  -->
+    <SolidColorBrush x:Key="CardBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CardBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CardBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CardForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CardForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CardForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <!--<SolidColorBrush x:Key="CardBorderBrushPointerOver" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="CardBorderBrushPressed" Color="Transparent" />
+    <SolidColorBrush x:Key="CardBorderBrushDisabled" Color="Transparent" />
+    <SolidColorBrush x:Key="CardFooterBackground" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  CheckBox  -->
+    <SolidColorBrush x:Key="CheckBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="CheckBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckGlyphForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillChecked" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillCheckedPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillUncheckedPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillUncheckedDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundStrokeUncheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxForegroundUncheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ColorPicker  -->
+    <!--  TODO  -->
+
+    <!--  ComboBox  -->
+    <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  ContentDialog  -->
+    <SolidColorBrush
+        x:Key="ContentDialogSmokeFill"
+        Opacity="0.8"
+        Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContentDialogBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContentDialogTopOverlay" Color="Transparent" />
+    <SolidColorBrush x:Key="ContentDialogBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContentDialogSeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContentDialogForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ContextMenu  -->
+    <SolidColorBrush x:Key="ContextMenuBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContextMenuBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContextMenuForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  DataGrid  -->
+    <!--  TODO  -->
+
+    <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Expander  -->
+    <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderBorderPointerOverBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderDisabledForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderDisabledBorderBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ExpanderContentBackground" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  FluentWindow  -->
+    <SolidColorBrush x:Key="WindowBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="WindowForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Flyout  -->
+    <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  HyperlinkButton  -->
+    <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForeground" Color="{StaticResource SystemColorHotlightColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  InfoBadge  -->
+    <!--  TODO  -->
+
+    <!--  InfoBar  -->
+    <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="InfoBarErrorSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  Label  -->
+    <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ListBox  -->
+    <SolidColorBrush x:Key="ListBoxItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ListBoxItemSelectedBackgroundThemeBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <!--  ListView  -->
+    <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  LoadingScreen  -->
+    <SolidColorBrush x:Key="LoadingScreenBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LoadingScreenForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Menu  -->
+    <SolidColorBrush x:Key="MenuBarBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  MessageDialog  -->
+    <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="MessageBoxForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="MessageBoxSeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="MessageBoxTopOverlay" Color="Transparent" />
+
+    <!--  NavigationView  -->
+    <SolidColorBrush x:Key="NavigationViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemSeparatorForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ProgressBar  -->
+    <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ProgressBarBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ProgressBarIndeterminateBackground" Color="Transparent" />
+
+    <!--  ProgressRing  -->
+    <SolidColorBrush x:Key="ProgressRingForegroundThemeBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="Transparent" />
+
+    <!--  RadioButton  -->
+    <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFill" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  RatingControl  -->
+    <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  Separator  -->
+    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Slider  -->
+    <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderTrackFillPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderTickBarFill" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderOuterThumbBackground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderThumbBackground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderThumbBackgroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  SnackBar  -->
+    <SolidColorBrush x:Key="SnackBarBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SnackBarForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SnackBarBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  StatusBar  -->
+    <!--  TO DO  -->
+
+    <!--  TabControl / TabView  -->
+    <SolidColorBrush x:Key="TabViewBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TabViewItemForegroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TabViewBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TabViewItemHeaderBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewSelectedItemBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  TextBox (same brushes are used for AutoSuggestBox / NumberBox / PasswordBox / RichSuggestBox)  -->
+    <SolidColorBrush x:Key="TextControlBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <!--<SolidColorBrush x:Key="TextControlBorderBrush" Color="{StaticResource TextControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="TextControlForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextControlForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlFocusedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ThumbRate  -->
+    <SolidColorBrush x:Key="ThumbRateForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  TimePicker  -->
+    <SolidColorBrush x:Key="TimePickerButtonBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundDisabled" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="TimePickerButtonBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="TimePickerButtonBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundDefault" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToggleButton  -->
+    <SolidColorBrush x:Key="ToggleButtonBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundChecked" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundCheckedPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundCheckedDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <!--<SolidColorBrush x:Key="ToggleButtonBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushCheckedPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushCheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundChecked" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToggleSwitch  -->
+    <SolidColorBrush x:Key="ToggleSwitchContentForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchContentForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOff" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOffPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOffDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOn" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOnPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOnDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOn" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOnPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOnDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOff" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOffPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOffDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOff" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOn" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnPressed" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToolTip  -->
+    <SolidColorBrush x:Key="ToolTipBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToolTipBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ToolBar  -->
+    <!--  TODO  -->
+
+    <!--  TreeGrid  -->
+    <!--  TODO  -->
+
+    <!--  TreeView  -->
+    <SolidColorBrush x:Key="TreeViewItemBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TreeViewItemSelectionIndicatorForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+
+
+
+
+    <!--  Colors  -->
+    <!--  Colors copied from Default theme to match list of keys. Should not be using these keys. These are set to Red to notify that.  -->
+    <Color x:Key="TextFillColorPrimary">#FF0000</Color>
+    <Color x:Key="TextFillColorSecondary">#FF0000</Color>
+    <Color x:Key="TextFillColorTertiary">#FF0000</Color>
+    <Color x:Key="TextFillColorDisabled">#FF0000</Color>
+    <Color x:Key="TextPlaceholderColor">#FF0000</Color>
+    <Color x:Key="TextFillColorInverse">#FF0000</Color>
+
+    <Color x:Key="AccentTextFillColorDisabled">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorSelectedText">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorPrimary">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorSecondary">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlFillColorDisabled">#FF0000</Color>
+    <Color x:Key="ControlFillColorTransparent">#FF0000</Color>
+    <Color x:Key="ControlFillColorInputActive">#FF0000</Color>
+
+    <Color x:Key="ControlStrongFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrongFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlSolidFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="SubtleFillColorTransparent">#FF0000</Color>
+    <Color x:Key="SubtleFillColorSecondary">#FF0000</Color>
+    <Color x:Key="SubtleFillColorTertiary">#FF0000</Color>
+    <Color x:Key="SubtleFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlAltFillColorTransparent">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorQuarternary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlOnImageFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="AccentFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDefault">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentSecondary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentTertiary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FF0000</Color>
+
+    <Color x:Key="CardStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="CardStrokeColorDefaultSolid">#FF0000</Color>
+
+    <Color x:Key="ControlStrongStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrongStrokeColorDisabled">#FF0000</Color>
+
+    <Color x:Key="SurfaceStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="SurfaceStrokeColorFlyout">#FF0000</Color>
+    <Color x:Key="SurfaceStrokeColorInverse">#FF0000</Color>
+
+    <Color x:Key="DividerStrokeColorDefault">#FF0000</Color>
+
+    <Color x:Key="FocusStrokeColorOuter">#FF0000</Color>
+    <Color x:Key="FocusStrokeColorInner">#FF0000</Color>
+
+    <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
+    <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
+
+    <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="LayerFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerFillColorAlt">#FF0000</Color>
+    <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+
+    <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
+    <Color x:Key="AcrylicBackgroundFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+
+    <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
+
+    <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
+    <Color x:Key="SystemFillColorCaution">#FF0000</Color>
+    <Color x:Key="SystemFillColorCritical">#FF0000</Color>
+    <Color x:Key="SystemFillColorNeutral">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
+    <Color x:Key="SystemFillColorAttentionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSuccessBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorCautionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorCriticalBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorNeutralBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidAttentionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+</ResourceDictionary>

--- a/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
@@ -1,0 +1,672 @@
+<!--
+    This Source Code Form is subject to the terms of the MIT License.
+    If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+    Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+    All Rights Reserved.
+    
+    Based on Microsoft XAML for Win UI
+    Copyright (c) Microsoft Corporation. All Rights Reserved.
+-->
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Microsoft UI XAML
+        
+        2.5 controls should not depends on brushes
+        https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/CommonStyles/Common_themeresources_any.xaml
+    -->
+
+    <!--  Colors depending on the theme should be changed by the Manager  -->
+    <Color x:Key="SystemAccentColor">#4cc2ff</Color>
+    <Color x:Key="SystemAccentColorSecondary">#4cc2ff</Color>
+    <Color x:Key="SystemAccentColorTertiary">#4cc2ff</Color>
+
+    <!--  Highcontrast theme: DESERT  -->
+    <Color x:Key="SystemColorWindowTextColor">#3D3D3D</Color>
+    <Color x:Key="SystemColorWindowColor">#FFFAEF</Color>
+    <Color x:Key="SystemColorHighlightTextColor">#FFF5E3</Color>
+    <Color x:Key="SystemColorHighlightColor">#903909</Color>
+    <Color x:Key="SystemColorButtonTextColor">#202020</Color>
+    <Color x:Key="SystemColorButtonFaceColor">#FFFAEF</Color>
+    <Color x:Key="SystemColorHotlightColor">#1C5E75</Color>
+    <Color x:Key="SystemColorGrayTextColor">#676767</Color>
+
+    <Color x:Key="ApplicationBackgroundColor">#FFFAEF</Color>
+    <!--  Same as SystemColorWindowColor  -->
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
+
+    <Color x:Key="KeyboardFocusBorderColor">#3D3D3D</Color>
+    <!--  Same as SystemColorWindowTextColor  -->
+    <SolidColorBrush x:Key="KeyboardFocusBorderColorBrush" Color="{StaticResource KeyboardFocusBorderColor}" />
+
+    <!--  Brushes  -->
+
+    <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorDisabledBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextPlaceholderColorBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextFillColorInverseBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlStrongFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlStrongFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlSolidFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="SubtleFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SubtleFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlAltFillColorTransparentBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="ControlAltFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorQuarternaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlAltFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="ControlOnImageFillColorDefaultBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorSecondaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorTertiaryBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ControlOnImageFillColorDisabledBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <SolidColorBrush x:Key="AccentFillColorDisabledBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorTertiaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDisabledBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="ControlStrokeColorForStrongFillWhenOnImageBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="CardStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CardStrokeColorDefaultSolidBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDefaultBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDisabledBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="SurfaceStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorFlyoutBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorInverseBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="DividerStrokeColorDefaultBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="FocusStrokeColorOuterBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="FocusStrokeColorInnerBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{StaticResource SystemFillColorSuccess}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBrush" Color="{StaticResource SystemFillColorCaution}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBrush" Color="{StaticResource SystemFillColorCritical}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBrush" Color="{StaticResource SystemFillColorNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidNeutralBrush" Color="{StaticResource SystemFillColorSolidNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorAttentionBackgroundBrush" Color="{StaticResource SystemFillColorAttentionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSuccessBackgroundBrush" Color="{StaticResource SystemFillColorSuccessBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBackgroundBrush" Color="{StaticResource SystemFillColorCautionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBackgroundBrush" Color="{StaticResource SystemFillColorCriticalBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBackgroundBrush" Color="{StaticResource SystemFillColorNeutralBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidAttentionBackgroundBrush" Color="{StaticResource SystemFillColorSolidAttentionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidNeutralBackgroundBrush" Color="{StaticResource SystemFillColorSolidNeutralBackground}" />
+
+    <!--  Elevation border brushes  -->
+
+    <SolidColorBrush x:Key="ControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CircleElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="AccentControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextControlElevationBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="SystemColorWindowTextColorBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SystemColorWindowColorBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SystemColorButtonFaceColorBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="SystemColorButtonTextColorBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="SystemColorHighlightColorBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="SystemColorHighlightTextColorBrush" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="SystemColorHotlightColorBrush" Color="{StaticResource SystemColorHotlightColor}" />
+    <SolidColorBrush x:Key="SystemColorGrayTextColorBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <DrawingBrush
+        x:Key="StripedBackgroundBrush"
+        Stretch="UniformToFill"
+        TileMode="Tile"
+        Viewport="0,0,10,10"
+        ViewportUnits="Absolute">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#0DFFFFFF">
+                        <GeometryDrawing.Geometry>
+                            <GeometryGroup FillRule="Nonzero">
+                                <PathGeometry>
+                                    <PathFigure StartPoint="0,0">
+                                        <LineSegment Point="25,0" />
+                                        <LineSegment Point="100,75" />
+                                        <LineSegment Point="100,100" />
+                                        <LineSegment Point="75,100" />
+                                        <LineSegment Point="0,25" />
+                                        <LineSegment Point="0,0" />
+                                    </PathFigure>
+                                    <PathFigure StartPoint="75,0">
+                                        <LineSegment Point="100,25" />
+                                        <LineSegment Point="100,0" />
+                                    </PathFigure>
+                                    <PathFigure StartPoint="0,75">
+                                        <LineSegment Point="25,100" />
+                                        <LineSegment Point="0,100" />
+                                    </PathFigure>
+                                </PathGeometry>
+                            </GeometryGroup>
+                        </GeometryDrawing.Geometry>
+                    </GeometryDrawing>
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+
+
+    <!--  Control brushes  -->
+
+    <!--  Badge  -->
+    <!--  TODO  -->
+
+    <!--  BreadcrumbBar  -->
+    <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="BreadcrumbBarHoverForegroundBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="BreadcrumbBarCurrentNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Button  -->
+    <SolidColorBrush x:Key="AccentButtonBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonBackgroundDisabled" ResourceKey="AccentFillColorDisabledBrush" />-->
+    <SolidColorBrush x:Key="AccentButtonForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPointerOver" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonForegroundDisabled" ResourceKey="TextOnAccentFillColorDisabled" />-->
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrush" Color="{StaticResource AccentControlElevationBorder}" />-->
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrushPointerOver" Color="{StaticResource AccentControlElevationBorder}" />-->
+    <SolidColorBrush x:Key="AccentButtonBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="AccentButtonBorderBrushDisabled" Color="{StaticResource ControlFillColorTransparentBrush}" />-->
+    <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <!--<SolidColorBrush x:Key="ButtonBorderBrush" Color="{StaticResource ControlElevationBorder}" />-->
+    <!--<SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{StaticResource ControlElevationBorder}" />-->
+    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent" />
+    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Transparent" />
+
+    <!--  Calendar  -->
+    <SolidColorBrush x:Key="CalendarViewForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewSelectedBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CalendarViewSelectedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CalendarViewTodayBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CalendarViewTodayForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CalendarViewButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Card / CardAction / CardColor / CardExpander  -->
+    <SolidColorBrush x:Key="CardBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CardBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CardBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CardForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CardForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CardForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CardForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <!--<SolidColorBrush x:Key="CardBorderBrushPointerOver" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="CardBorderBrushPressed" Color="Transparent" />
+    <SolidColorBrush x:Key="CardBorderBrushDisabled" Color="Transparent" />
+    <SolidColorBrush x:Key="CardFooterBackground" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  CheckBox  -->
+    <SolidColorBrush x:Key="CheckBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="CheckBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckGlyphForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillChecked" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillCheckedPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillUncheckedPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillUncheckedDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundStrokeUncheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="CheckBoxForegroundUncheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ColorPicker  -->
+    <!--  TODO  -->
+
+    <!--  ComboBox  -->
+    <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <!--<SolidColorBrush x:Key="ComboBoxItemBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  ContentDialog  -->
+    <SolidColorBrush
+        x:Key="ContentDialogSmokeFill"
+        Opacity="0.8"
+        Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContentDialogBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContentDialogTopOverlay" Color="Transparent" />
+    <SolidColorBrush x:Key="ContentDialogBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContentDialogSeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContentDialogForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ContextMenu  -->
+    <SolidColorBrush x:Key="ContextMenuBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ContextMenuBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ContextMenuForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  DataGrid  -->
+    <!--  TODO  -->
+
+    <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <!--  Expander  -->
+    <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderBorderPointerOverBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderDisabledForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ExpanderHeaderDisabledBorderBrush" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ExpanderContentBackground" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  FluentWindow  -->
+    <SolidColorBrush x:Key="WindowBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="WindowForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Flyout  -->
+    <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  HyperlinkButton  -->
+    <SolidColorBrush x:Key="HyperlinkButtonBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForeground" Color="{StaticResource SystemColorHotlightColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="HyperlinkButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  InfoBadge  -->
+    <!--  TODO  -->
+
+    <!--  InfoBar  -->
+    <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <SolidColorBrush x:Key="InfoBarErrorSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityIconBackground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  Label  -->
+    <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ListBox  -->
+    <SolidColorBrush x:Key="ListBoxItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ListBoxItemSelectedBackgroundThemeBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
+
+    <!--  ListView  -->
+    <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  LoadingScreen  -->
+    <SolidColorBrush x:Key="LoadingScreenBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="LoadingScreenForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Menu  -->
+    <SolidColorBrush x:Key="MenuBarBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+
+    <!--  MessageDialog  -->
+    <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="MessageBoxForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="MessageBoxSeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="MessageBoxTopOverlay" Color="Transparent" />
+
+    <!--  NavigationView  -->
+    <SolidColorBrush x:Key="NavigationViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemSeparatorForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ProgressBar  -->
+    <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ProgressBarBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ProgressBarIndeterminateBackground" Color="Transparent" />
+
+    <!--  ProgressRing  -->
+    <SolidColorBrush x:Key="ProgressRingForegroundThemeBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="Transparent" />
+
+    <!--  RadioButton  -->
+    <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFill" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  RatingControl  -->
+    <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  Separator  -->
+    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  Slider  -->
+    <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderTrackFillPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderTickBarFill" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderOuterThumbBackground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderThumbBackground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SliderThumbBackgroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  SnackBar  -->
+    <SolidColorBrush x:Key="SnackBarBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="SnackBarForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SnackBarBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  StatusBar  -->
+    <!--  TO DO  -->
+
+    <!--  TabControl / TabView  -->
+    <SolidColorBrush x:Key="TabViewBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TabViewItemForegroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TabViewBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TabViewItemHeaderBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TabViewSelectedItemBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  TextBox (same brushes are used for AutoSuggestBox / NumberBox / PasswordBox / RichSuggestBox)  -->
+    <SolidColorBrush x:Key="TextControlBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <!--<SolidColorBrush x:Key="TextControlBorderBrush" Color="{StaticResource TextControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="TextControlForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TextControlForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlFocusedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TextControlButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ThumbRate  -->
+    <SolidColorBrush x:Key="ThumbRateForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+    <!--  TimePicker  -->
+    <SolidColorBrush x:Key="TimePickerButtonBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBackgroundDisabled" Color="{StaticResource SystemColorHighlightColor}" />
+    <!--<SolidColorBrush x:Key="TimePickerButtonBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="TimePickerButtonBorderBrushPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundDefault" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="TimePickerButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToggleButton  -->
+    <SolidColorBrush x:Key="ToggleButtonBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundChecked" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundCheckedPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBackgroundCheckedDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <!--<SolidColorBrush x:Key="ToggleButtonBorderBrush" Color="{StaticResource ControlElevationBorderBrush}" />-->
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushCheckedPressed" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleButtonBorderBrushCheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundChecked" Color="{StaticResource SystemColorButtonFaceColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleButtonForegroundCheckedDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToggleSwitch  -->
+    <SolidColorBrush x:Key="ToggleSwitchContentForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchContentForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOff" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOffPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOffDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOn" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOnPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOnDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOn" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOnPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOnDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOff" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOffPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOffDisabled" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOff" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffPressed" Color="{StaticResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOffDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOn" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnPressed" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOnDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!--  ToolTip  -->
+    <SolidColorBrush x:Key="ToolTipBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="ToolTipBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+
+    <!--  ToolBar  -->
+    <!--  TODO  -->
+
+    <!--  TreeGrid  -->
+    <!--  TODO  -->
+
+    <!--  TreeView  -->
+    <SolidColorBrush x:Key="TreeViewItemBackground" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="TreeViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="TreeViewItemSelectionIndicatorForeground" Color="{StaticResource SystemColorHighlightColor}" />
+
+
+
+
+
+    <!--  Colors  -->
+    <!--  Colors copied from Default theme to match list of keys. Should not be using these keys. These are set to Red to notify that.  -->
+    <Color x:Key="TextFillColorPrimary">#FF0000</Color>
+    <Color x:Key="TextFillColorSecondary">#FF0000</Color>
+    <Color x:Key="TextFillColorTertiary">#FF0000</Color>
+    <Color x:Key="TextFillColorDisabled">#FF0000</Color>
+    <Color x:Key="TextPlaceholderColor">#FF0000</Color>
+    <Color x:Key="TextFillColorInverse">#FF0000</Color>
+
+    <Color x:Key="AccentTextFillColorDisabled">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorSelectedText">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorPrimary">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorSecondary">#FF0000</Color>
+    <Color x:Key="TextOnAccentFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlFillColorDisabled">#FF0000</Color>
+    <Color x:Key="ControlFillColorTransparent">#FF0000</Color>
+    <Color x:Key="ControlFillColorInputActive">#FF0000</Color>
+
+    <Color x:Key="ControlStrongFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrongFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlSolidFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="SubtleFillColorTransparent">#FF0000</Color>
+    <Color x:Key="SubtleFillColorSecondary">#FF0000</Color>
+    <Color x:Key="SubtleFillColorTertiary">#FF0000</Color>
+    <Color x:Key="SubtleFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlAltFillColorTransparent">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorQuarternary">#FF0000</Color>
+    <Color x:Key="ControlAltFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlOnImageFillColorDefault">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlOnImageFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="AccentFillColorDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorSecondary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorTertiary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDefault">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentSecondary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentTertiary">#FF0000</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF0000</Color>
+
+    <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FF0000</Color>
+
+    <Color x:Key="CardStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="CardStrokeColorDefaultSolid">#FF0000</Color>
+
+    <Color x:Key="ControlStrongStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="ControlStrongStrokeColorDisabled">#FF0000</Color>
+
+    <Color x:Key="SurfaceStrokeColorDefault">#FF0000</Color>
+    <Color x:Key="SurfaceStrokeColorFlyout">#FF0000</Color>
+    <Color x:Key="SurfaceStrokeColorInverse">#FF0000</Color>
+
+    <Color x:Key="DividerStrokeColorDefault">#FF0000</Color>
+
+    <Color x:Key="FocusStrokeColorOuter">#FF0000</Color>
+    <Color x:Key="FocusStrokeColorInner">#FF0000</Color>
+
+    <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
+    <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
+
+    <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="LayerFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerFillColorAlt">#FF0000</Color>
+    <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+
+    <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
+    <Color x:Key="AcrylicBackgroundFillColorDefault">#FF0000</Color>
+
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+
+    <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
+    <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
+
+    <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
+    <Color x:Key="SystemFillColorCaution">#FF0000</Color>
+    <Color x:Key="SystemFillColorCritical">#FF0000</Color>
+    <Color x:Key="SystemFillColorNeutral">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
+    <Color x:Key="SystemFillColorAttentionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSuccessBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorCautionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorCriticalBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorNeutralBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidAttentionBackground">#FF0000</Color>
+    <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+</ResourceDictionary>

--- a/src/Wpf.Ui/ThemeService.cs
+++ b/src/Wpf.Ui/ThemeService.cs
@@ -31,6 +31,10 @@ public partial class ThemeService : IThemeService
             SystemTheme.CapturedMotion => ApplicationTheme.Dark,
             SystemTheme.Sunrise => ApplicationTheme.Light,
             SystemTheme.Flow => ApplicationTheme.Light,
+            SystemTheme.HCBlack => ApplicationTheme.HighContrast,
+            SystemTheme.HC1 => ApplicationTheme.HighContrast,
+            SystemTheme.HC2 => ApplicationTheme.HighContrast,
+            SystemTheme.HCWhite => ApplicationTheme.HighContrast,
             _ => ApplicationTheme.Unknown
         };
     }


### PR DESCRIPTION
This PR:
- makes sure the right high contrast theme resource dictionary is loaded so that we can support all existing HC themes
- makes sure the background of a window is a solid color when in HC mode.

![ContrastWPfui](https://github.com/lepoco/wpfui/assets/9866362/cdf35c9e-cf27-43ac-9047-66f5b4e3e970)


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
