### PR TITLE
Fix ListView to be compatible when ListView.View is a GridView

### DIFF
--- a/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
@@ -72,7 +72,7 @@ public partial class MainWindowViewModel : ObservableObject
             {
                 new NavigationViewItem(nameof(System.Windows.Controls.DataGrid), typeof(DataGridPage)),
                 new NavigationViewItem(nameof(ListBox), typeof(ListBoxPage)),
-                new NavigationViewItem(nameof(ListView), typeof(ListViewPage)),
+                new NavigationViewItem(nameof(Ui.Controls.ListView), typeof(ListViewPage)),
                 new NavigationViewItem(nameof(TreeView), typeof(TreeViewPage)),
 #if DEBUG
                 new NavigationViewItem("TreeList", typeof(TreeListPage)),

--- a/src/Wpf.Ui.Gallery/Views/Pages/Collections/ListViewPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Collections/ListViewPage.xaml
@@ -12,7 +12,7 @@
     Title="ListViewPage"
     d:DataContext="{d:DesignInstance local:ListViewPage,
                                      IsDesignTimeCreatable=False}"
-    d:DesignHeight="450"
+    d:DesignHeight="750"
     d:DesignWidth="800"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -30,8 +30,9 @@
                 \t&lt;/ListView.ItemTemplate&gt;\n
                 &lt;/ListView&gt;
             </controls:ControlExample.XamlCode>
-            <ListView
-                Height="200"
+            <ui:ListView
+                MaxHeight="200"
+                d:ItemsSource="{d:SampleData ItemCount=2}"
                 ItemsSource="{Binding ViewModel.BasicListViewItems, Mode=TwoWay}"
                 SelectedIndex="2"
                 SelectionMode="Single">
@@ -40,7 +41,7 @@
                         <TextBlock Margin="8,4" Text="{Binding Name, Mode=OneWay}" />
                     </DataTemplate>
                 </ListView.ItemTemplate>
-            </ListView>
+            </ui:ListView>
         </controls:ControlExample>
 
         <controls:ControlExample Margin="0,36,0,0" HeaderText="ListView with Selection Support.">
@@ -58,9 +59,10 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <ListView
+                <ui:ListView
                     Grid.Column="0"
-                    Height="200"
+                    MaxHeight="200"
+                    d:ItemsSource="{d:SampleData ItemCount=2}"
                     ItemsSource="{Binding ViewModel.BasicListViewItems, Mode=TwoWay}"
                     SelectedIndex="1"
                     SelectionMode="{Binding ViewModel.ListViewSelectionMode, Mode=OneWay}">
@@ -99,7 +101,7 @@
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
-                </ListView>
+                </ui:ListView>
                 <StackPanel
                     Grid.Column="1"
                     MinWidth="120"
@@ -113,6 +115,39 @@
                     </ComboBox>
                 </StackPanel>
             </Grid>
+        </controls:ControlExample>
+
+        <controls:ControlExample Margin="0,36,0,0" HeaderText="ListView with GridView">
+            <controls:ControlExample.XamlCode>
+                &lt;ListView ItemsSource=&quot;{Binding ViewModel.BasicListViewItems}&quot;&gt;\n
+                \t&lt;ListView.View&gt;\n
+                \t\t&lt;GridView&gt;\n
+                \t\t\t&lt;GridViewColumn DisplayMemberBinding=&quot;{Binding FirstName}&quot; Header=&quot;First Name&quot;/&gt;\n
+                \t\t\t&lt;GridViewColumn DisplayMemberBinding=&quot;{Binding LastName}&quot; Header=&quot;Last Name&quot;/&gt;\n
+                \t\t\t&lt;GridViewColumn DisplayMemberBinding=&quot;{Binding Company}&quot; Header=&quot;Company&quot;/&gt;\n
+                \t\t&lt;/GridView&gt;\n
+                \t&lt;/ListView.View&gt;\n
+                &lt;/ListView&gt;
+            </controls:ControlExample.XamlCode>
+            <ui:ListView
+                MaxHeight="200"
+                d:ItemsSource="{d:SampleData ItemCount=3}"
+                BorderThickness="0"
+                ItemsSource="{Binding ViewModel.BasicListViewItems, Mode=TwoWay}">
+                <ListView.View>
+                    <GridView>
+                        <GridViewColumn
+                            Width="100"
+                            DisplayMemberBinding="{Binding FirstName}"
+                            Header="First Name" />
+                        <GridViewColumn
+                            Width="100"
+                            DisplayMemberBinding="{Binding LastName}"
+                            Header="Last Name" />
+                        <GridViewColumn DisplayMemberBinding="{Binding Company}" Header="Company" />
+                    </GridView>
+                </ListView.View>
+            </ui:ListView>
         </controls:ControlExample>
     </StackPanel>
 </Page>

