### PR TITLE
Fix regression in PR #1012

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -68,6 +68,15 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
 
     protected static void UpdateVisualState(NavigationView navigationView)
     {
+        // Skip display modes that don't have multiple states
+        if (navigationView.PaneDisplayMode is
+            NavigationViewPaneDisplayMode.LeftFluent or
+            NavigationViewPaneDisplayMode.Top or
+            NavigationViewPaneDisplayMode.Bottom)
+        {
+            return;
+        }
+
         _ = VisualStateManager.GoToState(
             navigationView,
             navigationView.IsPaneOpen ? "PaneOpen" : "PaneCompact",
@@ -94,7 +103,7 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         // TODO: Refresh
-        //UpdateVisualState((NavigationView)sender);
+        UpdateVisualState((NavigationView)sender);
     }
 
     /// <summary>


### PR DESCRIPTION
As @koal44 pointed out, https://github.com/lepoco/wpfui/pull/1012 introduced a bug which made the app crash when using FluentLeft navigation because updating the visual state tries to animate a width to or from OpenPaneLength=NaN. Sorry about that.

To avoid this, don't try to change the visual state for navigation view modes that don't have an open and a compact state.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
App crashes when using FluentLeft navigation mode, or at least it did before dd83b6eb9cceeeb8fb324fad16e1b3b6ae17719e

Issue Number: [Comment in PR #1012](https://github.com/lepoco/wpfui/pull/1012#issuecomment-2016329127)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Don't try to change the visual state for FluentLeft, Top or Bottom navigation view modes

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
