### PR TITLE
Fix content overflowing from PasswordBox, ComboBox and NumberBox (#497, #973)

### DIFF
--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -44,12 +44,17 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Decorator
+                    <controls:PassiveScrollViewer
                         x:Name="PART_ContentHost"
-                        Margin="{TemplateBinding Padding}"
-                        HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
-                        TextElement.Foreground="{TemplateBinding Foreground}" />
+                        HorizontalAlignment="Stretch"
+                        Margin="{TemplateBinding Padding}"
+                        CanContentScroll="False"
+                        HorizontalScrollBarVisibility="Hidden"
+                        IsDeferredScrollingEnabled="False"
+                        Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
+                        TextElement.Foreground="{TemplateBinding Foreground}"
+                        VerticalScrollBarVisibility="Hidden" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -49,12 +49,8 @@
                         VerticalAlignment="Stretch"
                         HorizontalAlignment="Stretch"
                         Margin="{TemplateBinding Padding}"
-                        CanContentScroll="False"
-                        HorizontalScrollBarVisibility="Hidden"
-                        IsDeferredScrollingEnabled="False"
                         Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
-                        TextElement.Foreground="{TemplateBinding Foreground}"
-                        VerticalScrollBarVisibility="Hidden" />
+                        TextElement.Foreground="{TemplateBinding Foreground}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -85,11 +85,15 @@
                                     IsTabStop="False"
                                     Foreground="{TemplateBinding Foreground}" />
                                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
-                                    <Decorator
+                                    <controls:PassiveScrollViewer
                                         x:Name="PART_ContentHost"
-                                        Margin="0"
                                         VerticalAlignment="Center"
-                                        TextElement.Foreground="{TemplateBinding Foreground}" />
+                                        CanContentScroll="False"
+                                        HorizontalScrollBarVisibility="Hidden"
+                                        IsDeferredScrollingEnabled="False"
+                                        Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
+                                        TextElement.Foreground="{TemplateBinding Foreground}"
+                                        VerticalScrollBarVisibility="Hidden" />
                                     <TextBlock
                                         x:Name="PlaceholderTextBox"
                                         Margin="0"

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -87,13 +87,8 @@
                                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
                                     <controls:PassiveScrollViewer
                                         x:Name="PART_ContentHost"
-                                        VerticalAlignment="Center"
-                                        CanContentScroll="False"
-                                        HorizontalScrollBarVisibility="Hidden"
-                                        IsDeferredScrollingEnabled="False"
                                         Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
-                                        TextElement.Foreground="{TemplateBinding Foreground}"
-                                        VerticalScrollBarVisibility="Hidden" />
+                                        TextElement.Foreground="{TemplateBinding Foreground}" />
                                     <TextBlock
                                         x:Name="PlaceholderTextBox"
                                         Margin="0"

--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
@@ -69,11 +69,15 @@
                                 Margin="{TemplateBinding Padding}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                <Decorator
+                                <controls:PassiveScrollViewer
                                     x:Name="PART_ContentHost"
-                                    Margin="0"
                                     VerticalAlignment="Center"
-                                    TextElement.Foreground="{TemplateBinding Foreground}" />
+                                    CanContentScroll="False"
+                                    HorizontalScrollBarVisibility="Hidden"
+                                    IsDeferredScrollingEnabled="False"
+                                    Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
+                                    TextElement.Foreground="{TemplateBinding Foreground}"
+                                    VerticalScrollBarVisibility="Hidden" />
                             </Grid>
                         </Border>
                         <!--  The Accent Border is a separate element so that changes to the border thickness do not affect the position of the element  -->
@@ -174,11 +178,15 @@
                                     TextElement.Foreground="{TemplateBinding Foreground}" />
 
                                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
-                                    <Decorator
+                                    <controls:PassiveScrollViewer
                                         x:Name="PART_ContentHost"
-                                        Margin="0"
                                         VerticalAlignment="Center"
-                                        TextElement.Foreground="{TemplateBinding Foreground}" />
+                                        CanContentScroll="False"
+                                        HorizontalScrollBarVisibility="Hidden"
+                                        IsDeferredScrollingEnabled="False"
+                                        Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
+                                        TextElement.Foreground="{TemplateBinding Foreground}"
+                                        VerticalScrollBarVisibility="Hidden" />
                                     <TextBlock
                                         x:Name="PlaceholderTextBox"
                                         Margin="0"

--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
@@ -71,13 +71,8 @@
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <controls:PassiveScrollViewer
                                     x:Name="PART_ContentHost"
-                                    VerticalAlignment="Center"
-                                    CanContentScroll="False"
-                                    HorizontalScrollBarVisibility="Hidden"
-                                    IsDeferredScrollingEnabled="False"
                                     Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
-                                    TextElement.Foreground="{TemplateBinding Foreground}"
-                                    VerticalScrollBarVisibility="Hidden" />
+                                    TextElement.Foreground="{TemplateBinding Foreground}" />
                             </Grid>
                         </Border>
                         <!--  The Accent Border is a separate element so that changes to the border thickness do not affect the position of the element  -->
@@ -180,13 +175,8 @@
                                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
                                     <controls:PassiveScrollViewer
                                         x:Name="PART_ContentHost"
-                                        VerticalAlignment="Center"
-                                        CanContentScroll="False"
-                                        HorizontalScrollBarVisibility="Hidden"
-                                        IsDeferredScrollingEnabled="False"
                                         Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
-                                        TextElement.Foreground="{TemplateBinding Foreground}"
-                                        VerticalScrollBarVisibility="Hidden" />
+                                        TextElement.Foreground="{TemplateBinding Foreground}" />
                                     <TextBlock
                                         x:Name="PlaceholderTextBox"
                                         Margin="0"

--- a/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
@@ -70,7 +70,6 @@
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <controls:PassiveScrollViewer
                                     x:Name="PART_ContentHost"
-                                    VerticalAlignment="Center"
                                     CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
                                     HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                     IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
@@ -154,7 +153,6 @@
                     <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
                         <controls:PassiveScrollViewer
                             x:Name="PART_ContentHost"
-                            VerticalAlignment="Center"
                             CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
                             HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                             IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
@@ -292,7 +290,6 @@
                     <Grid Margin="{TemplateBinding Padding}">
                         <controls:PassiveScrollViewer
                             x:Name="PART_ContentHost"
-                            VerticalAlignment="Center"
                             CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
                             HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                             IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"

--- a/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
@@ -22,23 +22,6 @@
     <Thickness x:Key="TextBoxClearButtonPadding">0,0,0,0</Thickness>
     <system:Double x:Key="TextBoxClearButtonHeight">24</system:Double>
 
-    <!--  TODO: Rework TextBox ScrollViewer  -->
-    <Style x:Key="DefaultTextBoxScrollViewerStyle" TargetType="{x:Type ScrollViewer}">
-        <Setter Property="Margin" Value="0" />
-        <Setter Property="Padding" Value="0" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="OverridesDefaultStyle" Value="True" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ScrollViewer}">
-                    <Grid>
-                        <ScrollContentPresenter Margin="0" CanContentScroll="{TemplateBinding CanContentScroll}" />
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
     <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}">
         <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
