### PR TITLE
Fixed the markup extension for the SymbolIcon and FontIcon class not working at all.

### DIFF
--- a/src/Wpf.Ui/Controls/Arc/Arc.cs
+++ b/src/Wpf.Ui/Controls/Arc/Arc.cs
@@ -3,27 +3,24 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
+using System.Windows.Controls;
+using System.Windows.Shapes;
 using Point = System.Windows.Point;
 using Size = System.Windows.Size;
+#pragma warning disable SA1124
 
-// ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 
-/// <summary>
-/// Control that draws a symmetrical arc with rounded edges.
-/// </summary>
-/// <example>
-/// <code lang="xml">
-/// &lt;ui:Arc
-///     EndAngle="359"
-///     StartAngle="0"
-///     Stroke="{ui:ThemeResource SystemAccentColorSecondaryBrush}"
-///     StrokeThickness="2"
-///     Visibility="Visible" /&gt;
-/// </code>
-/// </example>
-public class Arc : System.Windows.Shapes.Shape
+public class Arc : Shape
 {
+    #region Declarations
+
+    private Viewbox? _rootLayout;
+
+    #endregion
+
+    #region Static Properties
+
     /// <summary>Identifies the <see cref="StartAngle"/> dependency property.</summary>
     public static readonly DependencyProperty StartAngleProperty = DependencyProperty.Register(
         nameof(StartAngle),
@@ -39,6 +36,28 @@ public class Arc : System.Windows.Shapes.Shape
         typeof(Arc),
         new PropertyMetadata(0.0d, PropertyChangedCallback)
     );
+
+    /// <summary>Identifies the <see cref="SweepDirection"/> dependency property.</summary>
+    public static readonly DependencyProperty SweepDirectionProperty =
+        DependencyProperty.Register(
+            nameof(SweepDirection),
+            typeof(SweepDirection),
+            typeof(Arc),
+            new PropertyMetadata(SweepDirection.Clockwise, PropertyChangedCallback)
+            );
+
+    /// <summary>Identifies the <see cref="StrokeStartLineCap"/> dependency property.</summary>
+    public static new readonly DependencyProperty StrokeStartLineCapProperty =
+        DependencyProperty.Register(
+            nameof(StrokeStartLineCap),
+            typeof(PenLineCap),
+            typeof(Arc),
+            new PropertyMetadata(PenLineCap.Round, PropertyChangedCallback)
+            );
+
+    #endregion
+
+    #region Public Properties
 
     /// <summary>
     /// Gets or sets the initial angle from which the arc will be drawn.
@@ -59,37 +78,52 @@ public class Arc : System.Windows.Shapes.Shape
     }
 
     /// <summary>
+    /// Gets or sets the direction to where the arc will be drawn.
+    /// </summary>
+    public SweepDirection SweepDirection
+    {
+        get => (SweepDirection)GetValue(SweepDirectionProperty);
+        set => SetValue(SweepDirectionProperty, value);
+    }
+
+    public new PenLineCap StrokeStartLineCap
+    {
+        get { return (PenLineCap)GetValue(StrokeStartLineCapProperty); }
+        set { SetValue(StrokeStartLineCapProperty, value); }
+    }
+
+    /// <summary>
     /// Gets a value indicating whether one of the two larger arc sweeps is chosen; otherwise, if is <see langword="false"/>, one of the smaller arc sweeps is chosen.
     /// </summary>
     public bool IsLargeArc { get; internal set; } = false;
 
-    /// <inheritdoc />
-    protected override Geometry DefiningGeometry => GetDefiningGeometry();
+    #endregion
 
-    /// <summary>
-    /// Initializes static members of the <see cref="Arc"/> class.
-    /// </summary>
-    /// <remarks>
-    /// Overrides default properties.
-    /// </remarks>
-    static Arc()
+    #region Private Methods
+
+    private void EnsureRootLayout()
     {
-        StrokeStartLineCapProperty.OverrideMetadata(
-            typeof(Arc),
-            new FrameworkPropertyMetadata(PenLineCap.Round)
-        );
+        if (_rootLayout != null)
+        {
+            return;
+        }
 
-        StrokeEndLineCapProperty.OverrideMetadata(
-            typeof(Arc),
-            new FrameworkPropertyMetadata(PenLineCap.Round)
-        );
+        _rootLayout = new Viewbox { SnapsToDevicePixels = true };
+        AddVisualChild(_rootLayout);
     }
