### PR TITLE
Update UiApplication.cs

### DIFF
--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -23,17 +23,17 @@ public class UiApplication
     /// </summary>
     public UiApplication(Application application)
     {
-        if (application is not null)
+        if (application is null)
         {
-            var hasLibraryResources = application.Resources.MergedDictionaries
-                .Where(e => e.Source is not null)
-                .Any(e => e.Source.ToString().ToLower().Contains(Appearance.ApplicationThemeManager.LibraryNamespace));
-
-            if (hasLibraryResources)
-            {
-                _application = application;
-            }
+            return;
         }
+
+        if (!ApplicationHasResources(application)
+        {
+            return;
+        }
+
+        _application = application;
 
         System.Diagnostics.Debug.WriteLine(
                 $"INFO | {typeof(UiApplication)} application is {_application}",
@@ -125,5 +125,12 @@ public class UiApplication
     public void Shutdown()
     {
         _application?.Shutdown();
+    }
+
+    private static bool ApplicationHasResources(Application application)
+    {
+        return application.Resources.MergedDictionaries
+            .Where(e => e.Source is not null)
+            .Any(e => e.Source.ToString().ToLower().Contains(Appearance.ApplicationThemeManager.LibraryNamespace));
     }
 }

--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -23,7 +23,22 @@ public class UiApplication
     /// </summary>
     public UiApplication(Application application)
     {
-        _application = application;
+        if (application is not null)
+        {
+            var hasLibraryResources = application.Resources.MergedDictionaries
+                .Where(e => e.Source is not null)
+                .Any(e => e.Source.ToString().ToLower().Contains(Appearance.ApplicationThemeManager.LibraryNamespace));
+
+            if (hasLibraryResources)
+            {
+                _application = application;
+            }
+        }
+
+        System.Diagnostics.Debug.WriteLine(
+                $"INFO | {typeof(UiApplication)} application is {_application}",
+                "Wpf.Ui"
+        );
     }
 
     /// <summary>

--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -28,7 +28,7 @@ public class UiApplication
             return;
         }
 
-        if (!ApplicationHasResources(application)
+        if (!ApplicationHasResources(application))
         {
             return;
         }


### PR DESCRIPTION
Ignore `Application` without Library Resources

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

If the `Application.Current` does not contain any `Wpf.Ui;` resource that application still is used , this PR checks the resources and ignore the `Application` that does not use `Wpf.Ui;`.

Issue Number: #1081

## What is the new behavior?

By default nothing gonna change: if the `MyApp\App.xaml` have resources related to the `Wpf.Ui` library the `Application.Current` is used like before. 

This PR only impact when the library is running outside of the desktop app context.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
