### PR TITLE
Replacing FontSize property

### DIFF
--- a/src/Wpf.Ui/Controls/TextBlock/TextBlock.cs
+++ b/src/Wpf.Ui/Controls/TextBlock/TextBlock.cs
@@ -14,13 +14,6 @@ namespace Wpf.Ui.Controls;
 /// </summary>
 public class TextBlock : System.Windows.Controls.TextBlock
 {
-    static TextBlock()
-    {
-        TextElement
-            .FontSizeProperty
-            .OverrideMetadata(typeof(System.Windows.Controls.TextBlock), new FrameworkPropertyMetadata(14.0));
-    }
-
     /// <summary>
     /// Property for <see cref="FontTypography"/>.
     /// </summary>

--- a/src/Wpf.Ui/Controls/TextBlock/TextBlock.xaml
+++ b/src/Wpf.Ui/Controls/TextBlock/TextBlock.xaml
@@ -14,6 +14,7 @@
         <!--  The Display option causes a large aliasing effect  -->
         <!--<Setter Property="TextOptions.TextFormattingMode" Value="Ideal" />-->
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Focusable" Value="False" />


### PR DESCRIPTION
Moving the FontSize property from codebehind to style

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When a UI library is loaded as a plugin in another program (.dll project, instead of a separate single .exe), OverrideMetadata breaks text sizes in the whole application, because it overrides the text size of the whole domain. I suggest not to override DependencyProperty, but to set the value in the style of

As an example, you can run https://github.com/snoopwpf/snoopwpf and notice the increased text size after calling OverrideMetadata, without it this is not observed
