### PR TITLE
fix: TextBox, NumberBox, PasswordBox Placeholder Not Working Properly.

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -54,10 +54,10 @@
                     <Grid HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}">
                         <Border
                             x:Name="ContentBorder"
-                            MinWidth="{TemplateBinding MinWidth}"
-                            MinHeight="{TemplateBinding MinHeight}"
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MinHeight="{TemplateBinding MinHeight}"
                             Padding="0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
@@ -82,8 +82,8 @@
                                     VerticalAlignment="Top"
                                     Content="{TemplateBinding Icon}"
                                     FontSize="16"
-                                    IsTabStop="False"
-                                    Foreground="{TemplateBinding Foreground}" />
+                                    Foreground="{TemplateBinding Foreground}"
+                                    IsTabStop="False" />
                                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
                                     <controls:PassiveScrollViewer
                                         x:Name="PART_ContentHost"
@@ -115,8 +115,8 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="clear"
                                     Cursor="Arrow"
-                                    IsTabStop="False"
-                                    Foreground="{DynamicResource TextControlButtonForeground}">
+                                    Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="Dismiss24" />
                                     </controls:Button.Icon>
@@ -178,8 +178,8 @@
                                     VerticalAlignment="Top"
                                     Content="{TemplateBinding Icon}"
                                     FontSize="16"
-                                    IsTabStop="False"
-                                    Foreground="{TemplateBinding Foreground}" />
+                                    Foreground="{TemplateBinding Foreground}"
+                                    IsTabStop="False" />
                             </Grid>
                         </Border>
                         <!--  The Accent Border is a separate element so that changes to the border thickness do not affect the position of the element  -->
@@ -192,7 +192,7 @@
                             CornerRadius="{TemplateBinding Border.CornerRadius}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="PlaceholderEnabled" Value="False">
+                        <Trigger Property="CurrentPlaceholderEnabled" Value="False">
                             <Setter TargetName="PlaceholderTextBox" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                         <Trigger Property="ShowClearButton" Value="False">

--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.cs
@@ -88,7 +88,7 @@ public class PasswordBox : Wpf.Ui.Controls.TextBox
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether whether to display the  password reveal button.
+    /// Gets or sets a value indicating whether to display the password reveal button.
     /// </summary>
     public bool RevealButtonEnabled
     {
@@ -125,15 +125,7 @@ public class PasswordBox : Wpf.Ui.Controls.TextBox
         }
         else
         {
-            if (PlaceholderEnabled && Text.Length > 0)
-            {
-                SetCurrentValue(PlaceholderEnabledProperty, false);
-            }
-
-            if (!PlaceholderEnabled && Text.Length < 1)
-            {
-                SetCurrentValue(PlaceholderEnabledProperty, true);
-            }
+            SetPlaceholderTextVisibility();
 
             RevealClearButton();
         }

--- a/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
+++ b/src/Wpf.Ui/Controls/PasswordBox/PasswordBox.xaml
@@ -204,8 +204,8 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="clear"
                                     Cursor="Arrow"
-                                    IsTabStop="False"
-                                    Foreground="{DynamicResource TextControlButtonForeground}">
+                                    Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource PasswordBoxButtonIconSize}" Symbol="Dismiss24" />
                                     </controls:Button.Icon>
@@ -228,8 +228,8 @@
                                     Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     CommandParameter="reveal"
                                     Cursor="Arrow"
-                                    IsTabStop="False"
-                                    Foreground="{DynamicResource TextControlButtonForeground}">
+                                    Foreground="{DynamicResource TextControlButtonForeground}"
+                                    IsTabStop="False">
                                     <controls:Button.Icon>
                                         <controls:SymbolIcon FontSize="{StaticResource PasswordBoxButtonIconSize}" Symbol="Eye24" />
                                     </controls:Button.Icon>
@@ -256,7 +256,7 @@
                             CornerRadius="{TemplateBinding Border.CornerRadius}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="PlaceholderEnabled" Value="False">
+                        <Trigger Property="CurrentPlaceholderEnabled" Value="False">
                             <Setter TargetName="PlaceholderTextBox" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                         <Trigger Property="ShowClearButton" Value="False">

