### PR TITLE
fix:  PlaceholderText may not display promptly under certain circumstances

### DIFF
--- a/src/Wpf.Ui/Controls/TextBox/TextBox.cs
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.cs
@@ -45,7 +45,7 @@ public class TextBox : System.Windows.Controls.TextBox
         nameof(PlaceholderEnabled),
         typeof(bool),
         typeof(TextBox),
-        new PropertyMetadata(true)
+        new PropertyMetadata(true, OnPlaceholderEnabledChanged)
     );
 
     /// <summary>Identifies the <see cref="CurrentPlaceholderEnabled"/> dependency property.</summary>
@@ -53,7 +53,8 @@ public class TextBox : System.Windows.Controls.TextBox
         nameof(CurrentPlaceholderEnabled),
         typeof(bool),
         typeof(TextBox),
-        new PropertyMetadata(true));
+        new PropertyMetadata(true)
+    );
 
     /// <summary>Identifies the <see cref="ClearButtonEnabled"/> dependency property.</summary>
     public static readonly DependencyProperty ClearButtonEnabledProperty = DependencyProperty.Register(
@@ -197,7 +198,7 @@ public class TextBox : System.Windows.Controls.TextBox
                 SetCurrentValue(CurrentPlaceholderEnabledProperty, true);
             }
         }
-        else
+        else if (CurrentPlaceholderEnabled)
         {
             SetCurrentValue(CurrentPlaceholderEnabledProperty, false);
         }
@@ -262,5 +263,20 @@ public class TextBox : System.Windows.Controls.TextBox
         Debug.WriteLine($"INFO: {typeof(TextBox)} button clicked", "Wpf.Ui.TextBox");
 
         OnClearButtonClick();
+    }
+
+    private static void OnPlaceholderEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not TextBox control)
+        {
+            return;
+        }
+
+        control.OnPlaceholderEnabledChanged();
+    }
+
+    protected virtual void OnPlaceholderEnabledChanged()
+    {
+        SetPlaceholderTextVisibility();
     }
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When we set `PlaceholderEnabled` from `false` to `true`, if the `Text` is empty, the `PlaceholderText` will not display immediately; it will only appear after the `OnTextChanged` method is triggered.

Issue Number: N/A

## What is the new behavior?

- A new callback function, `OnPlaceholderEnabledChanged`, has been added. When `PlaceholderEnabled` is set from `false` to `true`, if the `Text` is empty, the `PlaceholderText` will be displayed immediately, and vice versa.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
