### PR TITLE
Fix/submenu navigation

### DIFF
--- a/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
@@ -35,7 +35,7 @@ public partial class MainWindowViewModel : ObservableObject
         {
             Content = "Design guidance",
             Icon = new SymbolIcon { Symbol = SymbolRegular.DesignIdeas24 },
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem("Typography", SymbolRegular.TextFont24, typeof(TypographyPage)),
                 new NavigationViewItem("Icons", SymbolRegular.Diversity24, typeof(IconsPage)),
@@ -46,7 +46,7 @@ public partial class MainWindowViewModel : ObservableObject
         new NavigationViewItemSeparator(),
         new NavigationViewItem("Basic Input", SymbolRegular.CheckboxChecked24, typeof(BasicInputPage))
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem(nameof(Anchor), typeof(AnchorPage)),
                 new NavigationViewItem(nameof(Wpf.Ui.Controls.Button), typeof(ButtonPage)),
@@ -68,7 +68,7 @@ public partial class MainWindowViewModel : ObservableObject
             Content = "Collections",
             Icon = new SymbolIcon { Symbol = SymbolRegular.Table24 },
             TargetPageType = typeof(CollectionsPage),
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem(nameof(System.Windows.Controls.DataGrid), typeof(DataGridPage)),
                 new NavigationViewItem(nameof(ListBox), typeof(ListBoxPage)),
@@ -81,7 +81,7 @@ public partial class MainWindowViewModel : ObservableObject
         },
         new NavigationViewItem("Date & time", SymbolRegular.CalendarClock24, typeof(DateAndTimePage))
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem(nameof(CalendarDatePicker), typeof(CalendarDatePickerPage)),
                 new NavigationViewItem(nameof(System.Windows.Controls.Calendar), typeof(CalendarPage)),
@@ -91,7 +91,7 @@ public partial class MainWindowViewModel : ObservableObject
         },
         new NavigationViewItem("Dialogs & flyouts", SymbolRegular.Chat24, typeof(DialogsAndFlyoutsPage))
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem(nameof(Snackbar), typeof(SnackbarPage)),
                 new NavigationViewItem(nameof(ContentDialog), typeof(ContentDialogPage)),
@@ -102,7 +102,7 @@ public partial class MainWindowViewModel : ObservableObject
 #if DEBUG
         new NavigationViewItem("Layout", SymbolRegular.News24, typeof(LayoutPage))
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem("Expander", typeof(ExpanderPage)),
                 new NavigationViewItem("CardControl", typeof(CardControlPage)),
@@ -115,7 +115,7 @@ public partial class MainWindowViewModel : ObservableObject
             Content = "Media",
             Icon = new SymbolIcon { Symbol = SymbolRegular.PlayCircle24 },
             TargetPageType = typeof(MediaPage),
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem("Image", typeof(ImagePage)),
                 new NavigationViewItem("Canvas", typeof(CanvasPage)),
@@ -125,7 +125,7 @@ public partial class MainWindowViewModel : ObservableObject
         },
         new NavigationViewItem("Navigation", SymbolRegular.Navigation24, typeof(NavigationPage))
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem("BreadcrumbBar", typeof(BreadcrumbBarPage)),
                 new NavigationViewItem("NavigationView", typeof(NavigationViewPage)),
@@ -140,7 +140,7 @@ public partial class MainWindowViewModel : ObservableObject
             typeof(StatusAndInfoPage)
         )
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem("InfoBadge", typeof(InfoBadgePage)),
                 new NavigationViewItem("InfoBar", typeof(InfoBarPage)),
@@ -151,7 +151,7 @@ public partial class MainWindowViewModel : ObservableObject
         },
         new NavigationViewItem("Text", SymbolRegular.DrawText24, typeof(TextPage))
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem(nameof(AutoSuggestBox), typeof(AutoSuggestBoxPage)),
                 new NavigationViewItem(nameof(NumberBox), typeof(NumberBoxPage)),