--- a/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
+++ b/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
@@ -144,7 +144,7 @@
                                 BorderThickness="1"
                                 CornerRadius="8"
                                 SnapsToDevicePixels="True">
-                                <ListView
+                                <controls:ListView
                                     x:Name="PART_SuggestionsList"
                                     MaxHeight="{TemplateBinding MaxSuggestionListHeight}"
                                     DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
@@ -162,7 +162,7 @@
                                                 VirtualizationMode="Recycling" />
                                         </ItemsPanelTemplate>
                                     </ListView.ItemsPanel>
-                                </ListView>
+                                </controls:ListView>
                             </Border>
                         </Popup>
                     </Grid>

--- a/src/Wpf.Ui/Controls/ListView/ListView.cs
+++ b/src/Wpf.Ui/Controls/ListView/ListView.cs
@@ -1,0 +1,60 @@
+namespace Wpf.Ui.Controls;
+
+public class ListView : System.Windows.Controls.ListView
+{
+    public string ViewState
+    {
+        get => (string)GetValue(ViewStateProperty);
+        set => SetValue(ViewStateProperty, value);
+    }
+
+    /// <summary>Identifies the <see cref="ViewState"/> dependency property.</summary>
+    public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(nameof(ViewState), typeof(string), typeof(ListView), new FrameworkPropertyMetadata("Default", OnViewStateChanged));
+
+    private static void OnViewStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ListView self)
+        {
+            return;
+        }
+
+        self.OnViewStateChanged(e);
+    }
+
+    protected virtual void OnViewStateChanged(DependencyPropertyChangedEventArgs e)
+    {
+        // derived classes can hook `ViewState` property changes by overriding this method
+    }
+
+    public ListView()
+    {
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        // immediately unsubscribe to prevent memory leaks
+        Loaded -= OnLoaded;
+
+        // get the descriptor for the `View` property since the framework doesn't provide a public hook for it
+        var descriptor = DependencyPropertyDescriptor.FromProperty(System.Windows.Controls.ListView.ViewProperty, typeof(System.Windows.Controls.ListView));
+        descriptor?.AddValueChanged(this, OnViewPropertyChanged);
+        UpdateViewState(); // set the initial state
+    }
+
+    private void OnViewPropertyChanged(object? sender, EventArgs e)
+    {
+        UpdateViewState();
+    }
+
+    private void UpdateViewState()
+    {
+        var viewState = View is null ? "Default" : "GridView";
+        SetCurrentValue(ViewStateProperty, viewState);
+    }
+
+    static ListView()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(typeof(ListView), new FrameworkPropertyMetadata(typeof(ListView)));
+    }
+}

