### PR TITLE
SymbolIcon preview

### DIFF
--- a/src/Wpf.Ui/Markup/SymbolIconExtension.cs
+++ b/src/Wpf.Ui/Markup/SymbolIconExtension.cs
@@ -37,6 +37,11 @@ public class SymbolIconExtension : MarkupExtension
         Symbol = symbol;
     }
 
+    public SymbolIconExtension(string symbol)
+    {
+        Symbol = (SymbolRegular)Enum.Parse(typeof(SymbolRegular), symbol);
+    }
+
     public SymbolIconExtension(SymbolRegular symbol, bool filled)
         : this(symbol)
     {


### PR DESCRIPTION
JetBrains Rider window preview support

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

I don't know about VS, but Rider doesn't understand this syntax and needs a string converter. If we add it, the preview starts working. Maybe you know a better way?

Before
![изображение](https://github.com/lepoco/wpfui/assets/20504884/1d3f84fe-a3d4-48c0-b60b-439120d839f5)

After
![изображение](https://github.com/lepoco/wpfui/assets/20504884/2945cdf6-6419-4fdd-a9e8-0e840408466c)
