### PR TITLE
Fix warnings

### DIFF
--- a/src/Wpf.Ui.Demo.Simple/AssemblyInfo.cs
+++ b/src/Wpf.Ui.Demo.Simple/AssemblyInfo.cs
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 using System.Windows;
 
 [assembly: ThemeInfo(

--- a/src/Wpf.Ui.FontMapper/FontSource.cs
+++ b/src/Wpf.Ui.FontMapper/FontSource.cs
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 namespace Wpf.Ui.FontMapper;
 
 class FontSource

--- a/src/Wpf.Ui.FontMapper/GitTag.cs
+++ b/src/Wpf.Ui.FontMapper/GitTag.cs
@@ -1,3 +1,8 @@
-﻿namespace Wpf.Ui.FontMapper;
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+namespace Wpf.Ui.FontMapper;
 
 record GitTag(string Ref, string Node_Id, string Url);

--- a/src/Wpf.Ui.Gallery/Views/Pages/Layout/ExpanderPage.xaml.cs
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Layout/ExpanderPage.xaml.cs
@@ -1,4 +1,9 @@
-﻿using Wpf.Ui.Controls;
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using Wpf.Ui.Controls;
 using Wpf.Ui.Gallery.ControlsLookup;
 using Wpf.Ui.Gallery.ViewModels.Pages.Layout;
 

--- a/src/Wpf.Ui.SyntaxHighlight/Highlighter.cs
+++ b/src/Wpf.Ui.SyntaxHighlight/Highlighter.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // TODO: This class is work in progress.
 
 using System;

--- a/src/Wpf.Ui.Tray/Hicon.cs
+++ b/src/Wpf.Ui.Tray/Hicon.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // TODO: This class is the only reason for using System.Drawing.Common.
 // It is worth looking for a way to get hIcon without using it.
 

--- a/src/Wpf.Ui/Controls/Anchor/Anchor.cs
+++ b/src/Wpf.Ui/Controls/Anchor/Anchor.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // https://docs.microsoft.com/en-us/fluent-ui/web-components/components/anchor
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/Badge/Badge.cs
+++ b/src/Wpf.Ui/Controls/Badge/Badge.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // https://docs.microsoft.com/en-us/fluent-ui/web-components/components/badge
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBar.cs
+++ b/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBar.cs
@@ -2,9 +2,9 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
-// Copyright(c) Microsoft Corporation.All rights reserved.
+
+/* Based on Windows UI Library
+   Copyright(c) Microsoft Corporation.All rights reserved. */
 
 using System.Collections.Specialized;
 using System.Windows.Controls.Primitives;

--- a/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItem.cs
+++ b/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItem.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
+
+/* Based on Windows UI Library */
 
 using Wpf.Ui.Converters;
 

--- a/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItemClickedEventArgs.cs
+++ b/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItemClickedEventArgs.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/ContextMenu/ContextMenuLoader.xaml.cs
+++ b/src/Wpf.Ui/Controls/ContextMenu/ContextMenuLoader.xaml.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Code is based on a StackOverflow-Answer: https://stackoverflow.com/a/56736232/9759874
+
+/* This Code is based on a StackOverflow-Answer: https://stackoverflow.com/a/56736232/9759874 */
 
 using System.Reflection;
 using System.Windows.Threading;

--- a/src/Wpf.Ui/Controls/DateTimeHelper.cs
+++ b/src/Wpf.Ui/Controls/DateTimeHelper.cs
@@ -2,13 +2,13 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-//
-// NOTE: This date time helper assumes it is working in a Gregorian calendar
-// If we ever support non Gregorian calendars this class would need to be redesigned
+
+/* NOTE: This date time helper assumes it is working in a Gregorian calendar
+   If we ever support non-Gregorian calendars this class would need to be redesigned */
 
 using System.Diagnostics;
 using System.Windows.Controls;

--- a/src/Wpf.Ui/Controls/GridView/GridViewRowPresenter.cs
+++ b/src/Wpf.Ui/Controls/GridView/GridViewRowPresenter.cs
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 using System.Reflection;
 using System.Windows.Controls;
 

--- a/src/Wpf.Ui/Controls/ItemRange.cs
+++ b/src/Wpf.Ui/Controls/ItemRange.cs
@@ -2,12 +2,12 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-//
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/ListView/ListView.cs
+++ b/src/Wpf.Ui/Controls/ListView/ListView.cs
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 namespace Wpf.Ui.Controls;
 
 /// <summary>

--- a/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
@@ -2,9 +2,9 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
-// Copyright(c) Microsoft Corporation.All rights reserved.
+
+/* Based on Windows UI Library
+   Copyright(c) Microsoft Corporation.All rights reserved. */
 
 using System.Collections;
 using System.Windows.Controls;

--- a/src/Wpf.Ui/Controls/NavigationView/INavigationViewItem.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/INavigationViewItem.cs
@@ -2,9 +2,9 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
-// Copyright(c) Microsoft Corporation.All rights reserved.
+
+/* Based on Windows UI Library
+   Copyright(c) Microsoft Corporation.All rights reserved. */
 
 using System.Collections;
 using System.Windows.Controls;

--- a/src/Wpf.Ui/Controls/NavigationView/NavigatedEventArgs.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigatedEventArgs.cs
@@ -2,9 +2,9 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
-// Copyright(c) Microsoft Corporation.All rights reserved.
+
+/* Based on Windows UI Library
+   Copyright(c) Microsoft Corporation.All rights reserved. */
 
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;

--- a/src/Wpf.Ui/Controls/NavigationView/NavigatingCancelEventArgs.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigatingCancelEventArgs.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationCache.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationCache.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationCacheMode.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationCacheMode.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.navigationview?view=winrt-22621
+
+/* Based on Windows UI Library https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.navigationview?view=winrt-22621 */
 
 using System.Collections;
 using System.Collections.ObjectModel;

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Events.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Events.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Navigation.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Navigation.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
+
+/* Based on Windows UI Library */
 
 using System.Collections.ObjectModel;
 using System.Diagnostics;

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.TemplateParts.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.TemplateParts.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewBackButtonVisible.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewBackButtonVisible.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewBreadcrumbItem.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewBreadcrumbItem.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
+
+/* Based on Windows UI Library */
 
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewItem.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.navigationviewitem?view=winrt-22621
+
+/* Based on Windows UI Library https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.navigationviewitem?view=winrt-22621 */
 
 using System.Collections;
 using System.Collections.ObjectModel;

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemHeader.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemHeader.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 //

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemSeparator.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemSeparator.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewPaneDisplayMode.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewPaneDisplayMode.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // Based on Windows UI Library
 // Copyright(c) Microsoft Corporation.All rights reserved.
 

--- a/src/Wpf.Ui/Controls/NumberBox/INumberFormatter.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/INumberFormatter.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on the source code provided by the .NET Foundation.
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/NumberBox/INumberParser.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/INumberParser.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on the source code provided by the .NET Foundation.
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -2,13 +2,13 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on the source code provided by the .NET Foundation.
-//
-// TODO: Mask (with placeholder); Clipboard paste;
-// TODO: Constant decimals when formatting. Although this can actually be done with NumberFormatter.
-// TODO: Disable expression by default
-// TODO: Lock to digit characters only by property
+
+/* TODO: Mask (with placeholder); Clipboard paste; */
+/* TODO: Constant decimals when formatting. Although this can actually be done with NumberFormatter. */
+/* TODO: Disable expression by default */
+/* TODO: Lock to digit characters only by property */
 
 using System.Windows.Data;
 using System.Windows.Input;

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBoxSpinButtonPlacementMode.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBoxSpinButtonPlacementMode.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on the source code provided by the .NET Foundation.
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBoxValidationMode.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBoxValidationMode.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on the source code provided by the .NET Foundation.
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/NumberBox/ValidateNumberFormatter.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/ValidateNumberFormatter.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on the source code provided by the .NET Foundation.
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.cs
@@ -2,11 +2,11 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // TODO: This is an initial implementation and requires the necessary corrections, tests and adjustments.
-//
-// TextProperty contains asterisks OR raw password if IsPasswordRevealed is set to true
-// PasswordProperty always contains raw password
+
+/* TextProperty contains asterisks OR raw password if IsPasswordRevealed is set to true
+   PasswordProperty always contains raw password */
 
 using System.Windows.Controls;
 

--- a/src/Wpf.Ui/Controls/ProgressRing/ProgressRing.cs
+++ b/src/Wpf.Ui/Controls/ProgressRing/ProgressRing.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// https://docs.microsoft.com/en-us/fluent-ui/web-components/components/progress-ring
+
+/* https://docs.microsoft.com/en-us/fluent-ui/web-components/components/progress-ring */
 
 using Brush = System.Windows.Media.Brush;
 using Brushes = System.Windows.Media.Brushes;

--- a/src/Wpf.Ui/Controls/ScrollDirection.cs
+++ b/src/Wpf.Ui/Controls/ScrollDirection.cs
@@ -2,12 +2,12 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-//
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/Snackbar/Snackbar.cs
+++ b/src/Wpf.Ui/Controls/Snackbar/Snackbar.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// TODO: Refactor as popup, detach from the window renderer
+
+/* TODO: Refactor as popup, detach from the window renderer */
 
 using System.Windows.Controls;
 using Wpf.Ui.Input;

--- a/src/Wpf.Ui/Controls/SpacingMode.cs
+++ b/src/Wpf.Ui/Controls/SpacingMode.cs
@@ -2,11 +2,11 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/TypedEventHandler.cs
+++ b/src/Wpf.Ui/Controls/TypedEventHandler.cs
@@ -2,9 +2,9 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on Windows UI Library
-// Copyright(c) Microsoft Corporation.All rights reserved.
+
+/* Based on Windows UI Library
+   Copyright(c) Microsoft Corporation.All rights reserved. */
 
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/VirtualizingGridView/VirtualizingGridView.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingGridView/VirtualizingGridView.cs
@@ -2,12 +2,12 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-//
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 using System.Windows.Controls;
 using System.Windows.Data;

--- a/src/Wpf.Ui/Controls/VirtualizingItemsControl/VirtualizingItemsControl.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingItemsControl/VirtualizingItemsControl.cs
@@ -2,11 +2,11 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 using System.Windows.Controls;
 

--- a/src/Wpf.Ui/Controls/VirtualizingUniformGrid/VirtualizingUniformGrid.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingUniformGrid/VirtualizingUniformGrid.cs
@@ -2,12 +2,12 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-//
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;

--- a/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingPanelBase.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingPanelBase.cs
@@ -2,14 +2,11 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;

--- a/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
@@ -425,8 +425,7 @@ public class VirtualizingWrapPanel : VirtualizingPanelBase
                 int rowCountInCacheBefore = (int)(cacheBeforeInPixel / GetHeight(ChildSize));
                 int rowCountInCacheAfter =
                     (
-                        (int)
-                            Math.Ceiling(
+                        (int)Math.Ceiling(
                                 (offsetInPixel + viewportHeight + cacheAfterInPixel) / GetHeight(ChildSize)
                             )
                     ) - (int)Math.Ceiling((offsetInPixel + viewportHeight) / GetHeight(ChildSize));

--- a/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
@@ -2,14 +2,11 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
-// Copyright (C) S. Bäumlisberger
-// All Rights Reserved.
-//
-// Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
-// https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+
+/* Based on VirtualizingWrapPanel created by S. Bäumlisberger licensed under MIT license.
+   https://github.com/sbaeumlisberger/VirtualizingWrapPanel
+   Copyright (C) S. Bäumlisberger
+   All Rights Reserved. */
 
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;

--- a/src/Wpf.Ui/Converters/ProgressThicknessConverter.cs
+++ b/src/Wpf.Ui/Converters/ProgressThicknessConverter.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// TODO: It's too hardcoded, we should define better formula.
+
+/* TODO: It's too hardcoded, we should define better formula. */
 
 using System.Windows.Data;
 

--- a/src/Wpf.Ui/Hardware/DisplayDpi.cs
+++ b/src/Wpf.Ui/Hardware/DisplayDpi.cs
@@ -2,8 +2,8 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 namespace Wpf.Ui.Hardware;
 

--- a/src/Wpf.Ui/Input/IRelayCommand.cs
+++ b/src/Wpf.Ui/Input/IRelayCommand.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+
+/* Licensed to the .NET Foundation under one or more agreements.
+   The .NET Foundation licenses this file to you under the MIT license.
+   See the LICENSE file in the project root for more information. */
 
 using System.Windows.Input;
 

--- a/src/Wpf.Ui/Input/IRelayCommand{T}.cs
+++ b/src/Wpf.Ui/Input/IRelayCommand{T}.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+
+/* Licensed to the .NET Foundation under one or more agreements.
+   The .NET Foundation licenses this file to you under the MIT license.
+   See the LICENSE file in the project root for more information. */
 
 using System.Windows.Input;
 

--- a/src/Wpf.Ui/Input/RelayCommand{T}.cs
+++ b/src/Wpf.Ui/Input/RelayCommand{T}.cs
@@ -2,12 +2,12 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-//
-// This file is inspired from the MvvmLight library (lbugnion/MvvmLight)
+
+/* Licensed to the .NET Foundation under one or more agreements.
+   The .NET Foundation licenses this file to you under the MIT license.
+   See the LICENSE file in the project root for more information.
+
+   This file is inspired by the MvvmLight library (lbugnion/MvvmLight) */
 
 using System.Runtime.CompilerServices;
 

--- a/src/Wpf.Ui/Interop/Dwmapi.cs
+++ b/src/Wpf.Ui/Interop/Dwmapi.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on reverse engineering of the Windows Operating System,
 // and is intended for use on Windows systems only.
 // This Source Code is partially based on the source code provided by the .NET Foundation.
@@ -14,13 +14,13 @@
 //
 // Windows Kits\10\Include\10.0.22000.0\um\dwmapi.h
 
-using System.Runtime.InteropServices;
-
-namespace Wpf.Ui.Interop;
-
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+
+using System.Runtime.InteropServices;
+
+namespace Wpf.Ui.Interop;
 
 /// <summary>
 /// Desktop Window Manager (DWM).

--- a/src/Wpf.Ui/Interop/Kernel32.cs
+++ b/src/Wpf.Ui/Interop/Kernel32.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on reverse engineering of the Windows Operating System,
 // and is intended for use on Windows systems only.
 // This Source Code is partially based on the source code provided by the .NET Foundation.
@@ -12,12 +12,11 @@
 // If you have suggestions for the code below, please submit your changes there.
 // https://github.com/lepoco/nativemethods
 
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
 using System.Runtime.InteropServices;
 
 namespace Wpf.Ui.Interop;
-
-// ReSharper disable IdentifierTypo
-// ReSharper disable InconsistentNaming
 
 /// <summary>
 /// Used by multiple technologies.

--- a/src/Wpf.Ui/Interop/ShObjIdl.cs
+++ b/src/Wpf.Ui/Interop/ShObjIdl.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on reverse engineering of the Windows Operating System,
 // and is intended for use on Windows systems only.
 // This Source Code is partially based on the source code provided by the .NET Foundation.
@@ -12,13 +12,12 @@
 // If you have suggestions for the code below, please submit your changes there.
 // https://github.com/lepoco/nativemethods
 
-using System.Runtime.InteropServices;
-
-namespace Wpf.Ui.Interop;
-
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+using System.Runtime.InteropServices;
+
+namespace Wpf.Ui.Interop;
 
 /// <summary>
 /// Exposes methods that enumerate the contents of a view and receive notification from callback upon enumeration completion.

--- a/src/Wpf.Ui/Interop/Shell32.cs
+++ b/src/Wpf.Ui/Interop/Shell32.cs
@@ -2,7 +2,7 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
+
 // This Source Code is partially based on reverse engineering of the Windows Operating System,
 // and is intended for use on Windows systems only.
 // This Source Code is partially based on the source code provided by the .NET Foundation.
@@ -12,15 +12,15 @@
 // If you have suggestions for the code below, please submit your changes there.
 // https://github.com/lepoco/nativemethods
 
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
-
-namespace Wpf.Ui.Interop;
-
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning disable SA1401 // Fields should be private
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Wpf.Ui.Interop;
 
 /// <summary>
 /// The Windows UI provides users with access to a wide variety of objects necessary to run applications and manage the operating system.

--- a/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
+++ b/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 using System.Runtime.InteropServices;
 using Microsoft.Win32;

--- a/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
+++ b/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
@@ -376,7 +376,9 @@ public static class UnsafeNativeMethods
 
                     return Color.FromArgb(255, values[2], values[1], values[0]);
                 }
-                catch { }
+                catch
+                {
+                }
             }
         }
 