--- a/src/Wpf.Ui/Controls/ListView/ListView.xaml
+++ b/src/Wpf.Ui/Controls/ListView/ListView.xaml
@@ -10,63 +10,178 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
-    <Style x:Key="DefaultListViewStyle" TargetType="{x:Type ListView}">
-        <Setter Property="Margin" Value="0" />
-        <Setter Property="Padding" Value="0" />
-        <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
-        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True" />
-        <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Standard" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="OverridesDefaultStyle" Value="True" />
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <VirtualizingStackPanel IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}" VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
+    <ControlTemplate x:Key="NullViewTemplate" TargetType="{x:Type controls:ListView}">
+        <Grid>
+            <controls:PassiveScrollViewer
+                x:Name="PART_ContentHost"
+                CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                <ItemsPresenter />
+            </controls:PassiveScrollViewer>
+            <Rectangle
+                x:Name="PART_DisabledVisual"
+                Opacity="0"
+                RadiusX="2"
+                RadiusY="2"
+                Stretch="Fill"
+                Stroke="Transparent"
+                StrokeThickness="0"
+                Visibility="Collapsed">
+                <Rectangle.Fill>
+                    <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                </Rectangle.Fill>
+            </Rectangle>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsGrouping" Value="True">
+                <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="PART_DisabledVisual" Property="Visibility" Value="Visible" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="GridViewScrollViewerTemplate" TargetType="ScrollViewer">
+        <Grid Background="Transparent">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Margin="{TemplateBinding Control.Padding}">
+                <ScrollViewer
+                    DockPanel.Dock="Top"
+                    Focusable="False"
+                    HorizontalScrollBarVisibility="Hidden"
+                    VerticalScrollBarVisibility="Hidden">
+                    <GridViewHeaderRowPresenter
+                        Margin="0"
+                        AllowsColumnReorder="{Binding Path=View.AllowsColumnReorder, RelativeSource={RelativeSource AncestorType=ListView}}"
+                        ColumnHeaderContainerStyle="{Binding Path=View.ColumnHeaderContainerStyle, RelativeSource={RelativeSource AncestorType=ListView}}"
+                        ColumnHeaderContextMenu="{Binding Path=View.ColumnHeaderContextMenu, RelativeSource={RelativeSource AncestorType=ListView}}"
+                        ColumnHeaderTemplate="{Binding Path=View.ColumnHeaderTemplate, RelativeSource={RelativeSource AncestorType=ListView}}"
+                        ColumnHeaderToolTip="{Binding Path=View.ColumnHeaderToolTip, RelativeSource={RelativeSource AncestorType=ListView}}"
+                        Columns="{Binding Path=View.Columns, RelativeSource={RelativeSource AncestorType=ListView}}"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                </ScrollViewer>
+                <ScrollContentPresenter
+                    Name="PART_ScrollContentPresenter"
+                    CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                    CanHorizontallyScroll="False"
+                    CanVerticallyScroll="False"
+                    Content="{TemplateBinding ContentControl.Content}"
+                    ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
+                    KeyboardNavigation.DirectionalNavigation="Local"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </DockPanel>
+            <ScrollBar
+                Name="PART_HorizontalScrollBar"
+                Grid.Row="1"
+                Cursor="Arrow"
+                Maximum="{TemplateBinding ScrollViewer.ScrollableWidth}"
+                Minimum="0"
+                Orientation="Horizontal"
+                Visibility="{TemplateBinding ScrollViewer.ComputedHorizontalScrollBarVisibility}"
+                Value="{Binding Path=HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+            <ScrollBar
+                Name="PART_VerticalScrollBar"
+                Grid.Column="1"
+                Cursor="Arrow"
+                Maximum="{TemplateBinding ScrollViewer.ScrollableHeight}"
+                Minimum="0"
+                Orientation="Vertical"
+                Visibility="{TemplateBinding ScrollViewer.ComputedVerticalScrollBarVisibility}"
+                Value="{Binding Path=VerticalOffset, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+            <DockPanel
+                Grid.Row="1"
+                Grid.Column="1"
+                LastChildFill="False">
+                <Rectangle
+                    Width="1"
+                    DockPanel.Dock="Left"
+                    Fill="#FFFFFFFF"
+                    Visibility="{TemplateBinding ScrollViewer.ComputedVerticalScrollBarVisibility}" />
+                <Rectangle
+                    Height="1"
+                    DockPanel.Dock="Top"
+                    Fill="#FFFFFFFF"
+                    Visibility="{TemplateBinding ScrollViewer.ComputedHorizontalScrollBarVisibility}" />
+            </DockPanel>
+        </Grid>
+    </ControlTemplate>
+
+    <!--  replaces framework styling for GridView column headers  -->
+    <Style TargetType="GridViewColumnHeader">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ListView}">
-                    <Grid>
-                        <controls:PassiveScrollViewer
-                            x:Name="PART_ContentHost"
-                            CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
-                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <ItemsPresenter />
-                        </controls:PassiveScrollViewer>
-                        <Rectangle
-                            x:Name="PART_DisabledVisual"
-                            Opacity="0"
-                            RadiusX="2"
-                            RadiusY="2"
-                            Stretch="Fill"
-                            Stroke="Transparent"
-                            StrokeThickness="0"
-                            Visibility="Collapsed">
-                            <Rectangle.Fill>
-                                <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
-                            </Rectangle.Fill>
-                        </Rectangle>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsGrouping" Value="True">
-                            <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="PART_DisabledVisual" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
+                <ControlTemplate TargetType="GridViewColumnHeader">
+                    <!--  margins and padding need some help  -->
+                    <TextBlock
+                        Margin="6,2,0,6"
+                        Padding="4"
+                        FontWeight="Bold"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Text="{TemplateBinding Content}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
+    <ControlTemplate x:Key="GridViewTemplate" TargetType="{x:Type controls:ListView}">
+        <Border
+            Name="Bd"
+            Background="Transparent"
+            BorderBrush="{TemplateBinding Border.BorderBrush}"
+            BorderThickness="{TemplateBinding Border.BorderThickness}">
+            <controls:PassiveScrollViewer
+                Padding="{TemplateBinding Control.Padding}"
+                CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                Focusable="False"
+                Template="{DynamicResource GridViewScrollViewerTemplate}">
+                <ItemsPresenter />
+            </controls:PassiveScrollViewer>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <Style x:Key="ListViewStyle" TargetType="{x:Type controls:ListView}">
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+        <Setter Property="Control.VerticalContentAlignment" Value="Center" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True" />
+        <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Standard" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=ViewState, RelativeSource={RelativeSource Mode=Self}}" Value="Default">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}" VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Template" Value="{DynamicResource NullViewTemplate}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=ViewState, RelativeSource={RelativeSource Mode=Self}}" Value="GridView">
+                <Setter Property="Template" Value="{DynamicResource GridViewTemplate}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style BasedOn="{StaticResource ListViewStyle}" TargetType="{x:Type controls:ListView}" />
 
 </ResourceDictionary>

