### PR TITLE
Fix titlebar color when using backdrop in WPF `Window`

### DIFF
--- a/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
+++ b/src/Wpf.Ui/Appearance/WindowBackgroundManager.cs
@@ -100,6 +100,7 @@ public static class WindowBackgroundManager
         }
 
         _ = WindowBackdrop.ApplyBackdrop(window, backdrop);
+
         if (applicationTheme is ApplicationTheme.Dark)
         {
             ApplyDarkThemeToWindow(window);
@@ -108,6 +109,8 @@ public static class WindowBackgroundManager
         {
             RemoveDarkThemeFromWindow(window);
         }
+
+        _ = WindowBackdrop.RemoveTitlebarBackground(window);
 
         foreach (object? subWindow in window.OwnedWindows)
         {
@@ -123,6 +126,8 @@ public static class WindowBackgroundManager
                 {
                     RemoveDarkThemeFromWindow(windowSubWindow);
                 }
+
+                _ = WindowBackdrop.RemoveTitlebarBackground(window);
             }
         }
     }

--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -199,6 +199,8 @@ public class FluentWindow : System.Windows.Window
         if (WindowBackdrop.IsSupported(newValue) && WindowBackdrop.RemoveBackground(this))
         {
             _ = WindowBackdrop.ApplyBackdrop(this, newValue);
+
+            _ = WindowBackdrop.RemoveTitlebarBackground(this);
         }
     }
 

--- a/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
@@ -425,7 +425,8 @@ public class VirtualizingWrapPanel : VirtualizingPanelBase
                 int rowCountInCacheBefore = (int)(cacheBeforeInPixel / GetHeight(ChildSize));
                 int rowCountInCacheAfter =
                     (
-                        (int)Math.Ceiling(
+                        (int)
+                            Math.Ceiling(
                                 (offsetInPixel + viewportHeight + cacheAfterInPixel) / GetHeight(ChildSize)
                             )
                     ) - (int)Math.Ceiling((offsetInPixel + viewportHeight) / GetHeight(ChildSize));

--- a/src/Wpf.Ui/Interop/Dwmapi.cs
+++ b/src/Wpf.Ui/Interop/Dwmapi.cs
@@ -620,6 +620,22 @@ internal static class Dwmapi
     );
 
     /// <summary>
+    /// Sets the value of Desktop Window Manager (DWM) non-client rendering attributes for a window.
+    /// </summary>
+    /// <param name="hWnd">The handle to the window for which the attribute value is to be set.</param>
+    /// <param name="dwAttribute">A flag describing which value to set, specified as a value of the DWMWINDOWATTRIBUTE enumeration.</param>
+    /// <param name="pvAttribute">A pointer to an object containing the attribute value to set.</param>
+    /// <param name="cbAttribute">The size, in bytes, of the attribute value being set via the <c>pvAttribute</c> parameter.</param>
+    /// <returns>If the function succeeds, it returns <c>S_OK</c>. Otherwise, it returns an <c>HRESULT</c> error code.</returns>
+    [DllImport(Libraries.Dwmapi)]
+    public static extern int DwmSetWindowAttribute(
+        [In] IntPtr hWnd,
+        [In] DWMWINDOWATTRIBUTE dwAttribute,
+        [In] ref uint pvAttribute,
+        [In] int cbAttribute
+    );
+
+    /// <summary>
     /// Retrieves the current value of a specified Desktop Window Manager (DWM) attribute applied to a window. For programming guidance, and code examples, see Controlling non-client region rendering.
     /// </summary>
     /// <param name="hWnd">The handle to the window from which the attribute value is to be retrieved.</param>

--- a/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
+++ b/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
@@ -376,9 +376,7 @@ public static class UnsafeNativeMethods
 
                     return Color.FromArgb(255, values[2], values[1], values[0]);
                 }
-                catch
-                {
-                }
+                catch { }
             }
         }
 

--- a/src/Wpf.Ui/Markup/Design.cs
+++ b/src/Wpf.Ui/Markup/Design.cs
@@ -28,10 +28,12 @@ public static class Design
     /// </summary>
     private static bool InDesignMode =>
         _inDesignMode ??=
-            (bool)DependencyPropertyDescriptor
+            (bool)
+                DependencyPropertyDescriptor
                     .FromProperty(DesignerProperties.IsInDesignModeProperty, typeof(FrameworkElement))
                     .Metadata.DefaultValue
-            || System.Diagnostics.Process.GetCurrentProcess()
+            || System
+                .Diagnostics.Process.GetCurrentProcess()
                 .ProcessName.StartsWith(DesignProcessName, StringComparison.Ordinal);
 
     public static readonly DependencyProperty BackgroundProperty = DependencyProperty.RegisterAttached(

--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -36,8 +36,8 @@ public class UiApplication
         _application = application;
 
         System.Diagnostics.Debug.WriteLine(
-                $"INFO | {typeof(UiApplication)} application is {_application}",
-                "Wpf.Ui"
+            $"INFO | {typeof(UiApplication)} application is {_application}",
+            "Wpf.Ui"
         );
     }
 
@@ -95,14 +95,11 @@ public class UiApplication
                     _resources.MergedDictionaries.Add(themesDictionary);
                     _resources.MergedDictionaries.Add(controlsDictionary);
                 }
-                catch
-                {
-                }
+                catch { }
             }
 
             return _application?.Resources ?? _resources;
         }
-
         set
         {
             if (_application is not null)
@@ -132,8 +129,10 @@ public class UiApplication
 
     private static bool ApplicationHasResources(Application application)
     {
-        return application.Resources.MergedDictionaries
-            .Where(e => e.Source is not null)
-            .Any(e => e.Source.ToString().ToLower().Contains(Appearance.ApplicationThemeManager.LibraryNamespace));
+        return application
+            .Resources.MergedDictionaries.Where(e => e.Source is not null)
+            .Any(e =>
+                e.Source.ToString().ToLower().Contains(Appearance.ApplicationThemeManager.LibraryNamespace)
+            );
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Window can have a color in custom titlebar when **Show accent colors** option is enabled in Windows.

Issue Number: N/A

## What is the new behavior?

After enabling Mica backdrop, the titlebar color should be removed.
