### PR TITLE
[NavSvc] make `INavigationService.Navigate*()` accepts `dataContext` as argument

### DIFF
--- a/src/Wpf.Ui/INavigationService.cs
+++ b/src/Wpf.Ui/INavigationService.cs
@@ -21,6 +21,14 @@ public interface INavigationService
     bool Navigate(Type pageType);
 
     /// <summary>
+    /// Lets you navigate to the selected page based on it's type, Should be used with <see cref="IPageService"/>.
+    /// </summary>
+    /// <param name="pageType"><see langword="Type"/> of the page.</param>
+    /// <param name="dataContext">DataContext <see cref="Object"/></param>
+    /// <returns><see langword="true"/> if the operation succeeds. <see langword="false"/> otherwise.</returns>
+    bool Navigate(Type pageType, object? dataContext);
+
+    /// <summary>
     /// Lets you navigate to the selected page based on it's tag. Should be used with <see cref="IPageService"/>.
     /// </summary>
     /// <param name="pageIdOrTargetTag">Id or tag of the page.</param>
@@ -28,11 +36,27 @@ public interface INavigationService
     bool Navigate(string pageIdOrTargetTag);
 
     /// <summary>
+    /// Lets you navigate to the selected page based on it's tag. Should be used with <see cref="IPageService"/>.
+    /// </summary>
+    /// <param name="pageIdOrTargetTag">Id or tag of the page.</param>
+    /// <param name="dataContext">DataContext <see cref="Object"/></param>
+    /// <returns><see langword="true"/> if the operation succeeds. <see langword="false"/> otherwise.</returns>
+    bool Navigate(string pageIdOrTargetTag, object? dataContext);
+
+    /// <summary>
     /// Synchronously adds an element to the navigation stack and navigates current navigation Frame to the
     /// </summary>
     /// <param name="pageType">Type of control to be synchronously added to the navigation stack</param>
     /// <returns><see langword="true"/> if the operation succeeds. <see langword="false"/> otherwise.</returns>
     bool NavigateWithHierarchy(Type pageType);
+
+    /// <summary>
+    /// Synchronously adds an element to the navigation stack and navigates current navigation Frame to the
+    /// </summary>
+    /// <param name="pageType">Type of control to be synchronously added to the navigation stack</param>
+    /// <param name="dataContext">DataContext <see cref="Object"/></param>
+    /// <returns><see langword="true"/> if the operation succeeds. <see langword="false"/> otherwise.</returns>
+    bool NavigateWithHierarchy(Type pageType, object? dataContext);
 
     /// <summary>
     /// Provides direct access to the control responsible for navigation.

--- a/src/Wpf.Ui/NavigationService.cs
+++ b/src/Wpf.Ui/NavigationService.cs
@@ -81,11 +81,27 @@ public partial class NavigationService : INavigationService
     }
 
     /// <inheritdoc />
+    public bool Navigate(Type pageType, object? dataContext)
+    {
+        ThrowIfNavigationControlIsNull();
+
+        return NavigationControl!.Navigate(pageType, dataContext);
+    }
+
+    /// <inheritdoc />
     public bool Navigate(string pageTag)
     {
         ThrowIfNavigationControlIsNull();
 
         return NavigationControl!.Navigate(pageTag);
+    }
+
+    /// <inheritdoc />
+    public bool Navigate(string pageTag, object? dataContext)
+    {
+        ThrowIfNavigationControlIsNull();
+
+        return NavigationControl!.Navigate(pageTag, dataContext);
     }
 
     /// <inheritdoc />
@@ -102,6 +118,14 @@ public partial class NavigationService : INavigationService
         ThrowIfNavigationControlIsNull();
 
         return NavigationControl!.NavigateWithHierarchy(pageType);
+    }
+
+    /// <inheritdoc />
+    public bool NavigateWithHierarchy(Type pageType, object? dataContext)
+    {
+        ThrowIfNavigationControlIsNull();
+
+        return NavigationControl!.NavigateWithHierarchy(pageType, dataContext);
     }
 
     private void ThrowIfNavigationControlIsNull()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

`INavigationService` lacks a way to specify `dataContext` for navigating.
Yes, we can get the underlying `NavigationControl` and navigate with `dataContext` object like this:
```C#
NavigationService.GetNavigationControl().Navigate(pageType, dataContext);
// or
NavigationService.GetNavigationControl().NavigateWithHierarchy(pageType, dataContext);
```
but... that's a bit tedious.

Issue Number: N/A

## What is the new behavior?

add these 3 overload methods with `dataContext` to `INavigationService`
```C#
bool Navigate(Type pageType, object? dataContext);
bool Navigate(string pageIdOrTargetTag, object? dataContext);
bool NavigateWithHierarchy(Type pageType, object? dataContext);
```
so client code can just do `NavigationService.Navigate(type, data)` without the hassle.

## Other information

However, if the current displaying page (ie. top-most navigation stack) is `pageType`, `Navigate*(...)` returns `false` and does nothing.
I managed to force-refresh the stack by doing this in client code:
```C#
while (!NavSvc.NavigateWithHierarchy(typeof(SomePage), someData))
{
    // failed, try pop the stack and try again
    if (!NavSvc.GoBack())
    {
        // cannot pop stack, really failed...
        Log.LogCritical(...);
        break;
    }
}
```