@@ -164,7 +164,7 @@ public partial class MainWindowViewModel : ObservableObject
         },
         new NavigationViewItem("System", SymbolRegular.Desktop24, typeof(OpSystemPage))
         {
-            MenuItems = new object[]
+            MenuItemsSource = new object[]
             {
                 new NavigationViewItem("Clipboard", typeof(ClipboardPage)),
                 new NavigationViewItem("FilePicker", typeof(FilePickerPage)),

--- a/src/Wpf.Ui.Gallery/Views/Pages/Navigation/NavigationViewPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Navigation/NavigationViewPage.xaml
@@ -197,7 +197,12 @@
                     <ui:NavigationViewItem
                         Content="Menu Item 1"
                         Icon="{ui:SymbolIcon Home24}"
-                        TargetPageType="{x:Type samples:SamplePage1}" />
+                        TargetPageType="{x:Type samples:SamplePage1}">
+                        <ui:NavigationViewItem.MenuItems>
+                            <ui:NavigationViewItem Content="Menu SubItem 1" TargetPageType="{x:Type samples:SamplePage3}" />
+                            <ui:NavigationViewItem Content="Menu SubItem 2" TargetPageType="{x:Type samples:SamplePage3}" />
+                        </ui:NavigationViewItem.MenuItems>
+                    </ui:NavigationViewItem>
                     <ui:NavigationViewItem
                         Content="Menu Item 2"
                         Icon="{ui:SymbolIcon AppFolder24}"

--- a/src/Wpf.Ui.Gallery/Views/Windows/SandboxWindow.xaml.cs
+++ b/src/Wpf.Ui.Gallery/Views/Windows/SandboxWindow.xaml.cs
@@ -22,7 +22,7 @@ public partial class SandboxWindow
 
         MyTestNavigationView.Loaded += (sender, args) =>
         {
-            MyTestNavigationView.MenuItems = new ObservableCollection<object>()
+            MyTestNavigationView.MenuItemsSource = new ObservableCollection<object>()
             {
                 new NavigationViewItem("Home", SymbolRegular.Home24, typeof(SamplePage1))
             };

--- a/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
@@ -36,7 +36,7 @@ public interface INavigationView
     /// <summary>
     /// Gets the collection of menu items displayed in the NavigationView.
     /// </summary>
-    IList MenuItems { get; set; }
+    IList MenuItems { get; }
 
     /// <summary>
     /// Gets or sets an object source used to generate the content of the NavigationView menu.
@@ -46,7 +46,7 @@ public interface INavigationView
     /// <summary>
     /// Gets the list of objects to be used as navigation items in the footer menu.
     /// </summary>
-    IList FooterMenuItems { get; set; }
+    IList FooterMenuItems { get; }
 
     /// <summary>
     /// Gets or sets the object that represents the navigation items to be used in the footer menu.

--- a/src/Wpf.Ui/Controls/NavigationView/INavigationViewItem.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/INavigationViewItem.cs
@@ -35,7 +35,7 @@ public interface INavigationViewItem
     /// <summary>
     /// Gets the collection of menu items displayed in the NavigationView.
     /// </summary>
-    IList MenuItems { get; set; }
+    IList MenuItems { get; }
 
     /// <summary>
     /// Gets or sets an object source used to generate the content of the NavigationView menu.

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -94,7 +94,7 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         // TODO: Refresh
-        UpdateVisualState((NavigationView)sender);
+        //UpdateVisualState((NavigationView)sender);
     }
 
     /// <summary>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -3,9 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-// Based on Windows UI Library
-// Copyright(c) Microsoft Corporation.All rights reserved.
-
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -15,17 +12,15 @@ using System.Windows.Input;
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 
-// https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.navigationview?view=winrt-22621
+// Based on Windows UI Library https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.navigationview?view=winrt-22621
 
 /// <summary>
 /// Represents a container that enables navigation of app content. It has a header, a view for the main content, and a menu pane for navigation commands.
 /// </summary>
-//[ToolboxItem(true)]
-//[System.Drawing.ToolboxBitmap(typeof(NavigationView), "NavigationView.bmp")]
 public partial class NavigationView : System.Windows.Controls.Control, INavigationView
 {
     /// <summary>
-    /// Static constructor which overrides default property metadata.
+    /// Initializes static members of the <see cref="NavigationView"/> class and overrides default property metadata.
     /// </summary>
     static NavigationView()
     {
@@ -42,10 +37,6 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     public NavigationView()
     {
         NavigationParent = this;
-
-        //It really should be here
-        MenuItems = new ObservableCollection<object>();
-        FooterMenuItems = new ObservableCollection<object>();
 
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
@@ -283,54 +274,35 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
         NavigateToMenuItemFromAutoSuggestBox(FooterMenuItems, element);
     }
 
-    protected virtual void AddItemsToDictionaries(IList list)
+    protected virtual void AddItemsToDictionaries(IEnumerable list)
     {
-        for (var i = 0; i < list.Count; i++)
+        foreach (NavigationViewItem singleNavigationViewItem in list.OfType<NavigationViewItem>())
         {
-            var singleMenuItem = list[i];
-
-            if (singleMenuItem is not INavigationViewItem singleNavigationViewItem)
-                continue;
-
             if (!PageIdOrTargetTagNavigationViewsDictionary.ContainsKey(singleNavigationViewItem.Id))
             {
-                PageIdOrTargetTagNavigationViewsDictionary.Add(
-                    singleNavigationViewItem.Id,
-                    singleNavigationViewItem
-                );
+                PageIdOrTargetTagNavigationViewsDictionary.Add(singleNavigationViewItem.Id, singleNavigationViewItem);
             }
 
-            if (
-                !PageIdOrTargetTagNavigationViewsDictionary.ContainsKey(
-                    singleNavigationViewItem.TargetPageTag
-                )
-            )
+            if (!PageIdOrTargetTagNavigationViewsDictionary.ContainsKey(singleNavigationViewItem.TargetPageTag))
             {
-                PageIdOrTargetTagNavigationViewsDictionary.Add(
-                    singleNavigationViewItem.TargetPageTag,
-                    singleNavigationViewItem
-                );
+                PageIdOrTargetTagNavigationViewsDictionary.Add(singleNavigationViewItem.TargetPageTag, singleNavigationViewItem);
             }
 
-            if (
-                singleNavigationViewItem.TargetPageType is not null
-                && !PageTypeNavigationViewsDictionary.ContainsKey(singleNavigationViewItem.TargetPageType)
-            )
+            if (singleNavigationViewItem.TargetPageType != null
+                && !PageTypeNavigationViewsDictionary.ContainsKey(singleNavigationViewItem.TargetPageType))
             {
-                PageTypeNavigationViewsDictionary.Add(
-                    singleNavigationViewItem.TargetPageType,
-                    singleNavigationViewItem
-                );
+                PageTypeNavigationViewsDictionary.Add(singleNavigationViewItem.TargetPageType, singleNavigationViewItem);
             }
 
             singleNavigationViewItem.IsMenuElement = true;
 
-            if (singleNavigationViewItem.MenuItems.Count <= 0)
-                continue;
-
-            AddItemsToDictionaries(singleNavigationViewItem.MenuItems);
+            if (singleNavigationViewItem.HasMenuItems)
+            {
+                AddItemsToDictionaries(singleNavigationViewItem.MenuItems);
+            }
         }
     }
+
 
     protected virtual void AddItemsToDictionaries()
     {
@@ -338,25 +310,21 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
         AddItemsToDictionaries(FooterMenuItems);
     }
 
-    protected virtual void AddItemsToAutoSuggestBoxItems(IList list)
+    protected virtual void AddItemsToAutoSuggestBoxItems(IEnumerable list)
     {
-        for (var i = 0; i < list.Count; i++)
+        foreach (NavigationViewItem singleNavigationViewItem in list.OfType<NavigationViewItem>())
         {
-            var singleMenuItem = list[i];
-
-            if (singleMenuItem is not NavigationViewItem singleNavigationViewItem)
-                continue;
-
             if (
                 singleNavigationViewItem is { Content: string content, TargetPageType: { } }
-                && !string.IsNullOrWhiteSpace(content)
-            )
+                && !String.IsNullOrWhiteSpace(content))
+            {
                 _autoSuggestBoxItems.Add(content);
+            }
 
-            if (singleNavigationViewItem.MenuItems.Count <= 0)
-                continue;
-
-            AddItemsToAutoSuggestBoxItems(singleNavigationViewItem.MenuItems);
+            if (singleNavigationViewItem.HasMenuItems)
+            {
+                AddItemsToAutoSuggestBoxItems(singleNavigationViewItem.MenuItems);
+            }
         }
     }
 
@@ -366,15 +334,10 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
         AddItemsToAutoSuggestBoxItems(FooterMenuItems);
     }
 
-    protected virtual bool NavigateToMenuItemFromAutoSuggestBox(IList list, string selectedSuggestBoxItem)
+    protected virtual bool NavigateToMenuItemFromAutoSuggestBox(IEnumerable list, string selectedSuggestBoxItem)
     {
-        for (var i = 0; i < list.Count; i++)
+        foreach (NavigationViewItem singleNavigationViewItem in list.OfType<NavigationViewItem>())
         {
-            var singleMenuItem = list[i];
-
-            if (singleMenuItem is not NavigationViewItem singleNavigationViewItem)
-                continue;
-
             if (singleNavigationViewItem.Content is string content && content == selectedSuggestBoxItem)
             {
                 NavigateInternal(singleNavigationViewItem);
@@ -384,26 +347,28 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
                 return true;
             }
 
-            if (singleNavigationViewItem.MenuItems.Count <= 0)
-                continue;
-
-            NavigateToMenuItemFromAutoSuggestBox(singleNavigationViewItem.MenuItems, selectedSuggestBoxItem);
+            if (NavigateToMenuItemFromAutoSuggestBox(singleNavigationViewItem.MenuItems, selectedSuggestBoxItem))
+            {
+                return true;
+            }
         }
 
         return false;
     }
 
-    protected virtual void UpdateMenuItemsTemplate(IList list)
+    protected virtual void UpdateMenuItemsTemplate(IEnumerable list)
     {
-        for (var i = 0; i < list.Count; i++)
+        if (ItemTemplate == null)
         {
-            var singleMenuItem = list[i];
+            return;
+        }
 
-            if (singleMenuItem is not NavigationViewItem singleNavigationViewItem)
-                continue;
-
-            if (ItemTemplate is not null && singleNavigationViewItem.Template != ItemTemplate)
+        foreach (var item in list)
+        {
+            if (item is NavigationViewItem singleNavigationViewItem)
+            {
                 singleNavigationViewItem.Template = ItemTemplate;
+            }
         }
     }
 
@@ -432,16 +397,14 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
         currentItem.NavigationViewItemParent?.Activate(this);
     }
 
-    protected void DeactivateMenuItems(IList list)
+    protected void DeactivateMenuItems(IEnumerable list)
     {
-        for (var i = 0; i < list.Count; i++)
+        foreach (var item in list)
         {
-            var singleMenuItem = list[i];
-
-            if (singleMenuItem is not NavigationViewItem singleNavigationViewItem)
-                continue;
-
-            singleNavigationViewItem.Deactivate(this);
+            if (item is NavigationViewItem singleNavigationViewItem)
+            {
+                singleNavigationViewItem.Deactivate(this);
+            }
         }
     }
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -41,6 +41,15 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
         SizeChanged += OnSizeChanged;
+
+        // Initialize MenuItems collection
+        var menuItems = new ObservableCollection<object>();
+        menuItems.CollectionChanged += OnMenuItems_CollectionChanged;
+        SetValue(MenuItemsPropertyKey, menuItems);
+
+        var footerMenuItems = new ObservableCollection<object>();
+        footerMenuItems.CollectionChanged += OnMenuItems_CollectionChanged;
+        SetValue(FooterMenuItemsPropertyKey, footerMenuItems);
     }
 
     /// <inheritdoc/>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -54,6 +54,16 @@ public partial class NavigationView
         new FrameworkPropertyMetadata(false)
     );
 
