### PR TITLE
[TYPO] link to 404

### DIFF
--- a/docs/documentation/nuget.md
+++ b/docs/documentation/nuget.md
@@ -28,4 +28,4 @@ NuGet is a free, open-source package management system for the Microsoft .NET pl
 
 # Done!
 
-Package installed, to learn more, go to the [**Getting started**](/tutorial/getting-started.html) page.
+Package installed, to learn more, go to the [**Getting started**](/documentation/getting-started.html) page.


### PR DESCRIPTION
Website typo in the link to the Getting Started page from the NuGet package page.

## Pull request type

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x ] Documentation content changes

## What is the current behavior?

Clicking on "Package installed, to learn more, go to the [Getting started](https://wpfui.lepo.co/tutorial/getting-started.html) page." goes to 404.

## What is the new behavior?

Link is fixed to documentation/getting-started.html instead of tutorial/getting-started.html

