### PR TITLE
TitleBarPaneCompactMarginDefault set to 35 to prevent icon moving.

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -67,7 +67,7 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     private readonly ObservableCollection<NavigationViewBreadcrumbItem> _breadcrumbBarItems = [];
 
     private static readonly Thickness TitleBarPaneOpenMarginDefault = new(35, 0, 0, 0);
-    private static readonly Thickness TitleBarPaneCompactMarginDefault = new(55, 0, 0, 0);
+    private static readonly Thickness TitleBarPaneCompactMarginDefault = new(35, 0, 0, 0);
     private static readonly Thickness AutoSuggestBoxMarginDefault = new(8, 8, 8, 16);
     private static readonly Thickness FrameMarginDefault = new(0, 50, 0, 0);
 


### PR DESCRIPTION
Toggling the NavigationBar no longer makes the TitleBar title and icon jump around.

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- Title and icon in the TitleBar jump around, when toggling the NavigationMenu to show icons only.

Base on this discussion: https://github.com/lepoco/wpfui/discussions/911

Bug: https://github.com/lepoco/wpfui/issues/1194

## What is the new behavior?

- Toggling the NavigationBar no longer makes the TitleBar title and icon jump around.