+    private static readonly DependencyPropertyKey MenuItemsPropertyKey = DependencyProperty.RegisterReadOnly(
+       nameof(MenuItems),
+       typeof(ObservableCollection<object>),
+       typeof(NavigationView),
+       new PropertyMetadata(null)
+   );
+
+    /// <summary>Identifies the <see cref="MenuItems"/> dependency property.</summary>
+    public static readonly DependencyProperty MenuItemsProperty = MenuItemsPropertyKey.DependencyProperty;
+
     /// <summary>
     /// Property for <see cref="MenuItemsSource"/>.
     /// </summary>
@@ -63,6 +73,16 @@ public partial class NavigationView
         typeof(NavigationView),
         new FrameworkPropertyMetadata(null, OnMenuItemsSourceChanged)
     );
+
+    private static readonly DependencyPropertyKey FooterMenuItemsPropertyKey = DependencyProperty.RegisterReadOnly(
+       nameof(FooterMenuItems),
+       typeof(ObservableCollection<object>),
+       typeof(NavigationView),
+       new PropertyMetadata(null)
+   );
+
+    /// <summary>Identifies the <see cref="FooterMenuItems"/> dependency property.</summary>
+    public static readonly DependencyProperty FooterMenuItemsProperty = FooterMenuItemsPropertyKey.DependencyProperty;
 
     /// <summary>
     /// Property for <see cref="FooterMenuItemsSource"/>.
