### PR TITLE
Update readonly numberbox to prohibit changing values via keyboard / buttons

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -264,6 +264,11 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
     {
         base.OnKeyUp(e);
 
+        if(IsReadOnly)
+        {
+            return;
+        }
+
         switch (e.Key)
         {
             case Key.PageUp:

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -235,6 +235,7 @@
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />
                         </MultiTrigger>
                         <Trigger Property="IsReadOnly" Value="True">
+                            <Setter Property="SpinButtonPlacementMode" Value="Hidden" />
                             <Setter TargetName="ClearButton" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="ClearButton" Property="Margin" Value="0" />
                         </Trigger>


### PR DESCRIPTION
## Pull request type

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently if a numberbox is set to readonly, one can still change the value by keyboard up/down arrow, page up / page down, and the spin buttons.

Issue Number: N/A

## What is the new behavior?

If a numberbox is set to readonly, one cannot change its value.  Whether by attempting to type a new value, up/down arrows, and the spin buttons are hidden (similar to the existing behavior of how the clear button is hidden).