### PR TITLE
Scrollbar fixes

### DIFF
--- a/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
@@ -2,7 +2,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
-    xmlns:converters="clr-namespace:Wpf.Ui.Converters"
     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <Duration x:Key="DynamicScrollAnimationDuration">0:0:0.16</Duration>
@@ -16,6 +15,7 @@
         <Setter Property="Width" Value="{StaticResource DynamicLineButtonWidth}" />
         <Setter Property="Height" Value="{StaticResource DynamicLineButtonHeight}" />
         <Setter Property="Margin" Value="0" />
+        <Setter Property="FontSize" Value="11" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Focusable" Value="False" />
@@ -34,7 +34,7 @@
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
                             Filled="True"
-                            FontSize="12"
+                            FontSize="{TemplateBinding FontSize}"
                             Foreground="{TemplateBinding Foreground}"
                             Symbol="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
                     </Border>
@@ -112,6 +112,14 @@
                 <RowDefinition Height="0.00001*" />
                 <RowDefinition MaxHeight="14" />
             </Grid.RowDefinitions>
+            <Border
+                x:Name="PART_Border"
+                Grid.RowSpan="3"
+                Width="12"
+                HorizontalAlignment="Center"
+                Background="{DynamicResource ScrollBarTrackFillPointerOver}"
+                CornerRadius="6"
+                Opacity="0" />
             <RepeatButton
                 x:Name="PART_ButtonScrollUp"
                 Grid.Row="0"
@@ -158,7 +166,13 @@
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Width"
                                 From="6"
-                                To="10"
+                                To="8"
+                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                            <DoubleAnimation
+                                Storyboard.TargetName="PART_Border"
+                                Storyboard.TargetProperty="Opacity"
+                                From="0.0"
+                                To="1.0"
                                 Duration="{StaticResource DynamicScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollUp"
@@ -181,8 +195,14 @@
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Width"
-                                From="10"
+                                From="8"
                                 To="6"
+                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                            <DoubleAnimation
+                                Storyboard.TargetName="PART_Border"
+                                Storyboard.TargetProperty="Opacity"
+                                From="1.0"
+                                To="0.0"
                                 Duration="{StaticResource DynamicScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollUp"
@@ -236,6 +256,14 @@
                 <ColumnDefinition Width="0.00001*" />
                 <ColumnDefinition MaxWidth="18" />
             </Grid.ColumnDefinitions>
+            <Border
+                x:Name="PART_Border"
+                Grid.ColumnSpan="3"
+                Height="12"
+                VerticalAlignment="Center"
+                Background="{DynamicResource ScrollBarButtonBackground}"
+                CornerRadius="6"
+                Opacity="0" />
 
             <RepeatButton
                 x:Name="PART_ButtonScrollLeft"
@@ -285,7 +313,13 @@
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Height"
                                 From="6"
-                                To="10"
+                                To="8"
+                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                            <DoubleAnimation
+                                Storyboard.TargetName="PART_Border"
+                                Storyboard.TargetProperty="Opacity"
+                                From="0.0"
+                                To="1.0"
                                 Duration="{StaticResource DynamicScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollLeft"
@@ -308,8 +342,14 @@
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Height"
-                                From="10"
+                                From="8"
                                 To="6"
+                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                            <DoubleAnimation
+                                Storyboard.TargetName="PART_Border"
+                                Storyboard.TargetProperty="Opacity"
+                                From="1.0"
+                                To="0.0"
                                 Duration="{StaticResource DynamicScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollLeft"

--- a/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
@@ -9,7 +9,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
-    xmlns:converters="clr-namespace:Wpf.Ui.Converters"
     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <Duration x:Key="ScrollAnimationDuration">0:0:0.16</Duration>
@@ -22,7 +21,7 @@
         <Setter Property="Foreground" Value="{DynamicResource ScrollBarButtonArrowForeground}" />
         <Setter Property="Width" Value="{StaticResource LineButtonWidth}" />
         <Setter Property="Height" Value="{StaticResource LineButtonHeight}" />
-        <Setter Property="FontSize" Value="12" />
+        <Setter Property="FontSize" Value="11" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -125,12 +124,13 @@
                 Grid.RowSpan="3"
                 Width="12"
                 HorizontalAlignment="Center"
-                Background="{DynamicResource ScrollBarButtonBackground}"
+                Background="{DynamicResource ScrollBarTrackFillPointerOver}"
                 CornerRadius="6"
                 Opacity="0" />
             <RepeatButton
                 x:Name="PART_ButtonScrollUp"
                 Grid.Row="0"
+                HorizontalContentAlignment="Left"
                 Command="ScrollBar.LineUpCommand"
                 Content="{x:Static controls:SymbolRegular.CaretUp24}"
                 Opacity="0"