@@ -298,22 +318,8 @@ public partial class NavigationView
         set => SetValue(AlwaysShowHeaderProperty, value);
     }
 
-    private ObservableCollection<object>? _menuItems;
-
     /// <inheritdoc/>
-    public IList MenuItems
-    {
-        get
-        {
-            if (_menuItems == null)
-            {
-                _menuItems = new ObservableCollection<object>();
-                _menuItems.CollectionChanged += OnMenuItems_CollectionChanged;
-            }
-
-            return _menuItems;
-        }
-    }
+    public IList MenuItems => (ObservableCollection<object>)GetValue(MenuItemsProperty);
 
     /// <inheritdoc/>
     [Bindable(true)]
@@ -333,22 +339,8 @@ public partial class NavigationView
         }
     }
 
-    private ObservableCollection<object>? _footerMenuItems;
-
     /// <inheritdoc/>
-    public IList FooterMenuItems
-    {
-        get
-        {
-            if (_footerMenuItems == null)
-            {
-                _footerMenuItems = new ObservableCollection<object>();
-                _footerMenuItems.CollectionChanged += OnFooterMenuItems_CollectionChanged;
-            }
-
-            return _footerMenuItems;
-        }
-    }
+    public IList FooterMenuItems => (ObservableCollection<object>)GetValue(FooterMenuItemsProperty);
 
     /// <inheritdoc/>
     [Bindable(true)]

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewItem.cs
@@ -143,37 +143,8 @@ public class NavigationViewItem
 
     #region Properties
 
