### PR TITLE
Perf: Exclude the unnecessary fields defined on a specific version

### DIFF
--- a/src/Wpf.Ui/Controls/MessageBox/MessageBox.cs
+++ b/src/Wpf.Ui/Controls/MessageBox/MessageBox.cs
@@ -236,10 +236,12 @@ public class MessageBox : System.Windows.Window
     /// </summary>
     public IRelayCommand TemplateButtonCommand => (IRelayCommand)GetValue(TemplateButtonCommandProperty);
 
+#if !NET8_0_OR_GREATER
     private static readonly PropertyInfo CanCenterOverWPFOwnerPropertyInfo = typeof(Window).GetProperty(
         "CanCenterOverWPFOwner",
         BindingFlags.NonPublic | BindingFlags.Instance
     )!;
+#endif
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MessageBox"/> class.


### PR DESCRIPTION
Exclude the definition of the `CanCenterOverWPFOwnerPropertyInfo` field in .NET 8.0 or higher

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

In the current implementation, even if the `CanCenterOverWPFOwnerPropertyInfo` field is not used (.NET 8 and higher), this field is still being initialized.

Issue Number: N/A

## What is the new behavior?
Exclude the definition of the `CanCenterOverWPFOwnerPropertyInfo` field in .NET 8.0 or higher