--- a/src/Wpf.Ui/Controls/ListView/ListViewItem.xaml
+++ b/src/Wpf.Ui/Controls/ListView/ListViewItem.xaml
@@ -4,59 +4,109 @@
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
     All Rights Reserved.
 -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+
+    <ControlTemplate x:Key="NullViewItemTemplate" TargetType="{x:Type ListViewItem}">
+        <Border
+            x:Name="Border"
+            Margin="0"
+            Padding="0"
+            Background="Transparent"
+            BorderThickness="1"
+            CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <Grid>
+                <ContentPresenter Margin="{TemplateBinding Padding}" />
+                <Rectangle
+                    x:Name="ActiveRectangle"
+                    Width="3"
+                    Height="18"
+                    Margin="0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Fill="{DynamicResource ListViewItemPillFillBrush}"
+                    RadiusX="2"
+                    RadiusY="2"
+                    Visibility="Collapsed" />
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsEnabled" Value="True" />
+                    <Condition Property="IsMouseOver" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+            </MultiTrigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="GridViewItemTemplate" TargetType="ListViewItem">
+        <Border
+            x:Name="Border"
+            Margin="0"
+            Padding="0"
+            Background="Transparent"
+            BorderBrush="{TemplateBinding Border.BorderBrush}"
+            BorderThickness="{TemplateBinding Border.BorderThickness}"
+            CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <Grid>
+                <GridViewRowPresenter
+                    Margin="{TemplateBinding Padding}"
+                    VerticalAlignment="{TemplateBinding Control.VerticalContentAlignment}"
+                    Columns="{TemplateBinding GridView.ColumnCollection}"
+                    Content="{TemplateBinding ContentControl.Content}" />
+                <Rectangle
+                    x:Name="ActiveRectangle"
+                    Width="3"
+                    Height="18"
+                    Margin="0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Fill="{DynamicResource ListViewItemPillFillBrush}"
+                    RadiusX="2"
+                    RadiusY="2"
+                    Visibility="Collapsed" />
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsEnabled" Value="True" />
+                    <Condition Property="IsMouseOver" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+            </MultiTrigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <Style x:Key="ListViewItemStyle" TargetType="{x:Type ListViewItem}">
         <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Margin" Value="0,0,0,2" />
         <Setter Property="Padding" Value="4" />
