### PR TITLE
Fix screen reader issues with CardAction/Button/MenuItem/NavigationViewItem

### DIFF
--- a/src/Wpf.Ui/Controls/Button/Button.xaml
+++ b/src/Wpf.Ui/Controls/Button/Button.xaml
@@ -195,18 +195,6 @@
                                     VerticalAlignment="Center"
                                     Content="{TemplateBinding Content}"
                                     TextElement.Foreground="{TemplateBinding Foreground}" />
-                                
-                                <!-- TextBlock added so that screen readers don't try to read Icon -->
-                                <TextBlock 
-                                   Grid.Column="0"
-                                   Grid.ColumnSpan="2"
-                                   Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                                   Margin="-10"
-                                   FontSize="1"
-                                   Opacity="0"
-                                   Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                                   Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                                   Background="Black"/>
                             </Grid>
                         </Border>
                     </Border>

--- a/src/Wpf.Ui/Controls/Button/Button.xaml
+++ b/src/Wpf.Ui/Controls/Button/Button.xaml
@@ -195,6 +195,18 @@
                                     VerticalAlignment="Center"
                                     Content="{TemplateBinding Content}"
                                     TextElement.Foreground="{TemplateBinding Foreground}" />
+                                
+                                <!-- TextBlock added so that screen readers don't try to read Icon -->
+                                <TextBlock 
+                                   Grid.Column="0"
+                                   Grid.ColumnSpan="2"
+                                   Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                                   Margin="-10"
+                                   FontSize="1"
+                                   Opacity="0"
+                                   Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                                   Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                                   Background="Black"/>
                             </Grid>
                         </Border>
                     </Border>

--- a/src/Wpf.Ui/Controls/CardAction/CardAction.cs
+++ b/src/Wpf.Ui/Controls/CardAction/CardAction.cs
@@ -4,6 +4,8 @@
 // All Rights Reserved.
 
 // ReSharper disable once CheckNamespace
+using System.Windows.Automation.Peers;
+
 namespace Wpf.Ui.Controls;
 
 /// <summary>
@@ -47,5 +49,10 @@ public class CardAction : System.Windows.Controls.Primitives.ButtonBase
     {
         get => (IconElement?)GetValue(IconProperty);
         set => SetValue(IconProperty, value);
+    }
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new CardActionAutomationPeer(this);
     }
 }

