### PR TITLE
Eliminate un-selectable space between ComboBoxItems

### DIFF
--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -20,7 +20,7 @@
     <Thickness x:Key="ComboBoxBorderThemeThickness">1,1,1,1</Thickness>
     <Thickness x:Key="ComboBoxAccentBorderThemeThickness">0,0,0,2</Thickness>
     <Thickness x:Key="ComboBoxChevronMargin">8,0,10,0</Thickness>
-    <Thickness x:Key="ComboBoxItemMargin">3,2,3,0</Thickness>
+    <Thickness x:Key="ComboBoxItemMargin">6,4,6,0</Thickness>
     <Thickness x:Key="ComboBoxItemContentMargin">10,8,8,8</Thickness>
     <system:Double x:Key="ComboBoxChevronSize">11.0</system:Double>
     <system:Double x:Key="ComboBoxPopupMinHeight">32.0</system:Double>
@@ -92,7 +92,6 @@
         <!--  Universal WPF UI focus  -->
         <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />
         <Setter Property="Padding" Value="{StaticResource ComboBoxItemContentMargin}" />
         <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -104,7 +103,7 @@
                     <Grid Background="Transparent">
                         <Border
                             Name="ContentBorder"
-                            Margin="{TemplateBinding Margin}"
+                            Margin="{DynamicResource ComboBoxItemMargin}"
                             Padding="0"
                             VerticalAlignment="Stretch"
                             CornerRadius="{TemplateBinding Border.CornerRadius}"

--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -101,7 +101,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                    <Grid>
+                    <Grid Background="Transparent">
                         <Border
                             Name="ContentBorder"
                             Margin="{TemplateBinding Margin}"


### PR DESCRIPTION
Eliminates blank space that can't be clicked to change the selection of a ComboBox and that doesn't respond when you mouse over it.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

There's a space between the end of the highlighted `ComboBoxItem`'s `Border` and the start of the next `ComboBoxItem`'s `ContentPresenter` that doesn't respond to mouse over and that doesn't affect the `ComboBox`'s value when clicked.


https://github.com/lepoco/wpfui/assets/6920322/c1f645f5-1dd0-4b00-8a03-a55dd0cb7375



Issue Number: N/A

## What is the new behavior?

After the first commit, the un-selectable space is decreased significantly:


https://github.com/lepoco/wpfui/assets/6920322/67eb7296-a6df-466b-8e4a-b87073bc75a5

The second commit eliminates the un-selectable space completely:


https://github.com/lepoco/wpfui/assets/6920322/c6c66cee-cb82-4454-9c25-884cb22859c1

The downside of this second commit is that it diminishes the customizability of ComboBoxItem. It is possible to increase the effective margin but not decrease it bellow `6,4,6,0` (see the commit description).

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
