### PR TITLE
Fix issue 674: Dragging no longer works when SizeToContent is set on Window

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -446,11 +446,7 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
         _currentWindow =
             System.Windows.Window.GetWindow(this) ?? throw new ArgumentNullException("Window is null");
         _currentWindow.StateChanged += OnParentWindowStateChanged;
-
-        var handle = new WindowInteropHelper(_currentWindow).EnsureHandle();
-        var windowSource =
-            HwndSource.FromHwnd(handle) ?? throw new ArgumentNullException("Window source is null");
-        windowSource.AddHook(HwndSourceHook);
+        _currentWindow.ContentRendered += OnWindowContentRendered;
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -581,6 +577,19 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
                 RaiseEvent(new RoutedEventArgs(HelpClickedEvent, this));
                 break;
         }
+    }
+
+    /// <summary>
+    ///     Listening window hooks after rendering window content to SizeToContent support
+    /// </summary>
+    private void OnWindowContentRendered(object sender, EventArgs e)
+    {
+        var window = (Window)sender;
+        window.ContentRendered -= OnWindowContentRendered;
+
+        var handle = new WindowInteropHelper(window).Handle;
+        var windowSource = HwndSource.FromHwnd(handle) ?? throw new ArgumentNullException("Window source is null");
+        windowSource.AddHook(HwndSourceHook);
     }
 
     private IntPtr HwndSourceHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)


### PR DESCRIPTION
Fix for issue 674. If we subscribe to the ContentRendered window event, Hook will start receiving NCHITTEST messages properly

https://github.com/lepoco/wpfui/issues/674

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes