### PR TITLE
Fixed menu item add when item added to the ObservableCollection

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Windows/SandboxWindow.xaml.cs
+++ b/src/Wpf.Ui.Gallery/Views/Windows/SandboxWindow.xaml.cs
@@ -34,7 +34,7 @@ public partial class SandboxWindow
 
             if (configurationBasedLogic)
             {
-                _ = MyTestNavigationView.MenuItems.Add(
+                MyTestNavigationView.MenuItems.Add(
                     new NavigationViewItem("Test", SymbolRegular.Home24, typeof(SamplePage2))
                 );
             }

--- a/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
@@ -6,7 +6,7 @@
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 
-using System.Collections;
+using System.Collections.ObjectModel;
 using System.Windows.Controls;
 using Wpf.Ui.Animations;
 
@@ -36,22 +36,22 @@ public interface INavigationView
     /// <summary>
     /// Gets the collection of menu items displayed in the NavigationView.
     /// </summary>
-    IList MenuItems { get; }
+    ObservableCollection<object> MenuItems { get; }
 
     /// <summary>
     /// Gets or sets an object source used to generate the content of the NavigationView menu.
     /// </summary>
-    object? MenuItemsSource { get; set; }
+    ObservableCollection<object> MenuItemsSource { get; set; }
 
     /// <summary>
     /// Gets the list of objects to be used as navigation items in the footer menu.
     /// </summary>
-    IList FooterMenuItems { get; }
+    ObservableCollection<object> FooterMenuItems { get; }
 
     /// <summary>
     /// Gets or sets the object that represents the navigation items to be used in the footer menu.
     /// </summary>
-    object? FooterMenuItemsSource { get; set; }
+    ObservableCollection<object> FooterMenuItemsSource { get; set; }
 
     /// <summary>
     /// Gets the selected item.

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -51,7 +51,7 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
         SetValue(MenuItemsPropertyKey, menuItems);
 
         var footerMenuItems = new ObservableCollection<object>();
-        footerMenuItems.CollectionChanged += OnMenuItems_CollectionChanged;
+        footerMenuItems.CollectionChanged += OnFooterMenuItems_CollectionChanged;
         SetValue(FooterMenuItemsPropertyKey, footerMenuItems);
     }
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -3,7 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Windows.Controls;
@@ -62,7 +61,7 @@ public partial class NavigationView
     /// <summary>Identifies the <see cref="MenuItemsSource"/> dependency property.</summary>
     public static readonly DependencyProperty MenuItemsSourceProperty = DependencyProperty.Register(
         nameof(MenuItemsSource),
-        typeof(object),
+        typeof(ObservableCollection<object>),
         typeof(NavigationView),
         new FrameworkPropertyMetadata(null, OnMenuItemsSourceChanged)
     );
@@ -82,7 +81,7 @@ public partial class NavigationView
     /// <summary>Identifies the <see cref="FooterMenuItemsSource"/> dependency property.</summary>
     public static readonly DependencyProperty FooterMenuItemsSourceProperty = DependencyProperty.Register(
         nameof(FooterMenuItemsSource),
-        typeof(object),
+        typeof(ObservableCollection<object>),
         typeof(NavigationView),
         new FrameworkPropertyMetadata(null, OnFooterMenuItemsSourceChanged)
     );
@@ -274,13 +273,13 @@ public partial class NavigationView
     }
 
     /// <inheritdoc/>
-    public IList MenuItems => (ObservableCollection<object>)GetValue(MenuItemsProperty);
+    public ObservableCollection<object> MenuItems => (ObservableCollection<object>)GetValue(MenuItemsProperty);
 
     /// <inheritdoc/>
     [Bindable(true)]
