### PR TITLE
Fix: possible NullReferenceException in PasswordBox

### DIFF
--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.cs
@@ -237,7 +237,7 @@ public class PasswordBox : Wpf.Ui.Controls.TextBox
 
         var caretIndex = CaretIndex;
         var selectionIndex = SelectionStart;
-        var currentPassword = Password;
+        var currentPassword = Password ?? string.Empty;
         var newPasswordValue = currentPassword;
 
         if (isTriggeredByTextInput)


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

In the current version v3.0.4, binding the `Password` property of the `PasswordBox` control to a null property results in a `NullReferenceException` being thrown

```xaml
<ui:PasswordBox Password="{Binding Password}" />
```

```c#
public partial class MainWindow : Window
{
    public MainWindowsViewModel Context { get; set; }
    public MainWindow()
    {
        Context = new MainWindowsViewModel();
        DataContext = Context;
        InitializeComponent();
    }
}

public partial class MainWindowsViewModel : ObservableObject
{
    [ObservableProperty]
    private string? _password = null;
}
```

screenshot
![screenshot](https://github.com/lepoco/wpfui/assets/69706040/7f0679d0-941e-43a1-a979-bd47b0f3d31b)



<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix this bug.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