-    //private ObservableCollection<object>? _menuItems;
-
     /// <inheritdoc/>
-    /*public IList MenuItems
-    {
-        get
-        {
-            if (_menuItems == null)
-            {
-                _menuItems = new ObservableCollection<object>();
-                _menuItems.CollectionChanged += OnMenuItems_CollectionChanged;
-            }
-
-            return _menuItems;
-        }
-    }*/
-
-    public IList MenuItems
-    {
-        get
-        {
-            if ((ObservableCollection<object>)GetValue(MenuItemsProperty) == null)
-            {
-                var collection = new ObservableCollection<object>();
-                collection.CollectionChanged += OnMenuItems_CollectionChanged;
-                SetValue(MenuItemsPropertyKey, collection);
-            }
-
-            return (ObservableCollection<object>)GetValue(MenuItemsProperty);
-        }
-    }
+    public IList MenuItems => (ObservableCollection<object>)GetValue(MenuItemsProperty);
 
     /// <inheritdoc/>
     [Bindable(true)]
@@ -292,6 +263,11 @@ public class NavigationViewItem
         };
 
         Loaded += (_, _) => InitializeNavigationViewEvents();
+
+        // Initialize the `Items` collection
+        var menuItems = new ObservableCollection<object>();
+        menuItems.CollectionChanged += OnMenuItems_CollectionChanged;
+        SetValue(MenuItemsPropertyKey, menuItems);
     }
 
     public NavigationViewItem(Type targetPageType)

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
@@ -191,7 +191,7 @@
                 HorizontalOffset="-12"
                 IsOpen="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                 Placement="Bottom"
