### PR TITLE
Fix: failing to correctly trigger the methods of the INavigationAware interface.

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
@@ -182,35 +182,14 @@ public class NavigationViewContentPresenter : Frame
         _ = TransitionAnimationProvider.ApplyTransition(content, Transition, TransitionDuration);
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "ReSharper",
-        "SuspiciousTypeConversion.Global",
-        Justification = "The library user might make a class inherit from both FrameworkElement and INavigationAware at the same time."
-    )]
     private static void NotifyContentAboutNavigatingTo(object content)
     {
-        switch (content)
-        {
-            // The order in which the OnNavigatedToAsync methods of View and ViewModel are called is not guaranteed
-            case INavigationAware navigationAwareNavigationContent:
-                _ = Task.Run(navigationAwareNavigationContent.OnNavigatedToAsync).ConfigureAwait(false);
-                if (
-                    navigationAwareNavigationContent
-                        is FrameworkElement { DataContext: INavigationAware viewModel }
-                    && !ReferenceEquals(viewModel, navigationAwareNavigationContent)
-                )
-                {
-                    _ = Task.Run(viewModel.OnNavigatedToAsync).ConfigureAwait(false);
-                }
+        NotifyContentAboutNavigating(content, navigationAware => navigationAware.OnNavigatedToAsync());
+    }
 
-                break;
-            case INavigableView<object> { ViewModel: INavigationAware navigationAwareNavigableViewViewModel }:
-                _ = Task.Run(navigationAwareNavigableViewViewModel.OnNavigatedToAsync).ConfigureAwait(false);
-                break;
-            case FrameworkElement { DataContext: INavigationAware navigationAwareCurrentContent }:
-                _ = Task.Run(navigationAwareCurrentContent.OnNavigatedToAsync).ConfigureAwait(false);
-                break;
-        }
+    private static void NotifyContentAboutNavigatingFrom(object content)
+    {
+        NotifyContentAboutNavigating(content, navigationAware => navigationAware.OnNavigatedFromAsync());
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -218,29 +197,29 @@ public class NavigationViewContentPresenter : Frame
         "SuspiciousTypeConversion.Global",
         Justification = "The library user might make a class inherit from both FrameworkElement and INavigationAware at the same time."
     )]
-    private static void NotifyContentAboutNavigatingFrom(object content)
+    private static void NotifyContentAboutNavigating(object content, Func<INavigationAware, Task> function)
     {
         switch (content)
         {
-            // The order in which the OnNavigatedFromAsync methods of View and ViewModel are called is not guaranteed
+            // The order in which the OnNavigatedToAsync/OnNavigatedFromAsync methods of View and ViewModel are called
+            // is not guaranteed
             case INavigationAware navigationAwareNavigationContent:
-                _ = Task.Run(navigationAwareNavigationContent.OnNavigatedFromAsync).ConfigureAwait(false);
+                _ = Task.Run(() => function(navigationAwareNavigationContent)).ConfigureAwait(false);
                 if (
                     navigationAwareNavigationContent
                         is FrameworkElement { DataContext: INavigationAware viewModel }
                     && !ReferenceEquals(viewModel, navigationAwareNavigationContent)
                 )
                 {
-                    _ = Task.Run(viewModel.OnNavigatedFromAsync).ConfigureAwait(false);
+                    _ = Task.Run(() => function(viewModel)).ConfigureAwait(false);
                 }
 
                 break;
             case INavigableView<object> { ViewModel: INavigationAware navigationAwareNavigableViewViewModel }:
-                _ = Task.Run(navigationAwareNavigableViewViewModel.OnNavigatedFromAsync)
-                    .ConfigureAwait(false);
+                _ = Task.Run(() => function(navigationAwareNavigableViewViewModel)).ConfigureAwait(false);
                 break;
             case FrameworkElement { DataContext: INavigationAware navigationAwareCurrentContent }:
-                _ = Task.Run(navigationAwareCurrentContent.OnNavigatedFromAsync).ConfigureAwait(false);
+                _ = Task.Run(() => function(navigationAwareCurrentContent)).ConfigureAwait(false);
                 break;
         }
     }

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
@@ -182,12 +182,27 @@ public class NavigationViewContentPresenter : Frame
         _ = TransitionAnimationProvider.ApplyTransition(content, Transition, TransitionDuration);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "ReSharper",
+        "SuspiciousTypeConversion.Global",
+        Justification = "The library user might make a class inherit from both FrameworkElement and INavigationAware at the same time."
+    )]
     private static void NotifyContentAboutNavigatingTo(object content)
     {
         switch (content)
         {
+            // The order in which the OnNavigatedToAsync methods of View and ViewModel are called is not guaranteed
             case INavigationAware navigationAwareNavigationContent:
                 _ = Task.Run(navigationAwareNavigationContent.OnNavigatedToAsync).ConfigureAwait(false);
+                if (
+                    navigationAwareNavigationContent
+                        is FrameworkElement { DataContext: INavigationAware viewModel }
+                    && !ReferenceEquals(viewModel, navigationAwareNavigationContent)
+                )
+                {
+                    _ = Task.Run(viewModel.OnNavigatedToAsync).ConfigureAwait(false);
+                }
+
                 break;
             case INavigableView<object> { ViewModel: INavigationAware navigationAwareNavigableViewViewModel }:
                 _ = Task.Run(navigationAwareNavigableViewViewModel.OnNavigatedToAsync).ConfigureAwait(false);
@@ -198,12 +213,27 @@ public class NavigationViewContentPresenter : Frame
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "ReSharper",
+        "SuspiciousTypeConversion.Global",
+        Justification = "The library user might make a class inherit from both FrameworkElement and INavigationAware at the same time."
+    )]
     private static void NotifyContentAboutNavigatingFrom(object content)
     {
         switch (content)
         {
+            // The order in which the OnNavigatedFromAsync methods of View and ViewModel are called is not guaranteed
             case INavigationAware navigationAwareNavigationContent:
                 _ = Task.Run(navigationAwareNavigationContent.OnNavigatedFromAsync).ConfigureAwait(false);
+                if (
+                    navigationAwareNavigationContent
+                        is FrameworkElement { DataContext: INavigationAware viewModel }
+                    && !ReferenceEquals(viewModel, navigationAwareNavigationContent)
+                )
+                {
+                    _ = Task.Run(viewModel.OnNavigatedFromAsync).ConfigureAwait(false);
+                }
+
                 break;
             case INavigableView<object> { ViewModel: INavigationAware navigationAwareNavigableViewViewModel }:
                 _ = Task.Run(navigationAwareNavigableViewViewModel.OnNavigatedFromAsync)


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When both the View and ViewModel inherit from the `INavigationAware` interface, only the `OnNavigatedToAsync`/`OnNavigatedFromAsync` methods of the View are triggered

Issue Number: #1169

## What is the new behavior?
- fix this bug.

## Other information

The order in which the `OnNavigatedToAsync`/`OnNavigatedFromAsync` methods of View and ViewModel are called is not guaranteed
