### PR TITLE
Don't focus on inline buttons or icons in text input controls when pressing Tab

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -82,6 +82,7 @@
                                     VerticalAlignment="Top"
                                     Content="{TemplateBinding Icon}"
                                     FontSize="16"
+                                    IsTabStop="False"
                                     Foreground="{TemplateBinding Foreground}" />
                                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
                                     <Decorator
@@ -178,6 +179,7 @@
                                     VerticalAlignment="Top"
                                     Content="{TemplateBinding Icon}"
                                     FontSize="16"
+                                    IsTabStop="False"
                                     Foreground="{TemplateBinding Foreground}" />
                             </Grid>
                         </Border>

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -115,6 +115,7 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="clear"
                                     Cursor="Arrow"
+                                    IsTabStop="False"
                                     Foreground="{DynamicResource TextControlButtonForeground}">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="Dismiss24" />
@@ -138,6 +139,7 @@
                                     CommandParameter="increment"
                                     Cursor="Arrow"
                                     Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False"
                                     Visibility="Collapsed">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronUp24" />
@@ -162,6 +164,7 @@
                                     Cursor="Arrow"
                                     FontSize="{StaticResource NumberBoxButtonIconSize}"
                                     Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False"
                                     Visibility="Collapsed">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronDown24" />

--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
@@ -206,6 +206,7 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="clear"
                                     Cursor="Arrow"
+                                    IsTabStop="False"
                                     Foreground="{DynamicResource TextControlButtonForeground}">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource PasswordBoxButtonIconSize}" Symbol="Dismiss24" />
@@ -229,6 +230,7 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="reveal"
                                     Cursor="Arrow"
+                                    IsTabStop="False"
                                     Foreground="{DynamicResource TextControlButtonForeground}">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource PasswordBoxButtonIconSize}" Symbol="Eye24" />

--- a/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
@@ -206,6 +206,7 @@
                         BorderBrush="Transparent"
                         Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                         Cursor="Arrow"
+                        IsTabStop="False"
                         Foreground="{DynamicResource TextControlButtonForeground}">
                         <controls:Button.Icon>
                             <controls:SymbolIcon FontSize="{TemplateBinding FontSize}" Symbol="Dismiss24" />


### PR DESCRIPTION
Avoid tab-focusing on `ControlIconLeft`, `ControlIconRight`, `ClearButton`, `InlineIncrementButton`, `InlineDecrementButton`, and/or `RevealButton` present in `TextBox`, `AutoSuggestBox`, `NumberBox` and `PasswordBox` by setting `IsTabStop=False`

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When you press `Tab` on a text input control which has inline buttons (`ClearButton`, `InlineIncrementButton`, `InlineDecrementButton`, `RevealButton`), it focuses on those buttons instead of on the next control.

This breaks the flow and is inconsistent with WinUI3.


https://github.com/lepoco/wpfui/assets/6920322/0fc342da-b5c1-47a0-ab29-3349263ad638



Issue Number: N/A

## What is the new behavior?

Don't focus on buttons in text input controls with Tab.


https://github.com/lepoco/wpfui/assets/6920322/b3b4cb45-497b-4dbd-a03d-72a02f75839f



## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