-    public object? MenuItemsSource
+    public ObservableCollection<object>? MenuItemsSource
     {
-        get => GetValue(MenuItemsSourceProperty);
+        get => (ObservableCollection<object>?)GetValue(MenuItemsSourceProperty);
         set
         {
             if (value is null)
@@ -295,13 +294,13 @@ public partial class NavigationView
     }
 
     /// <inheritdoc/>
-    public IList FooterMenuItems => (ObservableCollection<object>)GetValue(FooterMenuItemsProperty);
+    public ObservableCollection<object> FooterMenuItems => (ObservableCollection<object>)GetValue(FooterMenuItemsProperty);
 
     /// <inheritdoc/>
     [Bindable(true)]
-    public object? FooterMenuItemsSource
+    public ObservableCollection<object> FooterMenuItemsSource
     {
-        get => GetValue(FooterMenuItemsSourceProperty);
+        get => (ObservableCollection<object>)GetValue(FooterMenuItemsSourceProperty);
         set
         {
             if (value is null)
@@ -452,13 +451,11 @@ public partial class NavigationView
 
     private void OnMenuItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        if (e.NewItems is null)
+        if (e.NewItems is not null)
         {
-            return;
+            UpdateMenuItemsTemplate(e.NewItems);
+            AddItemsToDictionaries(e.NewItems);
         }
-
-        UpdateMenuItemsTemplate(e.NewItems);
-        AddItemsToDictionaries(e.NewItems);
     }
 
     private static void OnMenuItemsSourceChanged(DependencyObject? d, DependencyPropertyChangedEventArgs e)
@@ -468,18 +465,18 @@ public partial class NavigationView
             return;
         }
 
-        navigationView.MenuItems.Clear();
-
-        if (e.NewValue is IEnumerable newItemsSource and not string)
+        if (navigationView is not null)
         {
-            foreach (var item in newItemsSource)
-            {
-                navigationView.MenuItems.Add(item);
-            }
+            navigationView.OnMenuItemsSourceChanged(e);
         }
-        else if (e.NewValue != null)
+    }
+
+    private void OnMenuItemsSourceChanged(DependencyPropertyChangedEventArgs e)
+    {
+        if (MenuItemsSource is not null)
         {
-            navigationView.MenuItems.Add(e.NewValue);
+            MenuItemsSource.CollectionChanged += OnMenuItems_CollectionChanged;
+            SetValue(MenuItemsPropertyKey, MenuItemsSource);
         }
     }
 
@@ -504,18 +501,18 @@ public partial class NavigationView
             return;
         }
 
-        navigationView.FooterMenuItems.Clear();
-
-        if (e.NewValue is IEnumerable newItemsSource and not string)
+        if (navigationView is not null)
         {
-            foreach (var item in newItemsSource)
-            {
-                navigationView.FooterMenuItems.Add(item);
-            }
+            navigationView.OnFooterMenuItemsSourceChanged(e);
         }
-        else if (e.NewValue != null)
+    }
+
+    private void OnFooterMenuItemsSourceChanged(DependencyPropertyChangedEventArgs e)
+    {
+        if (FooterMenuItemsSource is not null)
         {
-            navigationView.FooterMenuItems.Add(e.NewValue);
+            FooterMenuItemsSource.CollectionChanged += OnFooterMenuItems_CollectionChanged;
+            SetValue(MenuItemsPropertyKey, FooterMenuItemsSource);
         }
     }
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -512,7 +512,7 @@ public partial class NavigationView
         if (FooterMenuItemsSource is not null)
         {
             FooterMenuItemsSource.CollectionChanged += OnFooterMenuItems_CollectionChanged;
-            SetValue(MenuItemsPropertyKey, FooterMenuItemsSource);
+            SetValue(FooterMenuItemsPropertyKey, FooterMenuItemsSource);
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When MenuItemsSource or FooterMenuItemsSource in MVVM binding to ObservableCollection the Item added to the collection dose not update in the UI. 

Issue Number: N/A

## What is the new behavior?
```
        [ObservableProperty]
        private ObservableCollection<object> _broserNavigationViewItem = new ObservableCollection<object>();

         BroserNavigationViewItem.Add(new NavigationViewItem()
         {
             Content = content,
             Icon = new SymbolIcon { Symbol = icon },
             TargetPageType = targetPageType,
             TargetPageTag = name,
             Template = NavigationService.GetNavigationControl().ItemTemplate
         });
```
NavigationView item will add the Item 


## Other information