--- a/src/Wpf.Ui/Controls/TextBox/TextBox.cs
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.cs
@@ -48,6 +48,13 @@ public class TextBox : System.Windows.Controls.TextBox
         new PropertyMetadata(true)
     );
 
+    /// <summary>Identifies the <see cref="CurrentPlaceholderEnabled"/> dependency property.</summary>
+    public static readonly DependencyProperty CurrentPlaceholderEnabledProperty = DependencyProperty.Register(
+        nameof(CurrentPlaceholderEnabled),
+        typeof(bool),
+        typeof(TextBox),
+        new PropertyMetadata(true));
+
     /// <summary>Identifies the <see cref="ClearButtonEnabled"/> dependency property.</summary>
     public static readonly DependencyProperty ClearButtonEnabledProperty = DependencyProperty.Register(
         nameof(ClearButtonEnabled),
@@ -99,7 +106,7 @@ public class TextBox : System.Windows.Controls.TextBox
     }
 
     /// <summary>
-    /// Gets or sets numbers pattern.
+    /// Gets or sets placeholder text.
     /// </summary>
     public string PlaceholderText
     {
@@ -108,12 +115,21 @@ public class TextBox : System.Windows.Controls.TextBox
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to display the placeholder text.
+    /// Gets or sets a value indicating whether to enable the placeholder text.
     /// </summary>
     public bool PlaceholderEnabled
     {
         get => (bool)GetValue(PlaceholderEnabledProperty);
         set => SetValue(PlaceholderEnabledProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to display the placeholder text.
+    /// </summary>
+    public bool CurrentPlaceholderEnabled
+    {
+        get => (bool)GetValue(CurrentPlaceholderEnabledProperty);
+        protected set => SetValue(CurrentPlaceholderEnabledProperty, value);
     }
 
     /// <summary>
@@ -154,6 +170,7 @@ public class TextBox : System.Windows.Controls.TextBox
     public TextBox()
     {
         SetValue(TemplateButtonCommandProperty, new RelayCommand<string>(OnTemplateButtonClick));
+        CurrentPlaceholderEnabled = PlaceholderEnabled;
     }
 
     /// <inheritdoc />
@@ -161,17 +178,29 @@ public class TextBox : System.Windows.Controls.TextBox
     {
         base.OnTextChanged(e);
 
-        if (PlaceholderEnabled && Text.Length > 0)
-        {
-            SetCurrentValue(PlaceholderEnabledProperty, false);
-        }
-
-        if (!PlaceholderEnabled && Text.Length < 1)
-        {
-            SetCurrentValue(PlaceholderEnabledProperty, true);
-        }
+        SetPlaceholderTextVisibility();
 
         RevealClearButton();
+    }
+
+    protected void SetPlaceholderTextVisibility()
+    {
+        if (PlaceholderEnabled)
+        {
+            if (CurrentPlaceholderEnabled && Text.Length > 0)
+            {
+                SetCurrentValue(CurrentPlaceholderEnabledProperty, false);
+            }
+
+            if (!CurrentPlaceholderEnabled && Text.Length < 1)
+            {
+                SetCurrentValue(CurrentPlaceholderEnabledProperty, true);
+            }
+        }
+        else
+        {
+            SetCurrentValue(CurrentPlaceholderEnabledProperty, false);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
@@ -214,7 +214,7 @@
                 CornerRadius="{TemplateBinding Border.CornerRadius}" />
         </Grid>
         <ControlTemplate.Triggers>
-            <Trigger Property="PlaceholderEnabled" Value="False">
+            <Trigger Property="CurrentPlaceholderEnabled" Value="False">
                 <Setter TargetName="PlaceholderTextBox" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="ShowClearButton" Value="False">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes

## What is the current behavior?
- When `Password` is set before setting `PlaceholderEnabled`, both `PlaceholderText` and `Password` will appear simultaneously.
- If `PlaceholderEnabled` is `false` and `PlaceholderText` is not empty, clearing Text will still display `PlaceholderText`.

Issue Number: #1043

## What is the new behavior?

- fix this bugs.
- If `PlaceholderEnabled` is set to `false` and `PlaceholderText` is not empty, clearing `Text` will not display `PlaceholderText`.

## Other information
Added a new dependency property `CurrentPlaceholderEnabledProperty`.
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
