### PR TITLE
make `NavigationService` throw-helpers `protected` (instead of `private`)

### DIFF
--- a/src/Wpf.Ui/NavigationService.cs
+++ b/src/Wpf.Ui/NavigationService.cs
@@ -128,7 +128,7 @@ public partial class NavigationService : INavigationService
         return NavigationControl!.NavigateWithHierarchy(pageType, dataContext);
     }
 
-    private void ThrowIfNavigationControlIsNull()
+    protected void ThrowIfNavigationControlIsNull()
     {
         if (NavigationControl is null)
         {

--- a/src/Wpf.Ui/NavigationService.cs
+++ b/src/Wpf.Ui/NavigationService.cs
@@ -104,7 +104,7 @@ public partial class NavigationService : INavigationService
         return NavigationControl!.NavigateWithHierarchy(pageType);
     }
 
-    private void ThrowIfNavigationControlIsNull()
+    protected void ThrowIfNavigationControlIsNull()
     {
         if (NavigationControl is null)
         {
@@ -112,7 +112,7 @@ public partial class NavigationService : INavigationService
         }
     }
 
-    private void ThrowIfPageServiceIsNull()
+    protected void ThrowIfPageServiceIsNull()
     {
         if (_pageService is null)
         {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

`NavigationService` has their throw-helpers declared with `private` modifier, which made derived classes difficult.

Issue Number: N/A

## What is the new behavior?

- Make them `protected` so they can be used in derived classes.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
