### PR TITLE
Replace Assembly.Location to AppContext.BaseDirectory

### DIFF
--- a/src/Wpf.Ui.Extension.Template.Blank/App.xaml.cs
+++ b/src/Wpf.Ui.Extension.Template.Blank/App.xaml.cs
@@ -20,7 +20,7 @@ namespace $safeprojectname$
         // https://docs.microsoft.com/dotnet/core/extensions/logging
         private static readonly IHost _host = Host
             .CreateDefaultBuilder()
-            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)); })
+            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(AppContext.BaseDirectory)); })
             .ConfigureServices((context, services) =>
             {
                 throw new NotImplementedException("No service or window was registered.");

--- a/src/Wpf.Ui.Extension.Template.Compact/App.xaml.cs
+++ b/src/Wpf.Ui.Extension.Template.Compact/App.xaml.cs
@@ -25,7 +25,7 @@ namespace $safeprojectname$
         // https://docs.microsoft.com/dotnet/core/extensions/logging
         private static readonly IHost _host = Host
             .CreateDefaultBuilder()
-            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)); })
+            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(AppContext.BaseDirectory)); })
             .ConfigureServices((context, services) =>
             {
                 services.AddHostedService<ApplicationHostService>();

--- a/src/Wpf.Ui.Extension.Template.Fluent/App.xaml.cs
+++ b/src/Wpf.Ui.Extension.Template.Fluent/App.xaml.cs
@@ -25,7 +25,7 @@ namespace $safeprojectname$
         // https://docs.microsoft.com/dotnet/core/extensions/logging
         private static readonly IHost _host = Host
             .CreateDefaultBuilder()
-            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)); })
+            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(AppContext.BaseDirectory)); })
             .ConfigureServices((context, services) =>
             {
                 services.AddHostedService<ApplicationHostService>();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When you Publish the app which is based on one of the templates (Blank/Compact/Fluent), the app will be crashed since `Assembly.GetEntryAssembly()!.Location` in `App.xaml.cs:23` will always return `null`.
https://github.com/lepoco/wpfui/blob/09eeabd684f2e8f242ceff6deb60e1546d2a7bbf/src/Wpf.Ui.Extension.Template.Blank/App.xaml.cs#L23

This doesn't happen if you "build" the app (both Debug or Release), but when you "publish" it.

This issue also can be notified in build message when you publish the app:
`IL3000: 'System.Reflection.Assembly.Location' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.`

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The app will be properly published and executed

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Actually the demo app `Wpf.Ui.Demo.Mvvm` already solved this issue like below, so this can be also applied to the template projects.
https://github.com/lepoco/wpfui/blob/09eeabd684f2e8f242ceff6deb60e1546d2a7bbf/src/Wpf.Ui.Demo.Mvvm/App.xaml.cs#L30

References: 
- https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000 
- https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#api-incompatibility
- https://github.com/dotnet/corert/issues/5467


