### PR TITLE
fix: display sorting indicator in DataGrid headers

### DIFF
--- a/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
+++ b/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
@@ -500,10 +500,23 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="0,0,1,1">
-                            <ContentPresenter
-                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                <controls:SymbolIcon
+                                    Grid.Column="1"
+                                    Margin="5,0,0,0"
+                                    x:Name="SymbolIcon"
+                                    Filled="True"
+                                    Visibility="Hidden"
+                                    Symbol="CaretUp24" />
+                            </Grid>
                         </Border>
 
                         <Thumb
@@ -515,6 +528,21 @@
                             HorizontalAlignment="Right"
                             Style="{StaticResource ColumnHeaderGripperStyle}" />
                     </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="SymbolIcon" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="SortDirection" Value="Ascending">
+                            <Setter TargetName="SymbolIcon" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="SymbolIcon" Property="Symbol" Value="CaretUp24" />
+                            <Setter TargetName="SymbolIcon" Property="Foreground" Value="{DynamicResource SystemAccentColorSecondaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="SortDirection" Value="Descending">
+                            <Setter TargetName="SymbolIcon" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="SymbolIcon" Property="Symbol" Value="CaretDown24" />
+                            <Setter TargetName="SymbolIcon" Property="Foreground" Value="{DynamicResource SystemAccentColorSecondaryBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when using a DataGrid and sorting it by clicking on the header, the default behavior is to display a sorting indicator (▲|▼). However, this indicator is missing due to the applied header style in the project.

Issue Number: #1160

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The default sorting indicator (▲|▼) is now displayed correctly in DataGrid headers after applying a style.
- The issue where the sorting indicator was missing has been fixed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Before the change:
- No sorting indicator was displayed in DataGrid headers when sorting columns.

After the change:
- The sorting indicator is correctly displayed in DataGrid headers when sorting columns, improving user experience.