### PR TITLE
Fix NavigationView pane not closed by default when using IsPaneOpen="False"

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -66,6 +66,15 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     private static readonly Thickness s_autoSuggestBoxMargin = new(8, 8, 8, 16);
     private static readonly Thickness s_frameMargin = new(0, 50, 0, 0);
 
+    protected static void UpdateVisualState(NavigationView navigationView)
+    {
+        _ = VisualStateManager.GoToState(
+            navigationView,
+            navigationView.IsPaneOpen ? "PaneOpen" : "PaneCompact",
+            true
+        );
+    }
+
     /// <inheritdoc />
     protected override void OnInitialized(EventArgs e)
     {
@@ -85,6 +94,7 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         // TODO: Refresh
+        UpdateVisualState((NavigationView)sender);
     }
 
     /// <summary>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -663,11 +663,7 @@ public partial class NavigationView
             );
         }
 
-        _ = VisualStateManager.GoToState(
-            navigationView,
-            navigationView.IsPaneOpen ? "PaneOpen" : "PaneCompact",
-            true
-        );
+        UpdateVisualState(navigationView);
     }
 
     private static void OnTitleBarPropertyChangedCallback(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Setting `IsPaneOpen="False"` on a `NavigationView` is ignored.

Issue Number: #741

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

When `IsPaneOpen="False"`, the pane starts collapsed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