@@ -92,7 +75,7 @@
                                     HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                     IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                                     IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}"
-                                    Style="{StaticResource DefaultTextBoxScrollViewerStyle}"
+                                    Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
                                     TextElement.Foreground="{TemplateBinding Foreground}"
                                     VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
                             </Grid>
@@ -176,7 +159,7 @@
                             HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                             IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                             IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}"
-                            Style="{StaticResource DefaultTextBoxScrollViewerStyle}"
+                            Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
                             TextElement.Foreground="{TemplateBinding Foreground}"
                             VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
                         <TextBlock
@@ -314,7 +297,7 @@
                             HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                             IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                             IsTabStop="{TemplateBinding ScrollViewer.IsTabStop}"
-                            Style="{StaticResource DefaultTextBoxScrollViewerStyle}"
+                            Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
                             TextElement.Foreground="{TemplateBinding Foreground}"
                             VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
                     </Grid>

--- a/src/Wpf.Ui/Resources/DefaultTextBoxScrollViewerStyle.xaml
+++ b/src/Wpf.Ui/Resources/DefaultTextBoxScrollViewerStyle.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--  TODO: Rework TextBox ScrollViewer  -->
+    <Style x:Key="DefaultTextBoxScrollViewerStyle" TargetType="{x:Type ScrollViewer}">
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid>
+                        <ScrollContentPresenter Margin="0" CanContentScroll="{TemplateBinding CanContentScroll}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Wpf.Ui/Resources/DefaultTextBoxScrollViewerStyle.xaml
+++ b/src/Wpf.Ui/Resources/DefaultTextBoxScrollViewerStyle.xaml
@@ -7,6 +7,11 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="CanContentScroll" Value="False" />
+        <Setter Property="HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollViewer}">

--- a/src/Wpf.Ui/Resources/Wpf.Ui.xaml
+++ b/src/Wpf.Ui/Resources/Wpf.Ui.xaml
@@ -14,6 +14,7 @@
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Palette.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/DefaultContextMenu.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/DefaultFocusVisualStyle.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/DefaultTextBoxScrollViewerStyle.xaml" />
 
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/Anchor/Anchor.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/AutoSuggestBox/AutoSuggestBox.xaml" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the content of a PasswordBox, NumberBox or editable ComboBox is longer than the control, the cursor and selection overflow from the control. Notably, TextBox doesn't have this issue.

https://github.com/lepoco/wpfui/assets/6920322/60ae9ad0-f80e-423d-a105-0aab8165d638

https://github.com/lepoco/wpfui/assets/6920322/7e0704d3-3a40-4cf1-8185-f828e6296429

https://github.com/lepoco/wpfui/assets/6920322/480145d2-127e-46b1-ad35-46768028bee3

Issue Number: #497, #973

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

PasswordBox, NumberBox and ComboBox now behave like TextBox

https://github.com/lepoco/wpfui/assets/6920322/eb3f137b-0b09-4eac-b0c4-581af72099ad

https://github.com/lepoco/wpfui/assets/6920322/f5b7ed0e-0c60-4e27-94cb-085f4cd3126d

https://github.com/lepoco/wpfui/assets/6920322/b3e3f57e-4791-4392-9c0e-80536079e82b

https://github.com/lepoco/wpfui/assets/6920322/6c67a422-e104-4e7e-b6fb-336b9ff73ea8

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