-                PlacementTarget="{Binding ElementName=Border}"
+                PlacementTarget="{Binding ElementName=MainBorder}"
                 PopupAnimation="None"
                 StaysOpen="False"
                 VerticalOffset="1">
@@ -200,8 +200,8 @@
                     x:Name="SubMenuBorder"
                     Margin="12,0,12,18"
                     Padding="0,3,0,3"
-                    Background="{DynamicResource FlyoutBorderBrush}"
-                    BorderBrush="{DynamicResource FlyoutBackground}"
+                    Background="{DynamicResource FlyoutBackground}"
+                    BorderBrush="{DynamicResource FlyoutBorderBrush}"
                     BorderThickness="1"
                     CornerRadius="8"
                     SnapsToDevicePixels="True">
@@ -320,11 +320,11 @@
                                 From="0.0"
                                 To="1.0"
                                 Duration="0:0:0.167" />
-                            <DoubleAnimation
+                            <!--<DoubleAnimation
                                 Storyboard.TargetName="ChevronIcon"
                                 Storyboard.TargetProperty="(Control.RenderTransform).(RotateTransform.Angle)"
                                 To="-180"
-                                Duration="00:00:00.167" />
+                                Duration="00:00:00.167" />-->
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -338,11 +338,11 @@
                                 To="0.0"
                                 Duration="0:0:0.167" />
 
-                            <DoubleAnimation
+                            <!--<DoubleAnimation
                                 Storyboard.TargetName="ChevronIcon"
                                 Storyboard.TargetProperty="(Control.RenderTransform).(RotateTransform.Angle)"
                                 To="0"
-                                Duration="00:00:00.167" />
+                                Duration="00:00:00.167" />-->
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Rework `MenuItems` and `FooterMenuItems` in `NavigationView` and `NavigationViewItem`. Once fixed, we can showcase submenu items in the Gallery App.
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
Submenu styling was already implemented in the NavigationView's Top mode but was omitted from the Gallery App, presumably due to bugs (see #759). The main problem, as I saw it, was the cohesion between `Items`, `ItemsSource` and their dependency properties (DPs).
Traditionally in a wpf `ItemsControl`, `Items` is a readonly property of type `ItemsCollection` which can maintain it's own `ItemsSource`. In WinUi, it's still readonly but of the more generic type `IList<object>` and it comes with a DP.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
The relationship between `Items` and `ItemsSource` has been redefined. For each `Items`/`ItemsSource` pair, there is now one collection (`ObservableCollection<object>`) created in the control's constructor. Lazy loading in the getter proved problematic because XAML bypasses the getter in favor of its own store when a DP is defined. Instead of replacing the collection, `ItemsSource` now clears and updates the collection's elements. The `Items` properties is now read-only and backed by a read-only dependency property, aligning with conventional WPF/WinUI practices.

Added submenu content to the Gallery App
![Screenshot 2024-03-22 203837](https://github.com/lepoco/wpfui/assets/78566945/0214c903-fd02-43de-a1d8-4180db589f4d)

