### PR TITLE
Fix not being able to use Icon markup extensions as the Value of a Setter

### DIFF
--- a/src/Wpf.Ui/Markup/FontIconExtension.cs
+++ b/src/Wpf.Ui/Markup/FontIconExtension.cs
@@ -49,16 +49,6 @@ public class FontIconExtension : MarkupExtension
 
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        if (
-            serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget
-            {
-                TargetObject: Setter
-            }
-        )
-        {
-            return this;
-        }
-
         FontIcon fontIcon = new() { Glyph = Glyph, FontFamily = FontFamily };
 
         if (FontSize > 0)

--- a/src/Wpf.Ui/Markup/SymbolIconExtension.cs
+++ b/src/Wpf.Ui/Markup/SymbolIconExtension.cs
@@ -60,16 +60,6 @@ public class SymbolIconExtension : MarkupExtension
 
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        if (
-            serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget
-            {
-                TargetObject: Setter
-            }
-        )
-        {
-            return this;
-        }
-
         SymbolIcon symbolIcon = new() { Symbol = Symbol, Filled = Filled };
 
         if (FontSize > 0)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Trying to use `{ui:SymbolIcon}` or `{ui:FontIcon}` extensions as the Value of a Setter in a Style will fail:  

```
<ui:Button>
<ui:Button.Style>
    <Style TargetType="ui:Button" BasedOn="{StaticResource {x:Type ui:Button}}">
        <!-- Flip icon on RTL language -->
        <Setter Property="Icon" Value="{ui:SymbolIcon ArrowLeft24}" />
        <Style.Triggers>
            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=local:MainWindow}, Path=FlowDirection}" Value="{x:Static FlowDirection.RightToLeft}">
                <Setter Property="Icon" Value="{ui:SymbolIcon ArrowRight24}" />
            </DataTrigger>
        </Style.Triggers>
    </Style>
</ui:Button.Style>
</ui:Button>
```

```
SymbolIconExtension is not valid for Setter.Value. The only supported MarkupExtension types are DynamicResourceExtension and BindingBase or derived types.
```

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The extensions can be used in Setters again.

## Other information

This change was brought in https://github.com/lepoco/wpfui/pull/1067 , but the incriminating lines don't seem to be related to the problem this PR was fixing (adding the missing constructor)
