### PR TITLE
Fix TitleBarButton Foreground error when change theme

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -41,7 +41,7 @@
                                 Width="72"
                                 Height="72"
                                 Focusable="False">
-                                <Path x:Name="CanvasPath" Fill="{TemplateBinding ButtonsForeground}" />
+                                <Path x:Name="CanvasPath" Fill="{TemplateBinding RenderButtonsForeground}" />
                             </Canvas>
                         </Viewbox>
                     </Grid>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![image](https://github.com/lepoco/wpfui/assets/8638535/1af110de-b66b-46e9-826e-a803f6101b2e)

While changing theme between light and dark, the TitleBarButton Foreground not following the updated theme.

Issue Number: https://github.com/lepoco/wpfui/pull/993#issuecomment-2002125429 reported by @koal44

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

![image](https://github.com/lepoco/wpfui/assets/8638535/c4eec0a9-a26e-47fa-b966-2c813f45d600)
![image](https://github.com/lepoco/wpfui/assets/8638535/d65a6ccb-045e-4760-a351-4c38e8ca7a62)

- Use `RenderButtonsForeground` as canvas fill color
- Listen `ButtonsForeground` change, to make change after theme color changed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
