### PR TITLE
Make TitleBarButton public to enable re-templating TitleBar.

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -11,7 +11,7 @@ using Wpf.Ui.Interop;
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 
-internal class TitleBarButton : Wpf.Ui.Controls.Button
+public class TitleBarButton : Wpf.Ui.Controls.Button
 {
     /// <summary>
     /// Property for <see cref="ButtonType"/>.


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The ```Wpf.UI.Controls.TitleBarButton``` class is marked as _internal_. This prevents applications from subsclassing and re-templating the title bar to add additional behaviour.

Issue Number: #937 (indirectly)

## What is the new behavior?

```Wpf.UI.Controls.TitleBarButton``` is now _public_, enabling the title bar to be re-templated.

## Other information

n/a
