### PR TITLE
Workaround for touch input triggering alongside the hwnd hook on titlebar

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -177,7 +177,8 @@
                                 <controls:TitleBarButton
                                     x:Name="PART_MaximizeButton"
                                     Grid.Column="2"
-                                    ButtonType="Maximize" />
+                                    ButtonType="Maximize" 
+                                    IsHitTestVisible="False"/> <!-- Prevent touch events from firing the command, clicks/hover are handled by the hwnd hook -->
 
                                 <controls:TitleBarButton
                                     x:Name="PART_CloseButton"

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -178,7 +178,7 @@
                                     x:Name="PART_MaximizeButton"
                                     Grid.Column="2"
                                     ButtonType="Maximize" 
-                                    IsHitTestVisible="False"/> <!-- Prevent touch events from firing the command, clicks/hover are handled by the hwnd hook -->
+                                    IsHitTestVisible="False"/>
 
                                 <controls:TitleBarButton
                                     x:Name="PART_CloseButton"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Using touch on the maximize button fires the matching command twice, resulting in the window quickly maximizing and restoring itself

Issue Number: #1126

## What is the new behavior?

Setting hittest to false disables touch input on the button, which was firing alongside WM_NCLBUTTONUP in the hwndhook, resulting in the command being fired twice.

## Other information

It might be better to just catch WM_TOUCH alongside the other events in the hook to prevent this, but I wasn't able to make that work unfortunately 🤔
