### PR TITLE
[Bugfix] Wrong ApplicationBackgroundColor defined in HC themes

### DIFF
--- a/src/Wpf.Ui/Resources/Theme/HC1.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC1.xaml
@@ -32,7 +32,7 @@
     <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>
 
 
-    <Color x:Key="ApplicationBackgroundColor">#FFFAEF</Color>
+    <Color x:Key="ApplicationBackgroundColor">#2D3236</Color>
     <!--  Same as SystemColorWindowColor  -->
     <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
 

--- a/src/Wpf.Ui/Resources/Theme/HC2.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC2.xaml
@@ -31,7 +31,7 @@
     <Color x:Key="SystemColorHotlightColor">#8080FF</Color>
     <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>
 
-    <Color x:Key="ApplicationBackgroundColor">#FFFAEF</Color>
+    <Color x:Key="ApplicationBackgroundColor">#000000</Color>
     <!--  Same as SystemColorWindowColor  -->
     <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
 

--- a/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
@@ -31,7 +31,7 @@
     <Color x:Key="SystemColorHotlightColor">#75E9FC</Color>
     <Color x:Key="SystemColorGrayTextColor">#A6A6A6</Color>
 
-    <Color x:Key="ApplicationBackgroundColor">#FFFAEF</Color>
+    <Color x:Key="ApplicationBackgroundColor">#202020</Color>
     <!--  Same as SystemColorWindowColor  -->
     <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
 


### PR DESCRIPTION
This PR updates the `ApplicationBackgroundColor`. The `SystemColorWindowColor` was defined correctly, but the `ApplicationBackgroundColor` should have the same value. 