--- a/src/Wpf.Ui/Interop/UnsafeReflection.cs
+++ b/src/Wpf.Ui/Interop/UnsafeReflection.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 using Wpf.Ui.Controls;
 using Wpf.Ui.TaskBar;

--- a/src/Wpf.Ui/Interop/User32.cs
+++ b/src/Wpf.Ui/Interop/User32.cs
@@ -2,15 +2,15 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
-//
-// NOTE:
-// I split unmanaged code stuff into the NativeMethods library.
-// If you have suggestions for the code below, please submit your changes there.
-// https://github.com/lepoco/nativemethods
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation.
+
+   NOTE:
+   I split unmanaged code stuff into the NativeMethods library.
+   If you have suggestions for the code below, please submit your changes there.
+   https://github.com/lepoco/nativemethods */
 
 using System.Runtime.InteropServices;
 

--- a/src/Wpf.Ui/Interop/UxTheme.cs
+++ b/src/Wpf.Ui/Interop/UxTheme.cs
@@ -2,15 +2,15 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
-//
-// NOTE:
-// I split unmanaged code stuff into the NativeMethods library.
-// If you have suggestions for the code below, please submit your changes there.
-// https://github.com/lepoco/nativemethods
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation.
+
+   NOTE:
+   I split unmanaged code stuff into the NativeMethods library.
+   If you have suggestions for the code below, please submit your changes there.
+   https://github.com/lepoco/nativemethods */
 
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Wpf.Ui/Interop/WinDef/POINT.cs
+++ b/src/Wpf.Ui/Interop/WinDef/POINT.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 using System.Runtime.InteropServices;
 