+
+    #endregion
+
+    #region Protected Methods
+
+    /// <inheritdoc />
+    protected override Geometry DefiningGeometry => DefinedGeometry();
 
     /// <summary>
     /// Get the geometry that defines this shape.
     /// <para><see href="https://stackoverflow.com/a/36756365/13224348">Based on Mark Feldman implementation.</see></para>
     /// </summary>
-    protected Geometry GetDefiningGeometry()
+    protected Geometry DefinedGeometry()
     {
         var geometryStream = new StreamGeometry();
         var arcSize = new Size(
@@ -97,20 +131,18 @@ public class Arc : System.Windows.Shapes.Shape
             Math.Max(0, (RenderSize.Height - StrokeThickness) / 2)
         );
 
-        using (StreamGeometryContext context = geometryStream.Open())
-        {
-            context.BeginFigure(PointAtAngle(Math.Min(StartAngle, EndAngle)), false, false);
+        using StreamGeometryContext context = geometryStream.Open();
+        context.BeginFigure(PointAtAngle(Math.Min(StartAngle, EndAngle)), false, false);
 
-            context.ArcTo(
-                PointAtAngle(Math.Max(StartAngle, EndAngle)),
-                arcSize,
-                0,
-                IsLargeArc,
-                SweepDirection.Counterclockwise,
-                true,
-                false
-            );
-        }
+        context.ArcTo(
+            PointAtAngle(Math.Max(StartAngle, EndAngle)),
+            arcSize,
+            0,
+            IsLargeArc,
+            SweepDirection,
+            true,
+            false
+        );
 
         geometryStream.Transform = new TranslateTransform(StrokeThickness / 2, StrokeThickness / 2);
 
@@ -124,11 +156,36 @@ public class Arc : System.Windows.Shapes.Shape
     /// <param name="angle">The angle at which to create the point.</param>
     protected Point PointAtAngle(double angle)
     {
-        var radAngle = angle * (Math.PI / 180);
-        var xRadius = (RenderSize.Width - StrokeThickness) / 2;
-        var yRadius = (RenderSize.Height - StrokeThickness) / 2;
+        if (SweepDirection == SweepDirection.Counterclockwise)
+        {
+            angle += 90;
+            angle %= 360;
+            if (angle < 0)
+            {
+                angle += 360;
+            }
 
-        return new Point(xRadius + (xRadius * Math.Cos(radAngle)), yRadius - (yRadius * Math.Sin(radAngle)));
+            var radAngle = angle * (Math.PI / 180);
+            var xRadius = (RenderSize.Width - StrokeThickness) / 2;
+            var yRadius = (RenderSize.Height - StrokeThickness) / 2;
+
+            return new Point(xRadius + (xRadius * Math.Cos(radAngle)), yRadius - (yRadius * Math.Sin(radAngle)));
+        }
+        else
+        {
+            angle -= 90;
+            angle %= 360;
+            if (angle < 0)
+            {
+                angle += 360;
+            }
+
+            var radAngle = angle * (Math.PI / 180);
+            var xRadius = (RenderSize.Width - StrokeThickness) / 2;
+            var yRadius = (RenderSize.Height - StrokeThickness) / 2;
+
+            return new Point(xRadius + (xRadius * Math.Cos(-radAngle)), yRadius - (yRadius * Math.Sin(-radAngle)));
+        }
     }
 
     /// <summary>
@@ -142,8 +199,44 @@ public class Arc : System.Windows.Shapes.Shape
         }
 
         control.IsLargeArc = Math.Abs(control.EndAngle - control.StartAngle) > 180;
-
-        // Force complete new layout pass
         control.InvalidateVisual();
     }
