### PR TITLE
Fix incorrectly refactored High Contrast theme dictionary selection

### DIFF
--- a/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
@@ -97,7 +97,7 @@ public static class ApplicationThemeManager
                     SystemTheme.HC1 => "HC1",
                     SystemTheme.HC2 => "HC2",
                     SystemTheme.HCBlack => "HCBlack",
-                    SystemTheme.HCWhite => "HCBlack",
+                    SystemTheme.HCWhite => "HCWhite",
                     _ => "HCWhite",
                 };
                 break;


### PR DESCRIPTION
This was broken in c0ace5b18648a2f7ccc77eff388cae1fa6ef8555

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Selecting the Desert HC theme picks one of the dark HC themes instead

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Selecting Desert works again
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
