### PR TITLE
Set Expander content height to * instead of Auto

### DIFF
--- a/src/Wpf.Ui/Controls/Expander/Expander.xaml
+++ b/src/Wpf.Ui/Controls/Expander/Expander.xaml
@@ -106,7 +106,7 @@
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
                         <!--  Top level controls always visible  -->


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

In the current state the `Expander` does not respect the space given to it.
If the content get´s higher than the `Expander` is allowed to be all the remaining content is hiding behind.
![image](https://github.com/user-attachments/assets/52558cb3-b391-4b69-a4ca-5df215569781)
See #1180 for more infos.

Issue Number: fixes #1180

## What is the new behavior?

In the new behavior the size of content of the `Expander` is restricted to the size given to the `Expander`.
![image](https://github.com/user-attachments/assets/15c37d0a-8690-4050-8043-427b326d73d2)



