### PR TITLE
ContentDialog restore height during resizing

### DIFF
--- a/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.cs
@@ -677,12 +677,13 @@ public class ContentDialog : ContentControl
     private Size GetNewDialogSize(Size desiredSize)
     {
         var paddingWidth = Padding.Left + Padding.Right;
+        var paddingHeight = Padding.Top + Padding.Bottom;
 
         var marginHeight = DialogMargin.Bottom + DialogMargin.Top;
         var marginWidth = DialogMargin.Left + DialogMargin.Right;
 
         var width = desiredSize.Width - marginWidth + paddingWidth;
-        var height = desiredSize.Height - marginHeight;
+        var height = desiredSize.Height - marginHeight + paddingHeight;
 
         return new Size(width, height);
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The dialogue height is flattened and not restored. Missing Padding in computation?

https://github.com/lepoco/wpfui/assets/20504884/dc40fee7-2ac8-4623-94a2-a8188e7a5b16

## What is the new behavior?

Height recovery is back
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://github.com/lepoco/wpfui/assets/20504884/9f8d60f0-6b1b-4f04-a923-1ced0076f3f3

