### PR TITLE
Fixed the FontIcon markup extension

### DIFF
--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -46,9 +46,9 @@
                 <ControlTemplate TargetType="{x:Type TextBox}">
                     <controls:PassiveScrollViewer
                         x:Name="PART_ContentHost"
-                        VerticalAlignment="Stretch"
-                        HorizontalAlignment="Stretch"
                         Margin="{TemplateBinding Padding}"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
                         Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
                 </ControlTemplate>

--- a/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
@@ -116,7 +116,7 @@ public class FontIcon : IconElement
     /// Gets or sets the character code that identifies the icon glyph.
     /// </summary>
     /// <returns>The hexadecimal character code for the icon glyph.</returns>
-    public string Glyph
+    public string? Glyph
     {
         get => (string)GetValue(GlyphProperty);
         set => SetValue(GlyphProperty, value);

--- a/src/Wpf.Ui/Controls/ListView/ListViewItem.xaml
+++ b/src/Wpf.Ui/Controls/ListView/ListViewItem.xaml
@@ -48,7 +48,7 @@
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
-  <ControlTemplate x:Key="GridViewItemTemplate" TargetType="{x:Type controls:ListViewItem}">
+    <ControlTemplate x:Key="GridViewItemTemplate" TargetType="{x:Type controls:ListViewItem}">
         <Border
             x:Name="Border"
             Margin="0"

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -54,10 +54,10 @@
                     <Grid HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}">
                         <Border
                             x:Name="ContentBorder"
-                            MinWidth="{TemplateBinding MinWidth}"
-                            MinHeight="{TemplateBinding MinHeight}"
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MinHeight="{TemplateBinding MinHeight}"
                             Padding="0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
@@ -82,8 +82,8 @@
                                     VerticalAlignment="Top"
                                     Content="{TemplateBinding Icon}"
                                     FontSize="16"
-                                    IsTabStop="False"
-                                    Foreground="{TemplateBinding Foreground}" />
+                                    Foreground="{TemplateBinding Foreground}"
+                                    IsTabStop="False" />
                                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
                                     <controls:PassiveScrollViewer
                                         x:Name="PART_ContentHost"
@@ -115,8 +115,8 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="clear"
                                     Cursor="Arrow"
-                                    IsTabStop="False"
-                                    Foreground="{DynamicResource TextControlButtonForeground}">
+                                    Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="Dismiss24" />
                                     </controls:Button.Icon>
@@ -178,8 +178,8 @@
                                     VerticalAlignment="Top"
                                     Content="{TemplateBinding Icon}"
                                     FontSize="16"
-                                    IsTabStop="False"
-                                    Foreground="{TemplateBinding Foreground}" />
+                                    Foreground="{TemplateBinding Foreground}"
+                                    IsTabStop="False" />
                             </Grid>
                         </Border>
                         <!--  The Accent Border is a separate element so that changes to the border thickness do not affect the position of the element  -->

--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
@@ -204,8 +204,8 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="clear"
                                     Cursor="Arrow"
-                                    IsTabStop="False"
-                                    Foreground="{DynamicResource TextControlButtonForeground}">
+                                    Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource PasswordBoxButtonIconSize}" Symbol="Dismiss24" />
                                     </controls:Button.Icon>
@@ -228,8 +228,8 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="reveal"
                                     Cursor="Arrow"
-                                    IsTabStop="False"
-                                    Foreground="{DynamicResource TextControlButtonForeground}">
+                                    Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource PasswordBoxButtonIconSize}" Symbol="Eye24" />
                                     </controls:Button.Icon>

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -183,8 +183,8 @@
                                     x:Name="PART_CloseButton"
                                     Grid.Column="4"
                                     ButtonType="Close"
-                                    MouseOverButtonsForeground="White"
-                                    MouseOverBackground="{DynamicResource PaletteRedBrush}" />
+                                    MouseOverBackground="{DynamicResource PaletteRedBrush}"
+                                    MouseOverButtonsForeground="White" />
                             </Grid>
                         </Grid>
                     </Grid>

--- a/src/Wpf.Ui/Extensions/SymbolExtensions.cs
+++ b/src/Wpf.Ui/Extensions/SymbolExtensions.cs
@@ -34,7 +34,7 @@ public static class SymbolExtensions
     /// <summary>
     /// Converts <see cref="SymbolRegular"/> to <see langword="string"/> based on the ID.
     /// </summary>
-    public static string GetString(this SymbolRegular icon)
+    public static string? GetString(this SymbolRegular icon)
     {
         return Encoding.Unicode.GetString(BitConverter.GetBytes((int)icon)).TrimEnd('\0');
     }
@@ -42,7 +42,7 @@ public static class SymbolExtensions
     /// <summary>
     /// Converts <see cref="SymbolFilled"/> to <see langword="string"/> based on the ID.
     /// </summary>
-    public static string GetString(this SymbolFilled icon)
+    public static string? GetString(this SymbolFilled icon)
     {
         return Encoding.Unicode.GetString(BitConverter.GetBytes((int)icon)).TrimEnd('\0');
     }

--- a/src/Wpf.Ui/Markup/FontIconExtension.cs
+++ b/src/Wpf.Ui/Markup/FontIconExtension.cs
@@ -32,29 +32,31 @@ namespace Wpf.Ui.Markup;
 [MarkupExtensionReturnType(typeof(FontIcon))]
 public class FontIconExtension : MarkupExtension
 {
+    public FontIconExtension()
+    {
+    }
+
     public FontIconExtension(string glyph)
     {
         Glyph = glyph;
-        FontFamily = new FontFamily("FluentSystemIcons");
-    }
-
-    public FontIconExtension(string glyph, FontFamily fontFamily)
-        : this(glyph)
-    {
-        FontFamily = fontFamily;
     }
 
     [ConstructorArgument("glyph")]
-    public string Glyph { get; set; }
+    public string? Glyph { get; set; }
 
     [ConstructorArgument("fontFamily")]
-    public FontFamily FontFamily { get; set; }
+    public FontFamily FontFamily { get; set; } = new("FluentSystemIcons");
 
     public double FontSize { get; set; }
 
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        var fontIcon = new FontIcon { Glyph = Glyph, FontFamily = FontFamily };
+        if (serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget { TargetObject: Setter })
+        {
+            return this;
+        }
+
+        FontIcon fontIcon = new() { Glyph = Glyph, FontFamily = FontFamily };
 
         if (FontSize > 0)
         {

--- a/src/Wpf.Ui/Resources/DefaultTextBoxScrollViewerStyle.xaml
+++ b/src/Wpf.Ui/Resources/DefaultTextBoxScrollViewerStyle.xaml
@@ -1,5 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--  TODO: Rework TextBox ScrollViewer  -->
     <Style x:Key="DefaultTextBoxScrollViewerStyle" TargetType="{x:Type ScrollViewer}">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

So: I haven't watched the classes because I haven't had time lately. Luckily I have a few days.
That's why I now looked at the markup class.

Markup extensions in XAML require a default constructor with no parameters.
This is missing in the implementation because both constructors expect parameters.
And the most important:
Initializing the FontFamily property twice is not necessary and can lead to problems (which was probably the reason why the FontFamily was only recognized after the line was manually deleted and reinserted) especially if a user sets a different value to FontFamily hands over.

Issue Number: N/A

## What is the new behavior?

Now the FontIcon class should work as expected.
Should fix #666 and #986
#163 is a bug inside the tilebar and to directly connected to the FontIcon class itself.

## Other information
I would like to reafactor the code. Right now it's harder to follow up as it needs to be and the readability suffers greatly as a result. What do you say?
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
