### PR TITLE
fix non-legacy backdrop when switching themes

### DIFF
--- a/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
+++ b/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
@@ -91,10 +91,14 @@ public static class WindowBackgroundManager
         }
 
         // This was required to update the background when moving from a HC theme to light/dark theme. However, this breaks theme proper light/dark theme changing on Windows 10.
-        // else
-        // {
-        //    _ = WindowBackdrop.RemoveBackground(window);
-        // }
+        // But window backdrop effects are not applied when it has an opaque (or any) background on W11 (so removing this breaks backdrop effects when switching themes), however, for legacy MICA it may not be required
+        // using existing variable, though the OS build which (officially) supports setting DWM_SYSTEMBACKDROP_TYPE attribute is build 22621
+        // source: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type
+        if (Win32.Utilities.IsOSWindows11Insider1OrNewer && backdrop is not WindowBackdropType.None)
+        {
+            _ = WindowBackdrop.RemoveBackground(window);
+        }
+
         _ = WindowBackdrop.ApplyBackdrop(window, backdrop);
         if (applicationTheme is ApplicationTheme.Dark)
         {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #927 

## What is the new behavior?

- backdrop is applied correctly

## Other information

checked on windows 11 22631 build and on windows 10 19045 build (only default light/dark themes with simple demo app)
