### PR TITLE
Fix: setting NotifyIcon.TooltipText at runtime doesn't work

### DIFF
--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -388,6 +388,8 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         }
 
         notifyIcon.TooltipText = e.NewValue as string ?? string.Empty;
+        notifyIcon.internalNotifyIconManager.TooltipText = notifyIcon.TooltipText;
+        _ = notifyIcon.internalNotifyIconManager.ModifyToolTip();
     }
 
     private static void OnIconChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/Wpf.Ui.Tray/INotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/INotifyIcon.cs
@@ -83,6 +83,11 @@ internal interface INotifyIcon
     bool ModifyIcon();
 
     /// <summary>
+    /// Tries to modify the tooltip of the <see cref="INotifyIcon"/> in the shell.
+    /// </summary>
+    bool ModifyToolTip();
+
+    /// <summary>
     /// Tries to remove the <see cref="INotifyIcon"/> from the shell.
     /// </summary>
     bool Unregister();

--- a/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
+++ b/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
@@ -105,6 +105,12 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
     }
 
     /// <inheritdoc />
+    public virtual bool ModifyToolTip()
+    {
+        return TrayManager.ModifyToolTip(this);
+    }
+
+    /// <inheritdoc />
     public virtual bool Unregister()
     {
         return TrayManager.Unregister(this);

--- a/src/Wpf.Ui.Tray/TrayManager.cs
+++ b/src/Wpf.Ui.Tray/TrayManager.cs
@@ -124,6 +124,19 @@ internal static class TrayManager
         return Interop.Shell32.Shell_NotifyIcon(Interop.Shell32.NIM.MODIFY, notifyIcon.ShellIconData);
     }
 
+    public static bool ModifyToolTip(INotifyIcon notifyIcon)
+    {
+        if (!notifyIcon.IsRegistered)
+        {
+            return true;
+        }
+
+        notifyIcon.ShellIconData.szTip = notifyIcon.TooltipText;
+        notifyIcon.ShellIconData.uFlags |= Interop.Shell32.NIF.TIP;
+
+        return Interop.Shell32.Shell_NotifyIcon(Interop.Shell32.NIM.MODIFY, notifyIcon.ShellIconData);
+    }
+
     /// <summary>
     /// Tries to remove the <see cref="INotifyIcon"/> from the shell.
     /// </summary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Setting NotifyIcon.TooltipText at runtime doesn't work

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [Setting NotifyIcon.TooltipText at runtime doesn't work #670](https://github.com/lepoco/wpfui/issues/670)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- fix this bug.

## Other information

### Interface changed

In the `INotifyIcon` interface, a new method called `ModifyToolTip` has been added