### PR TITLE
Add CardAction page to the Gallery App #875

### DIFF
--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/Layout/CardActionViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/Layout/CardActionViewModel.cs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+namespace Wpf.Ui.Gallery.ViewModels.Pages.Layout;
+public partial class CardActionViewModel : ObservableObject
+{
+    public CardActionViewModel() { }
+}

--- a/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
@@ -105,7 +105,8 @@ public partial class MainWindowViewModel : ObservableObject
             MenuItems = new object[]
             {
                 new NavigationViewItem("Expander", typeof(ExpanderPage)),
-                new NavigationViewItem("CardControl", typeof(CardControlPage))
+                new NavigationViewItem("CardControl", typeof(CardControlPage)),
+                new NavigationViewItem("CardAction", typeof(CardActionPage))
             },
         },
 #endif

--- a/src/Wpf.Ui.Gallery/Views/Pages/Layout/CardActionPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Layout/CardActionPage.xaml
@@ -1,0 +1,68 @@
+<Page
+    x:Class="Wpf.Ui.Gallery.Views.Pages.Layout.CardActionPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Gallery.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Wpf.Ui.Gallery.Views.Pages.Layout"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="CardActionPage"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    mc:Ignorable="d">
+    <StackPanel Margin="0,0,0,24">
+        <controls:ControlExample
+            Margin="0"
+            HeaderText="A CardAction with an ImageIcon and a header."
+            XamlCode="&lt;ui:CardAction Icon=&quot;{ui:ImageIcon 'pack://application:,,,/Assets/wpfui.png'}&quot; /&gt;">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ui:CardAction Grid.Column="0" Icon="{ui:ImageIcon 'pack://application:,,,/Assets/wpfui.png'}">
+                    <StackPanel>
+                        <ui:TextBlock
+                            Margin="0"
+                            FontTypography="Body"
+                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                            Text="This is the header text"
+                            TextWrapping="WrapWithOverflow" />
+                    </StackPanel>
+                </ui:CardAction>
+            </Grid>
+        </controls:ControlExample>
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            HeaderText="A CardAction with an icon, a header and a description."
+            XamlCode="&lt;ui:CardAction Icon=&quot;{ui:SymbolIcon Fluent24}&quot; /&gt;">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ui:CardAction Grid.Column="0" Icon="{ui:SymbolIcon DocumentEdit20, FontSize=43, Filled=False}">
+                    <StackPanel>
+                        <ui:TextBlock
+                            Margin="0"
+                            FontTypography="BodyStrong"
+                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                            Text="This is the header text"
+                            TextWrapping="WrapWithOverflow" />
+                        <ui:TextBlock
+                            Appearance="Secondary"
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                            Text="This is a description text."
+                            TextWrapping="WrapWithOverflow" />
+                    </StackPanel>
+                </ui:CardAction>
+            </Grid>
+        </controls:ControlExample>
+
+    </StackPanel>
+</Page>

--- a/src/Wpf.Ui.Gallery/Views/Pages/Layout/CardActionPage.xaml.cs
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Layout/CardActionPage.xaml.cs
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Wpf.Ui.Controls;
+using Wpf.Ui.Gallery.ControlsLookup;
+using Wpf.Ui.Gallery.ViewModels.Pages.Layout;
+
+namespace Wpf.Ui.Gallery.Views.Pages.Layout;
+/// <summary>
+/// Interaction logic for CardActionPage.xaml
+/// </summary>
+[GalleryPage("Card action control.", SymbolRegular.Code24)]
+public partial class CardActionPage : INavigableView<CardActionViewModel>
+{
+    public CardActionPage(CardActionViewModel viewModel)
+    {
+        InitializeComponent();
+        ViewModel = viewModel;
+    }
+
+    public CardActionViewModel ViewModel { get; }
+}

--- a/src/Wpf.Ui.Gallery/Views/Pages/Layout/CardControlPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Layout/CardControlPage.xaml
@@ -9,32 +9,110 @@
     xmlns:system="clr-namespace:System;assembly=System.Runtime"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="CardControlPage"
-    d:DesignHeight="450"
+    d:DesignHeight="750"
     d:DesignWidth="800"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
+    <StackPanel Margin="0,0,0,24">
+        <controls:ControlExample
+            Margin="0"
+            HeaderText="A card control with a header and a button."
+            XamlCode="&lt;ui:CardControl Header=&quot;This is the header text.&quot; /&gt;">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ui:CardControl Grid.Column="0">
+                    <ui:CardControl.Header>
+                        <TextBlock Text="This is the header text." />
+                    </ui:CardControl.Header>
+                    <ui:CardControl.Content>
+                        <ui:Button Content="Button" />
+                    </ui:CardControl.Content>
+                </ui:CardControl>
+            </Grid>
+        </controls:ControlExample>
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            HeaderText="A card control with an icon, a header, a description, and a control"
+            XamlCode="&lt;ui:CardControl Icon=&quot;{ui:SymbolIcon FlashSettings24}&quot; /&gt;">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ui:CardControl
+                    Margin="4"
+                    Padding="20,10,20,10"
+                    Icon="{ui:SymbolIcon FlashSettings24}">
+                    <ui:CardControl.Header>
+                        <StackPanel>
+                            <ui:TextBlock
+                                Margin="0"
+                                FontTypography="BodyStrong"
+                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                Text="This is the header text"
+                                TextWrapping="WrapWithOverflow" />
+                            <ui:TextBlock
+                                Appearance="Secondary"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Text="This is a description text."
+                                TextWrapping="WrapWithOverflow" />
+                        </StackPanel>
+                    </ui:CardControl.Header>
+                    <ui:ToggleSwitch
+                        HorizontalContentAlignment="Left"
+                        IsEnabled="True"
+                        OffContent="Off"
+                        OnContent="On" />
+                </ui:CardControl>
+            </Grid>
+        </controls:ControlExample>
 
