### PR TITLE
Fix: Possible multiple invocations of the INavigationAware interface methods

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
@@ -183,47 +183,39 @@ public class NavigationViewContentPresenter : Frame
 
     private static void NotifyContentAboutNavigatingTo(object content)
     {
-        if (content is INavigationAware navigationAwareNavigationContent)
+        switch (content)
         {
-            navigationAwareNavigationContent.OnNavigatedTo();
-        }
-
-        if (
-            content is INavigableView<object>
+            case INavigationAware navigationAwareNavigationContent:
+                navigationAwareNavigationContent.OnNavigatedTo();
+                break;
+            case INavigableView<object>
             {
                 ViewModel: INavigationAware navigationAwareNavigableViewViewModel
-            }
-        )
-        {
-            navigationAwareNavigableViewViewModel.OnNavigatedTo();
-        }
-
-        if (content is FrameworkElement { DataContext: INavigationAware navigationAwareCurrentContent })
-        {
-            navigationAwareCurrentContent.OnNavigatedTo();
+            }:
+                navigationAwareNavigableViewViewModel.OnNavigatedTo();
+                break;
+            case FrameworkElement { DataContext: INavigationAware navigationAwareCurrentContent }:
+                navigationAwareCurrentContent.OnNavigatedTo();
+                break;
         }
     }
 
     private static void NotifyContentAboutNavigatingFrom(object content)
     {
-        if (content is INavigationAware navigationAwareNavigationContent)
+        switch (content)
         {
-            navigationAwareNavigationContent.OnNavigatedFrom();
-        }
-
-        if (
-            content is INavigableView<object>
+            case INavigationAware navigationAwareNavigationContent:
+                navigationAwareNavigationContent.OnNavigatedFrom();
+                break;
+            case INavigableView<object>
             {
                 ViewModel: INavigationAware navigationAwareNavigableViewViewModel
-            }
-        )
-        {
-            navigationAwareNavigableViewViewModel.OnNavigatedFrom();
-        }
-
-        if (content is FrameworkElement { DataContext: INavigationAware navigationAwareCurrentContent })
-        {
-            navigationAwareCurrentContent.OnNavigatedFrom();
+            }:
+                navigationAwareNavigableViewViewModel.OnNavigatedFrom();
+                break;
+            case FrameworkElement { DataContext: INavigationAware navigationAwareCurrentContent }:
+                navigationAwareCurrentContent.OnNavigatedFrom();
+                break;
         }
     }
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When the View's `DataContext` is itself and the View implements the `INavigationAware` interface, the methods of the `INavigationAware` interface will be called twice.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #636 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- fix this bug.