@@ -159,6 +159,7 @@
             <RepeatButton
                 x:Name="PART_ButtonScrollDown"
                 Grid.Row="2"
+                HorizontalContentAlignment="Left"
                 Command="ScrollBar.LineDownCommand"
                 Content="{x:Static controls:SymbolRegular.CaretDown24}"
                 Opacity="0"
@@ -173,7 +174,7 @@
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Width"
                                 From="6"
-                                To="10"
+                                To="8"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
@@ -202,7 +203,7 @@
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Width"
-                                From="10"
+                                From="8"
                                 To="6"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation
@@ -241,10 +242,10 @@
                 x:Name="PART_Border"
                 Grid.ColumnSpan="3"
                 Height="12"
-                Opacity="0"
-                Background="{DynamicResource ScrollBarButtonBackground}"
                 VerticalAlignment="Center"
-                CornerRadius="6"/>
+                Background="{DynamicResource ScrollBarButtonBackground}"
+                CornerRadius="6"
+                Opacity="0" />
 
             <RepeatButton
                 x:Name="PART_ButtonScrollLeft"
@@ -291,7 +292,7 @@
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Height"
                                 From="6"
-                                To="10"
+                                To="8"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
@@ -320,7 +321,7 @@
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Height"
-                                From="10"
+                                From="8"
                                 To="6"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation

--- a/src/Wpf.Ui/Controls/ScrollViewer/ScrollViewer.xaml
+++ b/src/Wpf.Ui/Controls/ScrollViewer/ScrollViewer.xaml
@@ -1,11 +1,14 @@
-﻿<!--
+<!--
     This Source Code Form is subject to the terms of the MIT License.
     If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
     <Style x:Key="UiScrollViewer" TargetType="{x:Type ScrollViewer}">
         <Setter Property="Margin" Value="0" />
@@ -34,7 +37,9 @@
                         -->
                         <Grid
                             Grid.Row="0"
+                            Grid.RowSpan="2"
                             Grid.Column="0"
+                            Grid.ColumnSpan="2"
                             Margin="{TemplateBinding Padding}">
                             <ScrollContentPresenter CanContentScroll="{TemplateBinding CanContentScroll}" />
                         </Grid>
@@ -64,5 +69,5 @@
     </Style>
 
     <Style BasedOn="{StaticResource UiScrollViewer}" TargetType="{x:Type ScrollViewer}" />
-
+    <Style BasedOn="{StaticResource UiScrollViewer}" TargetType="{x:Type controls:PassiveScrollViewer}" />
 </ResourceDictionary>

--- a/src/Wpf.Ui/Resources/Theme/Dark.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Dark.xaml
@@ -428,6 +428,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource ControlStrongFillColorDefault}" />

--- a/src/Wpf.Ui/Resources/Theme/Dark.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Dark.xaml
@@ -428,7 +428,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
-    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource ControlStrongFillColorDefault}" />

--- a/src/Wpf.Ui/Resources/Theme/HC1.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC1.xaml
@@ -318,6 +318,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HC2.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC2.xaml
@@ -317,6 +317,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
@@ -317,6 +317,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
@@ -317,6 +317,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource SystemColorButtonTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -428,6 +428,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource ControlStrongFillColorDefault}" />

--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -428,7 +428,7 @@
     <!--  TODO  -->
 
     <!--  DynamicScrollBar  -->
-    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
     <SolidColorBrush x:Key="ScrollBarThumbFill" Color="{StaticResource ControlStrongFillColorDefault}" />


### PR DESCRIPTION
### Updated the (Dynamic)ScrollBar default style to be more inline with WinUI addressing: #872
- Added on hover background color (couldn't use `InAppAcrylicDefaultBrush` like in WinUI, but used the replacement color we also use for e.g. `Flyout`)
- Decreased scrollbar thumb width based on WinUI spec
- Decreased icon fontsize so it's centered and inline with WinUI spec

Before:
![image](https://github.com/lepoco/wpfui/assets/9866362/dc2f5faf-3ecf-42bf-ab1a-ca06069fa9b9)

After:
![image](https://github.com/lepoco/wpfui/assets/9866362/dcc5beff-7674-43e1-bfc6-46c9d0b9d894)


### ScrollBar now overlaps content, addressing: #871
- Tweaked the default `ScrollViewer` style so it overlaps its content
- Set a default style for `PassiveScrollViewer` so it uses the `ScrollViewer` style as well (as `ListView` uses `PassiveScrollViewer`)
Before:
![image](https://github.com/lepoco/wpfui/assets/9866362/89702106-db2d-4b72-a5d2-1fe4ea9281f5)

After:
![image](https://github.com/lepoco/wpfui/assets/9866362/4666a175-f34c-4ebc-b791-fa8eda4f6a13)