+
+    protected override Visual? GetVisualChild(int index)
+    {
+        if (index != 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), "Arc should have only 1 child");
+        }
+
+        EnsureRootLayout();
+
+        return _rootLayout;
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        EnsureRootLayout();
+
+        _rootLayout!.Measure(availableSize);
+        return _rootLayout.DesiredSize;
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        EnsureRootLayout();
+
+        _rootLayout!.Arrange(new Rect(default, finalSize));
+        return finalSize;
+    }
+
+    /// <summary>Overrides the default OnRender method to draw the <see cref="Arc" /> element.</summary>
+    /// <param name="drawingContext">A <see cref="DrawingContext" /> object that is drawn during the rendering pass of this <see cref="System.Windows.Shapes.Shape" />.</param>
+    protected override void OnRender(DrawingContext drawingContext)
+    {
+        base.OnRender(drawingContext);
+        drawingContext.DrawGeometry(Stroke, new Pen(Stroke, StrokeThickness), DefinedGeometry());
+    }
+
+    #endregion
 }

--- a/src/Wpf.Ui/Controls/Arc/Arc.cs
+++ b/src/Wpf.Ui/Controls/Arc/Arc.cs
@@ -8,6 +8,7 @@ using System.Windows.Shapes;
 using Point = System.Windows.Point;
 using Size = System.Windows.Size;
 #pragma warning disable SA1124
+#pragma warning disable CS0108
 
 namespace Wpf.Ui.Controls;
 
@@ -47,7 +48,7 @@ public class Arc : Shape
             );
 
     /// <summary>Identifies the <see cref="StrokeStartLineCap"/> dependency property.</summary>
-    public static new readonly DependencyProperty StrokeStartLineCapProperty =
+    public static readonly DependencyProperty StrokeStartLineCapProperty =
         DependencyProperty.Register(
             nameof(StrokeStartLineCap),
             typeof(PenLineCap),
@@ -86,7 +87,7 @@ public class Arc : Shape
         set => SetValue(SweepDirectionProperty, value);
     }
 
-    public new PenLineCap StrokeStartLineCap
+    public PenLineCap StrokeStartLineCap
     {
         get { return (PenLineCap)GetValue(StrokeStartLineCapProperty); }
         set { SetValue(StrokeStartLineCapProperty, value); }
@@ -235,7 +236,13 @@ public class Arc : Shape
     protected override void OnRender(DrawingContext drawingContext)
     {
         base.OnRender(drawingContext);
-        drawingContext.DrawGeometry(Stroke, new Pen(Stroke, StrokeThickness), DefinedGeometry());
+        Pen pen = new(Stroke, StrokeThickness)
+        {
+            StartLineCap = StrokeStartLineCap,
+            EndLineCap = StrokeStartLineCap
+        };
+
+        drawingContext.DrawGeometry(Stroke, pen, DefinedGeometry());
     }
 
     #endregion

--- a/src/Wpf.Ui/Controls/Arc/Arc.cs
+++ b/src/Wpf.Ui/Controls/Arc/Arc.cs
@@ -7,20 +7,27 @@ using System.Windows.Controls;
 using System.Windows.Shapes;
 using Point = System.Windows.Point;
 using Size = System.Windows.Size;
-#pragma warning disable SA1124
+// ReSharper disable CheckNamespace
 #pragma warning disable CS0108
 
 namespace Wpf.Ui.Controls;
 
+/// <summary>
+/// Control that draws a symmetrical arc with rounded edges.
+/// </summary>
+/// <example>
+/// <code lang="xml">
+/// &lt;ui:Arc
+///     EndAngle="359"
+///     StartAngle="0"
+///     Stroke="{ui:ThemeResource SystemAccentColorSecondaryBrush}"
+///     StrokeThickness="2"
+///     Visibility="Visible" /&gt;
+/// </code>
+/// </example>
 public class Arc : Shape
 {
-    #region Declarations
-
     private Viewbox? _rootLayout;
-
-    #endregion
-
-    #region Static Properties
 
     /// <summary>Identifies the <see cref="StartAngle"/> dependency property.</summary>
     public static readonly DependencyProperty StartAngleProperty = DependencyProperty.Register(
@@ -55,10 +62,6 @@ public class Arc : Shape
             typeof(Arc),
             new PropertyMetadata(PenLineCap.Round, PropertyChangedCallback)
             );
-
-    #endregion
-
-    #region Public Properties
 
     /// <summary>
     /// Gets or sets the initial angle from which the arc will be drawn.
@@ -98,10 +101,6 @@ public class Arc : Shape
     /// </summary>
     public bool IsLargeArc { get; internal set; } = false;
 
-    #endregion
-
-    #region Private Methods
-
     private void EnsureRootLayout()
     {
         if (_rootLayout != null)
@@ -112,10 +111,6 @@ public class Arc : Shape
         _rootLayout = new Viewbox { SnapsToDevicePixels = true };
         AddVisualChild(_rootLayout);
     }
-
-    #endregion
-
-    #region Protected Methods
 
     /// <inheritdoc />
     protected override Geometry DefiningGeometry => DefinedGeometry();
@@ -244,6 +239,4 @@ public class Arc : Shape
 
         drawingContext.DrawGeometry(Stroke, pen, DefinedGeometry());
     }
-
-    #endregion
 }