--- a/src/Wpf.Ui/Interop/WinDef/POINTL.cs
+++ b/src/Wpf.Ui/Interop/WinDef/POINTL.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 using System.Runtime.InteropServices;
 

--- a/src/Wpf.Ui/Interop/WinDef/RECT.cs
+++ b/src/Wpf.Ui/Interop/WinDef/RECT.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 using System.Runtime.InteropServices;
 

--- a/src/Wpf.Ui/Interop/WinDef/RECTL.cs
+++ b/src/Wpf.Ui/Interop/WinDef/RECTL.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 using System.Runtime.InteropServices;
 

--- a/src/Wpf.Ui/Interop/WinDef/SIZE.cs
+++ b/src/Wpf.Ui/Interop/WinDef/SIZE.cs
@@ -2,10 +2,10 @@
 // If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
-//
-// This Source Code is partially based on reverse engineering of the Windows Operating System,
-// and is intended for use on Windows systems only.
-// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+/* This Source Code is partially based on reverse engineering of the Windows Operating System,
+   and is intended for use on Windows systems only.
+   This Source Code is partially based on the source code provided by the .NET Foundation. */
 
 using System.Runtime.InteropServices;
 

--- a/src/Wpf.Ui/Markup/Design.cs
+++ b/src/Wpf.Ui/Markup/Design.cs
@@ -28,12 +28,10 @@ public static class Design
     /// </summary>
     private static bool InDesignMode =>
         _inDesignMode ??=