--- a/src/Wpf.Ui/Controls/CardAction/CardActionAutomationPeer.cs
+++ b/src/Wpf.Ui/Controls/CardAction/CardActionAutomationPeer.cs
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+
+namespace Wpf.Ui.Controls;
+
+internal class CardActionAutomationPeer : FrameworkElementAutomationPeer
+{
+    private readonly CardAction _owner;
+
+    public CardActionAutomationPeer(CardAction owner)
+        : base(owner)
+    {
+        _owner = owner;
+    }
+
+    protected override string GetClassNameCore()
+    {
+        return "Button";
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+    {
+        return AutomationControlType.Button;
+    }
+
+    public override object GetPattern(PatternInterface patternInterface)
+    {
+        if (patternInterface == PatternInterface.ItemContainer)
+        {
+            return this;
+        }
+
+        return base.GetPattern(patternInterface);
+    }
+
+    protected override AutomationPeer GetLabeledByCore()
+    {
+        if (_owner.Content is UIElement element)
+        {
+            return CreatePeerForElement(element);
+        }
+
+        return base.GetLabeledByCore();
+    }
+
+    protected override string GetNameCore()
+    {
+        var result = base.GetNameCore() ?? string.Empty;
+
+        if (result == string.Empty)
+        {
+            result = AutomationProperties.GetName(_owner);
+        }
+
+        if (result == string.Empty && _owner.Content is DependencyObject d)
+        {
+            result = AutomationProperties.GetName(d);
+        }
+
+        if (result == string.Empty && _owner.Content is string s)
+        {
+            result = s;
+        }
+
+        return result;
+    }
+}

--- a/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
+++ b/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
@@ -74,6 +74,16 @@
                         ContentSource="Header"
                         RecognizesAccessKey="True"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
+                    <!-- TextBlock added so that screen readers don't try to read Icon -->
+                    <TextBlock Grid.Column="0"
+                        Grid.ColumnSpan="3"
+                        Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Margin="-10"
+                        FontSize="1"
+                        Opacity="0"
+                        Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Background="Black"/>
                 </Grid>
 
                 <Popup
@@ -181,6 +191,16 @@
                     ContentSource="Header"
                     RecognizesAccessKey="True"
                     TextElement.Foreground="{TemplateBinding Foreground}" />
+                <!-- TextBlock added so that screen readers don't try to read Icon -->
+                <TextBlock Grid.Column="0"
+                   Grid.ColumnSpan="3"
+                   Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Margin="-10"
+                   FontSize="1"
+                   Opacity="0"
+                   Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Background="Black"/>
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -264,6 +284,17 @@
                     FontSize="11"
                     Foreground="{DynamicResource TextFillColorDisabledBrush}"
                     Text="{TemplateBinding InputGestureText}" />
+                
+                <!-- TextBlock added so that screen readers don't try to read Icon -->
+                <TextBlock Grid.Column="0"
+                   Grid.ColumnSpan="5"
+                   Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Margin="-10"
+                   FontSize="1"
+                   Opacity="0"
+                   Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Background="Black"/>
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -334,6 +365,17 @@
                             FontSize="{TemplateBinding FontSize}"
                             Symbol="ChevronRight20" />
                     </Grid>
+                    
+                    <!-- Fix double narration from mousing over the button and then the associated text -->
+                    <TextBlock Grid.Column="0"
+                        Grid.ColumnSpan="3"
+                        Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Margin="-10"
+                        FontSize="1"
+                        Opacity="0"
+                        Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Background="Black"/>
                 </Grid>
             </Border>
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewItem.cs
@@ -8,6 +8,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -436,6 +437,11 @@ public class NavigationViewItem
         }
 
         e.Handled = true;
+    }
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new NavigationViewItemAutomationPeer(this);
     }
 
     private void OnMenuItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemAutomationPeer.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemAutomationPeer.cs
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+
+namespace Wpf.Ui.Controls;
+
+internal class NavigationViewItemAutomationPeer : FrameworkElementAutomationPeer
+{
+    private readonly NavigationViewItem _owner;
+
+    public NavigationViewItemAutomationPeer(NavigationViewItem owner)
+        : base(owner)
+    {
+        _owner = owner;
+    }
+
+    protected override string GetClassNameCore()
+    {
+        return "NavigationItem";
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+    {
+        return AutomationControlType.TabItem;
+    }
+
+    public override object GetPattern(PatternInterface patternInterface)
+    {
+        if (patternInterface == PatternInterface.ItemContainer)
+        {
+            return this;
+        }
+
+        return base.GetPattern(patternInterface);
+    }
+
+    protected override AutomationPeer GetLabeledByCore()
+    {
+        if (_owner.Content is UIElement element)
+        {
+            return CreatePeerForElement(element);
+        }
+
+        return base.GetLabeledByCore();
+    }
+
+    protected override string GetNameCore()
+    {
+        var result = base.GetNameCore() ?? string.Empty;
+
+        if (result == string.Empty)
+        {
+            result = AutomationProperties.GetName(_owner);
+        }
+
+        if (result == string.Empty && _owner.Content is DependencyObject d)
+        {
+            result = AutomationProperties.GetName(d);
+        }
+
+        if (result == string.Empty && _owner.Content is string s)
+        {
+            result = s;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Screen Readers will try to narrate the Icon for Buttons and MenuItems if they have them set.  
Additionally, CardAction and NavigationViewItem have no screen reader support whatsoever.  

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a dedicated AutomationPeer to CardAction and NavigationViewItem
- Overlaid Icons in Button/MenuItems with a transparent textblock to avoid them being read

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
