### PR TITLE
TitleBarButton: Fix Foreground not using property value at initial

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -115,6 +115,7 @@ public class TitleBarButton : Wpf.Ui.Controls.Button
 
     private void TitleBarButton_Loaded(object sender, RoutedEventArgs e)
     {
+        RenderButtonsForeground = ButtonsForeground;
         DependencyPropertyDescriptor
             .FromProperty(ButtonsForegroundProperty, typeof(Brush))
             .AddValueChanged(this, OnButtonsForegroundChanged);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![image](https://github.com/lepoco/wpfui/assets/8638535/10015680-a30f-4628-9d72-e2622bda177b)

Cause using `RenderButtonsForeground` as Canvas's `FillColor`, when app initial the window theme, `ButtonsForeground` changed but the event hadn't raised.

Issue Number: https://github.com/lepoco/wpfui/issues/1009#issuecomment-2011119494

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

![image](https://github.com/lepoco/wpfui/assets/8638535/a0cacd1d-d828-40c6-82ab-7961e34ff6c5)

- Set `RenderButtonsForeground` as `ButtonsForeground` when TitleBarButton Loaded.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