-            (bool)
-                DependencyPropertyDescriptor
+            (bool)DependencyPropertyDescriptor
                     .FromProperty(DesignerProperties.IsInDesignModeProperty, typeof(FrameworkElement))
                     .Metadata.DefaultValue
-            || System
-                .Diagnostics.Process.GetCurrentProcess()
+            || System.Diagnostics.Process.GetCurrentProcess()
                 .ProcessName.StartsWith(DesignProcessName, StringComparison.Ordinal);
 
     public static readonly DependencyProperty BackgroundProperty = DependencyProperty.RegisterAttached(

--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -95,11 +95,14 @@ public class UiApplication
                     _resources.MergedDictionaries.Add(themesDictionary);
                     _resources.MergedDictionaries.Add(controlsDictionary);
                 }
-                catch { }
+                catch
+                {
+                }
             }
 
             return _application?.Resources ?? _resources;
         }
+
         set
         {
             if (_application is not null)

--- a/src/Wpf.Ui/Win32/Utilities.cs
+++ b/src/Wpf.Ui/Win32/Utilities.cs
@@ -140,8 +140,8 @@ internal class Utilities
 
                 major = (int)majorObj;
             }
-            // When the 'CurrentMajorVersionNumber' value is not present we fallback to reading the previous key used for this: 'CurrentVersion'
-            else if (
+            else // When the 'CurrentMajorVersionNumber' value is not present we fallback to reading the previous key used for this: 'CurrentVersion'
+            if (
                 TryGetRegistryKey(
                     @"SOFTWARE\Microsoft\Windows NT\CurrentVersion",
                     "CurrentVersion",
@@ -176,8 +176,8 @@ internal class Utilities
 
                 minor = (int)minorObj;
             }
-            // When the 'CurrentMinorVersionNumber' value is not present we fallback to reading the previous key used for this: 'CurrentVersion'
-            else if (
+            else // When the 'CurrentMinorVersionNumber' value is not present we fallback to reading the previous key used for this: 'CurrentVersion'
+            if (
                 TryGetRegistryKey(
                     @"SOFTWARE\Microsoft\Windows NT\CurrentVersion",
                     "CurrentVersion",

--- a/tests/Wpf.Ui.Gallery.UnitTests/UnitTest1.cs
+++ b/tests/Wpf.Ui.Gallery.UnitTests/UnitTest1.cs
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 namespace Wpf.Ui.Gallery.UnitTests;
 
 public class UnitTest1

--- a/tests/Wpf.Ui.Gallery.UnitTests/Usings.cs
+++ b/tests/Wpf.Ui.Gallery.UnitTests/Usings.cs
@@ -1,1 +1,6 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 global using Xunit;


### PR DESCRIPTION
The parameter `file_header_template` in `.editorconfig` introduces the check for the file header. However, if the header comment contains more lines than specified in `file_header_template`, the header is detected as incorrect.
This triggers a very significant number of Roslyn analyzer warnings, which makes it hard to detect the real issues.

The solution is to split the header comment into two: the one specified in `file_header_template` and the rest.

Sometimes as a result the second part triggers the SA1512 warning, so it has to be converted to a multi-line comment.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