--- a/src/Wpf.Ui/Markup/FontIconExtension.cs
+++ b/src/Wpf.Ui/Markup/FontIconExtension.cs
@@ -32,29 +32,31 @@ namespace Wpf.Ui.Markup;
 [MarkupExtensionReturnType(typeof(FontIcon))]
 public class FontIconExtension : MarkupExtension
 {
+    public FontIconExtension()
+    {
+    }
+
     public FontIconExtension(string glyph)
     {
         Glyph = glyph;
-        FontFamily = new FontFamily("FluentSystemIcons");
-    }
-
-    public FontIconExtension(string glyph, FontFamily fontFamily)
-        : this(glyph)
-    {
-        FontFamily = fontFamily;
     }
 
     [ConstructorArgument("glyph")]
-    public string Glyph { get; set; }
+    public string? Glyph { get; set; }
 
     [ConstructorArgument("fontFamily")]
-    public FontFamily FontFamily { get; set; }
+    public FontFamily FontFamily { get; set; } = new("FluentSystemIcons");
 
     public double FontSize { get; set; }
 
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        var fontIcon = new FontIcon { Glyph = Glyph, FontFamily = FontFamily };
+        if (serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget { TargetObject: Setter })
+        {
+            return this;
+        }
+
+        FontIcon fontIcon = new() { Glyph = Glyph, FontFamily = FontFamily };
 
         if (FontSize > 0)
         {

--- a/src/Wpf.Ui/Markup/SymbolIconExtension.cs
+++ b/src/Wpf.Ui/Markup/SymbolIconExtension.cs
@@ -32,6 +32,11 @@ namespace Wpf.Ui.Markup;
 [MarkupExtensionReturnType(typeof(SymbolIcon))]
 public class SymbolIconExtension : MarkupExtension
 {
+
+    public SymbolIconExtension()
+    {
+    }
+
     public SymbolIconExtension(SymbolRegular symbol)
     {
         Symbol = symbol;
@@ -58,7 +63,12 @@ public class SymbolIconExtension : MarkupExtension
 
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        var symbolIcon = new SymbolIcon { Symbol = Symbol, Filled = Filled };
+        if (serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget { TargetObject: Setter })
+        {
+            return this;
+        }
+
+        SymbolIcon symbolIcon = new() { Symbol = Symbol, Filled = Filled };
 
         if (FontSize > 0)
         {


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently you cannot use a markup extension for symbolicons or fonticons because the constructor does not accept the arguments.

![grafik](https://github.com/lepoco/wpfui/assets/37399229/01ca7868-04f2-4575-bcd7-00ee07dc5acb)


## What is the new behavior?

The markup extension for the symbolicon and fonticon class are now working with some small issue.
![grafik](https://github.com/lepoco/wpfui/assets/37399229/1876c645-a732-4e5a-9cfc-352b862de529)

## Other information

So, I have now tested this extensively. I had previously closed this thread because for some reason the FontIcon markup extension randomly worked. However, I think that was due to VS (bugs and such).
I also confused the FontIcon class with the SymbolIcon class in the thread (sorry x.x).

So: The markup extension needs a standard constructor _without_ arguments. Furthermore, the existing constructor does not accept 2 arguments.
Because of the bugs in VS, I wasn't sure before whether it was really a mistake in the markup extension
(that's why i closed the last pull request), but now I am. The SymbolIcon markup extension had the same problem. 
The font size doesn't (forgot work), but it's not clear to me why.
Maybe you know why @pomianowski ?