-        <Setter Property="OverridesDefaultStyle" Value="True" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                    <Border
-                        x:Name="Border"
-                        Margin="0"
-                        Padding="0"
-                        Background="Transparent"
-                        BorderThickness="1"
-                        CornerRadius="{TemplateBinding Border.CornerRadius}">
-                        <Grid>
-                            <ContentPresenter Margin="{TemplateBinding Padding}" />
-                            <Rectangle
-                                x:Name="ActiveRectangle"
-                                Width="3"
-                                Height="18"
-                                Margin="0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Fill="{DynamicResource ListViewItemPillFillBrush}"
-                                RadiusX="2"
-                                RadiusY="2"
-                                Visibility="Collapsed" />
-                        </Grid>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsEnabled" Value="True" />
-                                <Condition Property="IsMouseOver" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
-
-                        </MultiTrigger>
-                        <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=ViewState, RelativeSource={RelativeSource AncestorType={x:Type ListView}}}" Value="Default">
+                <Setter Property="Template" Value="{DynamicResource NullViewItemTemplate}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=ViewState, RelativeSource={RelativeSource AncestorType={x:Type ListView}}}" Value="GridView">
+                <Setter Property="Template" Value="{DynamicResource GridViewItemTemplate}" />
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
-    <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="{x:Type ListViewItem}" />
+    <Style BasedOn="{StaticResource ListViewItemStyle}" TargetType="{x:Type ListViewItem}" />
 
 </ResourceDictionary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
The UI library currently breaks all `ListView` controls that use the `GridView` view. This PR adds support for `GridView` and showcases it in the GalleryApp
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature

## What is the current behavior?
The current behavior is that UI library interferes with how different derived types of `BaseView` are dynamically stylized, which renders types like `GridView` incompatible with this library. Although you can workaround this by voiding the library's styles, something like:
```
<ListView Style="{x:Null}">
   <ListView.Resources>
      <Style TargetType="ListViewItem"> <Setter Property="Background" Value="Transparent" /> </Style>
   </ListView.Resources>
   <ListView.View>
      <GridView><GridViewColumn DisplayMemberBinding="{Binding ...}" /></GridView>
   </ListView.View>
</ListView>
  ```
Digging through older framework code, it appears that when `View` changes, `ListView` uses the current `View` to change its own `DefaultStyleKey` and also apply new keys to its viewitem children. When the `View` is null, the `DefaultStyleKey` will point to `ListBox` and `ListBoxItem` (theme styles) and for `GridView` it'll be `GridViewStyle` and `GridViewItemContainerStyle`. When this library directly set a style on `ListView` and `ListViewItem` it broke the unorthodox approach the framework used to dynamically set styles to different views.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

My first attempt was to go with the flow of the WPF framework. For example, you should be able to style `ListBox` and see that refelcted in a `ListView` with null `View`, but various attempts at this failed.

Since there is actually only one derived type of BaseView - namely `GridView`, there are effectively only two scenarios that exist - nullview and gridview, so we can use a more standard approach and use xaml styles to handle these two different cases.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Extend ListView so that we can subscribe to changes in `View`
- Use triggers in `ListView.xaml` and `ListViewItem.xaml` to adapt to different View states
- Add a sample to the the Gallery app

## Other information
![image](https://github.com/lepoco/wpfui/assets/78566945/a6b3bba1-b12c-4cc7-a7a3-c7ce6e2cf816)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
