### PR TITLE
Various brush fixes

### DIFF
--- a/src/Wpf.Ui.SyntaxHighlight/Controls/CodeBlock.xaml
+++ b/src/Wpf.Ui.SyntaxHighlight/Controls/CodeBlock.xaml
@@ -14,16 +14,8 @@
     <Thickness x:Key="CodeBlockBorderThemeThickness">1</Thickness>
 
     <Style TargetType="{x:Type syntax:CodeBlock}">
-        <Setter Property="Background">
-            <Setter.Value>
-                <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
-            </Setter.Value>
-        </Setter>
-        <Setter Property="Foreground">
-            <Setter.Value>
-                <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Background" Value="{DynamicResource ControlFillColorDefaultBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
         <Setter Property="Padding" Value="{StaticResource CodeBlockPadding}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource CodeBlockBorderThemeThickness}" />

--- a/src/Wpf.Ui/Controls/Badge/Badge.xaml
+++ b/src/Wpf.Ui/Controls/Badge/Badge.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     This Source Code Form is subject to the terms of the MIT License.
     If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
@@ -11,16 +11,8 @@
     xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
     <Style TargetType="{x:Type controls:Badge}">
-        <Setter Property="Foreground">
-            <Setter.Value>
-                <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
-            </Setter.Value>
-        </Setter>
-        <Setter Property="Background">
-            <Setter.Value>
-                <SolidColorBrush Color="{DynamicResource SystemAccentColorSecondary}" />
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Foreground" Value="{DynamicResource BadgeForeground}"/>
+        <Setter Property="Background" Value="{DynamicResource BadgeBackground}"/>
         <!--<Setter Property="BorderBrush" Value="{DynamicResource SystemAccentBrush}" />-->
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="Padding" Value="4" />
@@ -41,11 +33,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="Appearance" Value="Primary">
-                            <Setter Property="Foreground">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource TextOnAccentFillColorPrimary}" />
-                                </Setter.Value>
-                            </Setter>
+                            <Setter Property="Foreground" Value="{DynamicResource BadgeForeground}"/>
                         </Trigger>
                         <Trigger Property="Appearance" Value="Transparent">
                             <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />

--- a/src/Wpf.Ui/Controls/CardColor/CardColor.xaml
+++ b/src/Wpf.Ui/Controls/CardColor/CardColor.xaml
@@ -43,11 +43,8 @@
                             <TextBlock
                                 Margin="0"
                                 FontSize="{TemplateBinding SubtitleFontSize}"
-                                Text="{TemplateBinding Subtitle}">
-                                <TextBlock.Foreground>
-                                    <SolidColorBrush Color="{DynamicResource CardForegroundPressed}" />
-                                </TextBlock.Foreground>
-                            </TextBlock>
+                                Foreground="{DynamicResource CardForegroundPressed}"
+                                Text="{TemplateBinding Subtitle}" />
                         </StackPanel>
                     </Border>
                 </ControlTemplate>

--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -14,7 +14,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
-    xmlns:converters="clr-namespace:Wpf.Ui.Converters"
     xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
@@ -138,11 +137,7 @@
                             <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ComboBoxItemForegroundSelected}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource ComboBoxItemForeground}" />
-                                </Setter.Value>
-                            </Setter>
+                            <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
@@ -192,14 +192,11 @@
                     BorderBrush="{DynamicResource FlyoutBackground}"
                     BorderThickness="1"
                     CornerRadius="8"
+                    Background="{DynamicResource FlyoutBorderBrush}"
                     SnapsToDevicePixels="True">
                     <Border.RenderTransform>
                         <TranslateTransform />
                     </Border.RenderTransform>
-                    <Border.Background>
-                        <SolidColorBrush Color="{DynamicResource FlyoutBorderBrush}" />
-                    </Border.Background>
-
                     <Border.Effect>
                         <DropShadowEffect
                             BlurRadius="20"

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -145,6 +145,7 @@
                             <!--  Main application title  -->
                             <TextBlock
                                 Grid.Column="1"
+                                FontSize="12"
                                 VerticalAlignment="Center"
                                 Text="{TemplateBinding Title}" />
                         </Grid>

--- a/src/Wpf.Ui/Resources/Theme/Dark.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Dark.xaml
@@ -317,8 +317,9 @@
     <!--  Control brushes  -->
 
     <!--  Badge  -->
-    <!--  TODO  -->
-
+    <SolidColorBrush x:Key="BadgeForeground" Color="{StaticResource TextOnAccentFillColorPrimary}"/>
+    <SolidColorBrush x:Key="BadgeBackground" Color="{StaticResource SystemAccentColorPrimary}"/>
+    
     <!--  BreadcrumbBar  -->
     <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="BreadcrumbBarHoverForegroundBrush" Color="{StaticResource TextFillColorSecondary}" />

--- a/src/Wpf.Ui/Resources/Theme/HC1.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC1.xaml
@@ -204,7 +204,8 @@
     <!--  Control brushes  -->
 
     <!--  Badge  -->
-    <!--  TODO  -->
+    <SolidColorBrush x:Key="BadgeForeground" Color="{StaticResource SystemColorHighlightTextColor}"/>
+    <SolidColorBrush x:Key="BadgeBackground" Color="{StaticResource SystemColorHighlightColor}"/>
 
     <!--  BreadcrumbBar  -->
     <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HC2.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC2.xaml
@@ -203,7 +203,8 @@
     <!--  Control brushes  -->
 
     <!--  Badge  -->
-    <!--  TODO  -->
+    <SolidColorBrush x:Key="BadgeForeground" Color="{StaticResource SystemColorHighlightTextColor}"/>
+    <SolidColorBrush x:Key="BadgeBackground" Color="{StaticResource SystemColorHighlightColor}"/>
 
     <!--  BreadcrumbBar  -->
     <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
@@ -203,7 +203,8 @@
     <!--  Control brushes  -->
 
     <!--  Badge  -->
-    <!--  TODO  -->
+    <SolidColorBrush x:Key="BadgeForeground" Color="{StaticResource SystemColorHighlightTextColor}"/>
+    <SolidColorBrush x:Key="BadgeBackground" Color="{StaticResource SystemColorHighlightColor}"/>
 
     <!--  BreadcrumbBar  -->
     <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
@@ -203,7 +203,8 @@
     <!--  Control brushes  -->
 
     <!--  Badge  -->
-    <!--  TODO  -->
+    <SolidColorBrush x:Key="BadgeForeground" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="BadgeBackground" Color="{StaticResource SystemColorHighlightColor}" />
 
     <!--  BreadcrumbBar  -->
     <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -317,7 +317,8 @@
     <!--  Control brushes  -->
 
     <!--  Badge  -->
-    <!--  TODO  -->
+    <SolidColorBrush x:Key="BadgeForeground" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="BadgeBackground" Color="{StaticResource SystemAccentColorPrimary}" />
 
     <!--  BreadcrumbBar  -->
     <SolidColorBrush x:Key="BreadcrumbBarNormalForegroundBrush" Color="{StaticResource TextFillColorPrimary}" />


### PR DESCRIPTION
This PR introduces the following changes:
- Setting the default `TitleBar` fontsize to 12, which is inline with Fluent Design guidelines
- A brush was set as a color, causing a crash whenever a `ComboBoxItem` was disabled: #794 
- A brush was set as a color, causing a crash whenever a `NavigationView` was in top mode: #797
- Adding dedicated `Badge` brushes to the resource dictionaries

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
