### PR TITLE
ApplicationManager.ApplySystemTheme UpdateAccent fix

### DIFF
--- a/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
@@ -233,7 +233,7 @@ public static class ApplicationThemeManager
             themeToSet = ApplicationTheme.HighContrast;
         }
 
-        Apply(themeToSet);
+        Apply(themeToSet, updateAccent: updateAccent);
     }
 
     /// <summary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Because the `updateAccent` isn't forwarded in `ApplicationThemeManager.ApplySystemTheme` (row 236) to `ApplicationThemeManager.Apply`, it defaults to `true`.

## What is the new behavior?

Correctly forwards the set `updateAccent` flag.

## Other information

Losely related to #965.
