### PR TITLE
Fix Close Button icon color in TitleBar while mouse over

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -15,6 +15,7 @@
         <Setter Property="Height" Value="30" />
         <Setter Property="MouseOverBackground" Value="{Binding Path=ButtonsBackground, RelativeSource={RelativeSource AncestorType={x:Type controls:TitleBar}}}" />
         <Setter Property="ButtonsForeground" Value="{Binding Path=ButtonsForeground, RelativeSource={RelativeSource AncestorType={x:Type controls:TitleBar}}}" />
+        <Setter Property="MouseOverButtonsForeground" Value="{Binding Path=MouseOverButtonsForeground, RelativeSource={RelativeSource AncestorType={x:Type controls:TitleBar}}}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -193,6 +194,7 @@
                                     x:Name="PART_CloseButton"
                                     Grid.Column="4"
                                     ButtonType="Close"
+                                    MouseOverButtonsForeground="White"
                                     MouseOverBackground="{DynamicResource PaletteRedBrush}" />
                             </Grid>
                         </Grid>

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -46,9 +46,6 @@
                         </Viewbox>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="LayoutRoot" Property="Background" Value="{Binding Path=MouseOverBackground, RelativeSource={RelativeSource TemplatedParent}}" />
-                        </Trigger>
                         <Trigger Property="ButtonType" Value="{x:Static controls:TitleBarButtonType.Help}">
                             <Setter Property="CommandParameter" Value="{x:Static controls:TitleBarButtonType.Help}" />
                             <Setter TargetName="ViewBox" Property="Width" Value="13" />
@@ -75,14 +72,6 @@
                             <Setter Property="CommandParameter" Value="{x:Static controls:TitleBarButtonType.Close}" />
                             <Setter TargetName="CanvasPath" Property="Data" Value="M36,41.1,6.15,71a3.44,3.44,0,0,1-2.53,1A3.55,3.55,0,0,1,0,68.38a3.44,3.44,0,0,1,1.05-2.53L30.9,36,1.05,6.15A3.49,3.49,0,0,1,0,3.59,3.51,3.51,0,0,1,.28,2.18,3.42,3.42,0,0,1,1.05,1,3.82,3.82,0,0,1,2.21.28,3.58,3.58,0,0,1,3.62,0,3.44,3.44,0,0,1,6.15,1.05L36,30.9,65.85,1.05a3.49,3.49,0,0,1,2.56-1A3.39,3.39,0,0,1,69.8.28,3.8,3.8,0,0,1,71,1.05a3.8,3.8,0,0,1,.77,1.15A3.39,3.39,0,0,1,72,3.59a3.49,3.49,0,0,1-1,2.56L41.1,36,71,65.85a3.44,3.44,0,0,1,1,2.53,3.58,3.58,0,0,1-.28,1.41A3.82,3.82,0,0,1,71,71a3.42,3.42,0,0,1-1.14.77,3.66,3.66,0,0,1-4-.77Z" />
                         </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="ButtonType" Value="{x:Static controls:TitleBarButtonType.Close}" />
-                                <Condition Property="IsMouseOver" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Foreground" Value="#FFFFFFFF" />
-                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -37,6 +37,19 @@ internal class TitleBarButton : Wpf.Ui.Controls.Button
     );
 
     /// <summary>
+    /// Property for <see cref="MouseOverButtonsForeground"/>.
+    /// </summary>
+    public static readonly DependencyProperty MouseOverButtonsForegroundProperty = DependencyProperty.Register(
+        nameof(MouseOverButtonsForeground),
+        typeof(Brush),
+        typeof(TitleBarButton),
+        new FrameworkPropertyMetadata(
+            SystemColors.ControlTextBrush,
+            FrameworkPropertyMetadataOptions.Inherits
+        )
+    );
+
+    /// <summary>
     /// Sets or gets the
     /// </summary>
     public TitleBarButtonType ButtonType
@@ -53,11 +66,20 @@ internal class TitleBarButton : Wpf.Ui.Controls.Button
         get => (Brush)GetValue(ButtonsForegroundProperty);
         set => SetValue(ButtonsForegroundProperty, value);
     }
+    /// <summary>
+    /// Foreground of the navigation buttons while mouse over.
+    /// </summary>
+    public Brush MouseOverButtonsForeground
+    {
+        get => (Brush)GetValue(MouseOverButtonsForegroundProperty);
+        set => SetValue(MouseOverButtonsForegroundProperty, value);
+    }
 
     public bool IsHovered { get; private set; }
 
     private User32.WM_NCHITTEST _returnValue;
     private Brush _defaultBackgroundBrush = Brushes.Transparent; //Should it be transparent?
+    private Brush _cacheButtonsForeground = SystemColors.ControlTextBrush; // cache ButtonsForeground while mouse over
 
     private bool _isClickedDown;
 
@@ -70,6 +92,8 @@ internal class TitleBarButton : Wpf.Ui.Controls.Button
             return;
 
         Background = MouseOverBackground;
+        _cacheButtonsForeground = ButtonsForeground;
+        ButtonsForeground = MouseOverButtonsForeground;
         IsHovered = true;
     }
 
@@ -82,6 +106,7 @@ internal class TitleBarButton : Wpf.Ui.Controls.Button
             return;
 
         Background = _defaultBackgroundBrush;
+        ButtonsForeground = _cacheButtonsForeground;
 
         IsHovered = false;
         _isClickedDown = false;
@@ -119,7 +144,6 @@ internal class TitleBarButton : Wpf.Ui.Controls.Button
 
                 RemoveHover();
                 return false;
-
             case User32.WM.NCMOUSELEAVE: // Mouse leaves the window
                 RemoveHover();
                 return false;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Normally, the TitleBar should change Close button background to Red, and change foreground to White while mouse over. But it looks like this now.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![image](https://github.com/lepoco/wpfui/assets/8638535/4d5f0b50-2b2a-4c20-aa53-a1c4828707fe)

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

![image](https://github.com/lepoco/wpfui/assets/8638535/b8576b4c-3ad2-4d96-9297-dc6297dfa61d)

Because the `TitleBar.cs` hook mouse event, so the TemplateBinding in `TitleBar.xaml` cannot trigger by `IsMouseOver`. So this pull request continuely use the `Hover/RemoveHover` method in `TitleBarButton.cs` as event, and add a `MouseOverButtonsForeground` property to allow user defining this color.


-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