-    <controls:ControlExample
-        Margin="0"
-        HeaderText="A card control with a header and a button."
-        XamlCode="&lt;ui:CardControl Header=&quot;This is the header text.&quot; /&gt;">
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <ui:CardControl Grid.Column="0">
-                <ui:CardControl.Header>
-                    <TextBlock Text="This is the header text." />
-                </ui:CardControl.Header>
-                <ui:CardControl.Content>
-                    <ui:Button Content="Button" />
-                </ui:CardControl.Content>
-            </ui:CardControl>
-
-        </Grid>
-    </controls:ControlExample>
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            HeaderText="A card control with an ImageIcon, a header, a description, and a DropDownButton"
+            XamlCode="&lt;ui:CardControl Icon=&quot;{ui:ImageIcon 'pack://application:,,,/Assets/wpfui.png'}&quot; /&gt;">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ui:CardControl
+                    Margin="4"
+                    Padding="20,10,20,10"
+                    Icon="{ui:ImageIcon 'pack://application:,,,/Assets/wpfui.png'}">
+                    <ui:CardControl.Header>
+                        <StackPanel>
+                            <ui:TextBlock
+                                Margin="0"
+                                FontTypography="BodyStrong"
+                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                Text="This is the header text"
+                                TextWrapping="WrapWithOverflow" />
+                            <ui:TextBlock
+                                Appearance="Secondary"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Text="This is a description text."
+                                TextWrapping="WrapWithOverflow" />
+                        </StackPanel>
+                    </ui:CardControl.Header>
+                    <ui:DropDownButton Content="Hello" Icon="{ui:SymbolIcon Fluent24}">
+                        <ui:DropDownButton.Flyout>
+                            <ContextMenu>
+                                <MenuItem Header="Add" />
+                                <MenuItem Header="Remove" />
+                                <MenuItem Header="Send" />
+                                <MenuItem Header="Hello" />
+                            </ContextMenu>
+                        </ui:DropDownButton.Flyout>
+                    </ui:DropDownButton>
+                </ui:CardControl>
+            </Grid>
+        </controls:ControlExample>
+    </StackPanel>
     <!--  TODO: Add CardAction  -->
 </Page>

--- a/src/Wpf.Ui.Gallery/Views/Pages/Layout/ExpanderPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Layout/ExpanderPage.xaml
@@ -16,7 +16,7 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid Margin="0,0,0,24">
+    <StackPanel Margin="0,0,0,24">
         <controls:ControlExample
             Margin="0"
             HeaderText="An Expander with text in the header and content areas"
@@ -30,9 +30,94 @@
                     Grid.Column="0"
                     Content="This is in the content"
                     Header="This text is in the header" />
-
                 <!--  TODO: ExpandDirection  -->
             </Grid>
         </controls:ControlExample>
-    </Grid>
+
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            HeaderText="An Expander with an Icon, a header text, a description, a control, and content areas"
+            XamlCode="&lt;Expander Icon=&quot;{ui:SymbolIcon PlaySettings20}&quot;/&gt;">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ui:CardExpander Grid.Column="0" Icon="{ui:SymbolIcon PlaySettings20}">
+                    <ui:CardExpander.Header>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ui:TextBlock
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                FontSize="16"
+                                FontTypography="Body"
+                                Text="This is a header text" />
+                            <ui:TextBlock
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                FontSize="12"
+                                Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
+                                Text="This is a description text" />
+                            <ui:ToggleSwitch
+                                Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                Margin="0,0,16,0"
+                                OffContent="Off"
+                                OnContent="On" />
+                        </Grid>
+                    </ui:CardExpander.Header>
+                    <StackPanel Margin="24,0.5,24,0">
+                        <ui:CardControl Padding="20,10,20,10" Header="This is an item">
+                            <ui:ToggleSwitch
+                                HorizontalContentAlignment="Left"
+                                IsEnabled="True"
+                                OffContent="Off"
+                                OnContent="On" />
+                        </ui:CardControl>
+                        <ui:CardControl
+                            Margin="0,0.5,0,0"
+                            Padding="20,10,20,10"
+                            Icon="{ui:SymbolIcon FlashSettings24}">
+                            <ui:CardControl.Header>
+                                <StackPanel>
+                                    <ui:TextBlock
+                                        Margin="0"
+                                        FontTypography="BodyStrong"
+                                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                        Text="This is a header text"
+                                        TextWrapping="WrapWithOverflow" />
+                                    <ui:TextBlock
+                                        Appearance="Secondary"
+                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                        Text="This is a description text."
+                                        TextWrapping="WrapWithOverflow" />
+                                </StackPanel>
+                            </ui:CardControl.Header>
+                            <ui:DropDownButton Content="Hello" Icon="{ui:SymbolIcon Fluent24}">
+                                <ui:DropDownButton.Flyout>
+                                    <ContextMenu>
+                                        <MenuItem Header="Add" />
+                                        <MenuItem Header="Remove" />
+                                        <MenuItem Header="Send" />
+                                        <MenuItem Header="Hello" />
+                                    </ContextMenu>
+                                </ui:DropDownButton.Flyout>
+                            </ui:DropDownButton>
+
+                        </ui:CardControl>
+                    </StackPanel>
+                </ui:CardExpander>
+                <!--  TODO: ExpandDirection  -->
+            </Grid>
+        </controls:ControlExample>
+    </StackPanel>
 </Page>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
A new page that shows different examples of the CardAction control has been added to the Gallery app. In addition, more CardControl examples having different content structure have been included in the CardControl page. 
  
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 875

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
