### PR TITLE
Improve lineargradient border for TextBox in Light/Dark themes 

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Pages/Text/TextBoxPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Text/TextBoxPage.xaml
@@ -11,7 +11,7 @@
     controls:PageControlDocumentation.DocumentationType="{x:Type ui:TextBox}"
     d:DataContext="{d:DesignInstance local:TextBoxPage,
                                      IsDesignTimeCreatable=False}"
-    d:DesignHeight="450"
+    d:DesignHeight="750"
     d:DesignWidth="800"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -34,7 +34,10 @@
             Margin="0,36,0,0"
             HeaderText="A multi-line TextBox."
             XamlCode="&lt;ui:TextBox PlaceholderText=&quot;Type something...&quot;TextWrapping=&quot;Wrap&quot; /&gt;">
-            <ui:TextBox PlaceholderText="Type something..." TextWrapping="Wrap" />
+            <ui:TextBox
+                MinHeight="100"
+                PlaceholderText="Type something..."
+                TextWrapping="Wrap" />
         </controls:ControlExample>
     </StackPanel>
 </Page>

--- a/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
@@ -14,7 +14,7 @@
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
     xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
-    <Thickness x:Key="TextBoxBorderThemeThickness">1,1,1,0</Thickness>
+    <Thickness x:Key="TextBoxBorderThemeThickness">1,1,1,1</Thickness>
     <Thickness x:Key="TextBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
     <Thickness x:Key="TextBoxLeftIconMargin">10,0,0,0</Thickness>
     <Thickness x:Key="TextBoxRightIconMargin">0,0,10,0</Thickness>
@@ -206,8 +206,8 @@
                         BorderBrush="Transparent"
                         Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                         Cursor="Arrow"
-                        IsTabStop="False"
-                        Foreground="{DynamicResource TextControlButtonForeground}">
+                        Foreground="{DynamicResource TextControlButtonForeground}"
+                        IsTabStop="False">
                         <controls:Button.Icon>
                             <controls:SymbolIcon FontSize="{TemplateBinding FontSize}" Symbol="Dismiss24" />
                         </controls:Button.Icon>

--- a/src/Wpf.Ui/Resources/Theme/Dark.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Dark.xaml
@@ -267,13 +267,10 @@
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <LinearGradientBrush x:Key="TextControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,2">
-        <LinearGradientBrush.RelativeTransform>
-            <ScaleTransform CenterY="0.5" ScaleY="-1" />
-        </LinearGradientBrush.RelativeTransform>
+    <LinearGradientBrush x:Key="TextControlElevationBorderBrush" MappingMode="RelativeToBoundingBox" StartPoint="0,0" EndPoint="0,2">
         <LinearGradientBrush.GradientStops>
-            <GradientStop Offset="0.5" Color="{StaticResource ControlStrongStrokeColorDefault}" />
-            <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+            <GradientStop Offset="0.0" Color="{StaticResource ControlStrokeColorDefault}" />
+            <GradientStop Offset="1.0" Color="{StaticResource ControlStrongStrokeColorDefault}" />
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 

--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -268,13 +268,10 @@
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <LinearGradientBrush x:Key="TextControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,2">
-        <LinearGradientBrush.RelativeTransform>
-            <ScaleTransform CenterY="0.5" ScaleY="-1" />
-        </LinearGradientBrush.RelativeTransform>
+    <LinearGradientBrush x:Key="TextControlElevationBorderBrush" MappingMode="RelativeToBoundingBox" StartPoint="0,0" EndPoint="0,2">
         <LinearGradientBrush.GradientStops>
-            <GradientStop Offset="0.5" Color="{StaticResource ControlStrongStrokeColorDefault}" />
-            <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+            <GradientStop Offset="0.0" Color="{StaticResource ControlStrokeColorDefault}" />
+            <GradientStop Offset="1.0" Color="{StaticResource ControlStrongStrokeColorDefault}" />
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
For multi-lined `TextBox`es the border seems wrong. It's using a `LinearGradientBrush` with absolute mapping so that the upper border was painted in one brush and the the rest of the border was painted in another brush. for a single line `TextBox` all you would see is a border painted in the upper brush, but a multi-line `TextBox` would reveal the lower part of a different Brush with no transition.

![Screenshot 2024-03-18 123348](https://github.com/lepoco/wpfui/assets/78566945/f5091983-c918-439f-a045-c732ad8a27d1)

## What is the new behavior?

I figure the intent was for a smooth linear transition between the two brushes and that's what's coded in this PR.

![Screenshot 2024-03-18 122959](https://github.com/lepoco/wpfui/assets/78566945/dc35a768-0b8b-4959-866f-e407cc323f39)

