### PR TITLE
Fix hover behavior for CardControl

### DIFF
--- a/src/Wpf.Ui/Controls/CardControl/CardControl.xaml
+++ b/src/Wpf.Ui/Controls/CardControl/CardControl.xaml
@@ -86,24 +86,6 @@
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource CardBackgroundPointerOver}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Background" Value="{DynamicResource CardBackgroundDisabled}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrushDisabled}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource CardForegroundDisabled}" />
-                            <Setter TargetName="HeaderContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource CardForegroundDisabled}" />
-                            <Setter TargetName="ControlIcon" Property="Foreground" Value="{DynamicResource CardForegroundDisabled}" />
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource CardBackgroundPressed}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrushPressed}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource CardForegroundPressed}" />
-                            <Setter TargetName="HeaderContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource CardForegroundPressed}" />
-                            <Setter TargetName="ControlIcon" Property="Foreground" Value="{DynamicResource CardForegroundPressed}" />
-                        </Trigger>
                         <Trigger Property="Content" Value="{x:Null}">
                             <Setter TargetName="ContentPresenter" Property="Margin" Value="0" />
                         </Trigger>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Non-actionable cards shouldn't have hover behavior, as per WinUI

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

CardControls behave as if they can be clicked when hovering over them
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #447

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- CardControls are inert, as in the Windows Settings app


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
