### PR TITLE
Fix memory leak in ListView

### DIFF
--- a/src/Wpf.Ui/Controls/ListView/ListView.cs
+++ b/src/Wpf.Ui/Controls/ListView/ListView.cs
@@ -26,6 +26,8 @@ namespace Wpf.Ui.Controls;
 /// </example>
 public class ListView : System.Windows.Controls.ListView
 {
+    private DependencyPropertyDescriptor? _descriptor;
+
     /// <summary>Identifies the <see cref="ViewState"/> dependency property.</summary>
     public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(
         nameof(ViewState),
@@ -62,6 +64,7 @@ public class ListView : System.Windows.Controls.ListView
     public ListView()
     {
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -69,12 +72,19 @@ public class ListView : System.Windows.Controls.ListView
         Loaded -= OnLoaded; // prevent memory leaks
 
         // Setup initial ViewState and hook into View property changes
-        var descriptor = DependencyPropertyDescriptor.FromProperty(
+        _descriptor = DependencyPropertyDescriptor.FromProperty(
             System.Windows.Controls.ListView.ViewProperty,
             typeof(System.Windows.Controls.ListView)
         );
-        descriptor?.AddValueChanged(this, OnViewPropertyChanged);
+        _descriptor?.AddValueChanged(this, OnViewPropertyChanged);
         UpdateViewState(); // set the initial state
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnUnloaded;
+
+        _descriptor?.RemoveValueChanged(this, OnViewPropertyChanged);
     }
 
     private void OnViewPropertyChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Fixes a memory leak explained in #1242:

> [OnLoaded](https://github.com/lepoco/wpfui/blob/4ac96867797267d566b82fbbfcab0c867353afaa/src/Wpf.Ui/Controls/ListView/ListView.cs#L67-L78) method of the ListView from WPF-UI uses DependencyPropertyDescriptor to invoke AddValueChanged, but never unregisters the event handler using RemoveValueChanged, which leads to a memory leak because a strong refence is created to the component.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

ListView leaks memory due to `RemoveValueChanged` is never called and the dangling reference to the control is being hold forever.

Issue Number: #1242

## What is the new behavior?

- ListView now subscribes to `Unloaded` event and removes the subscription to `ValueChanged` event of the View.

## Other information

<details><summary>A basic unit test which displays the difference between WpfUi's ListView vs regular ListView in terms of being successfully collected by GC</summary>

```cs
public class UnitTest1
{
    [Fact]
    public Task TestWpfUiControlsListView()
    {
        return TestListViewMemoryLeakAsync<Wpf.Ui.Controls.ListView>();
    }

    [Fact]
    public Task TestSystemWindowsControlListView()
    {
        return TestListViewMemoryLeakAsync<System.Windows.Controls.ListView>();
    }

    public async Task TestListViewMemoryLeakAsync<T>() where T : ListView, new()
    {
        WeakReference? wr = null;

        await StartSTATask(() =>
        {
            var listView = new T();

            wr = new WeakReference(listView);

            listView.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
            listView.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
        });

        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);

        Assert.NotNull(wr);
        Assert.False(wr.IsAlive);
    }

    public static Task StartSTATask(Action action)
    {
        var tcs = new TaskCompletionSource<object>();
        var thread = new Thread(() =>
        {
            try
            {
                action();
                tcs.SetResult(new object());
            }
            catch (Exception e)
            {
                tcs.SetException(e);
            }
        });
        thread.SetApartmentState(ApartmentState.STA);
        thread.Start();
        return tcs.Task;
    }
}
```

</details>

- Before:
![image](https://github.com/user-attachments/assets/a9754f92-6e77-4c6b-b578-ff34ce9e7242)

- After:
![image](https://github.com/user-attachments/assets/3896021d-901d-4aab-9d39-fa1d365b72c8)




<details><summary>I'd also like to recommend adding some basic unit-tests that would test (almost) all controls to ensure that the same basic mistake is not repeated in a future</summary>


This test finds all classes that are assignable to Control from Wpf.Ui. namespace that have parameterless constructor and make an attempt to perform the same test that was used for the `ListView` in the previous code listing.

Fun fact: in addition to ListView, it also reports `DataGrid` to also have a memory leak. I didn't dig into it so it could be some false positive, which doesn't happen in real life scenario, but what I could tell is that the issue was related specifically to the components used within `DataGrid.xaml` (commenting out entire markup fixed the unit test).

```cs
public class MemoryLeakTests(ITestOutputHelper output)
{
    [Fact]
    public async Task TestAllControls()
    {
        // Find classes that are assignable to Control from Wpf.Ui. namespace that have parameterless constructor.
        var controlTypes = typeof(FluentWindow).Assembly.GetTypes()
            .Where(t => t.IsAssignableTo(typeof(Control)) &&
                        t.Namespace!.StartsWith("Wpf.Ui.") &&
                        t.GetConstructor(Type.EmptyTypes) != null)
            .ToList();

        output.WriteLine($"Found {controlTypes.Count} control types.");

        foreach (Type controlType in controlTypes)
        {
            output.WriteLine(controlType.FullName);
        }

        controlTypes.Remove(typeof(Wpf.Ui.Controls.DataGrid));
        
        foreach (var controlType in controlTypes)
        {
            await TestControlViewMemoryLeakAsync(controlType);
        }
    }

    public async Task TestControlViewMemoryLeakAsync(Type type)
    {
        WeakReference? wr = null;

        await StartSTATask(() =>
        {
            try
            {
                var control = Activator.CreateInstance(type) as Control;

                Assert.NotNull(control);

                wr = new WeakReference(control);

                control.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
                control.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
            }
            catch(Exception e)
            {
                output.WriteLine($"Failed to test {type.FullName} because of an exception during object construction: {e}");
            }
        });

        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);

        Assert.NotNull(wr);
        Assert.False(wr.IsAlive, $"Memory leak detected in {type.FullName}.");

        output.WriteLine($"Test passed for {type.FullName}.");
    }

    public async Task TestControlViewMemoryLeakAsync<T>() where T : Control, new()
    {
        await TestControlViewMemoryLeakAsync(typeof(T));
    }

    public static Task StartSTATask(Action action)
    {
        var tcs = new TaskCompletionSource<object>();
        var thread = new Thread(() =>
        {
            try
            {
                action();
                tcs.SetResult(new object());
            }
            catch (Exception e)
            {
                tcs.SetException(e);
            }
        });
        thread.SetApartmentState(ApartmentState.STA);
        thread.Start();
        return tcs.Task;
    }
}
```

</details>

Aforementioned unit test are not included in the PR (doesn't look like there are many in this repo at all), but I can commit the as well if requested.
