### PR TITLE
Defining a FontSize in a FontIcon should not be overridden by its VisualParent's

### DIFF
--- a/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
@@ -117,7 +117,7 @@ public class FontIcon : IconElement
             SetResourceReference(FontSizeProperty, "DefaultIconFontSize");
 
             // If the FontSize is the default, set it to the parent's FontSize.
-            if (VisualParent is not null)
+            if (VisualParent is not null && TextElement.GetFontSize(VisualParent) != SystemFonts.MessageFontSize)
             {
                 SetCurrentValue(FontSizeProperty, TextElement.GetFontSize(VisualParent));
             }

--- a/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
@@ -112,14 +112,15 @@ public class FontIcon : IconElement
 
     protected override UIElement InitializeChildren()
     {
-        if (VisualParent is not null)
-        {
-            SetCurrentValue(FontSizeProperty, TextElement.GetFontSize(VisualParent));
-        }
-
         if (FontSize.Equals(SystemFonts.MessageFontSize))
         {
             SetResourceReference(FontSizeProperty, "DefaultIconFontSize");
+
+            // If the FontSize is the default, set it to the parent's FontSize.
+            if (VisualParent is not null)
+            {
+                SetCurrentValue(FontSizeProperty, TextElement.GetFontSize(VisualParent));
+            }
         }
 
         TextBlock = new TextBlock


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When using a `FontIcon`, its `FontSize` will first take the FontSize of its `VisualParent` if it has one, then be set to `DefaultIconFontSize` if it's still at the default WPF FontSize.   

Both of those actions override whatever FontSize you would set in the FontIcon control itself.  
An easy example of this is if I want to have a `HyperlinkButton` with a custom Icon Font Size:  

```
<ui:HyperlinkButton x:Name="UpgradeHyperlink"
       Margin="0,2,0,0" Height="30"
       Icon="{ui:SymbolIcon ChevronCircleUp20, FontSize=20}"
       Content="Upgrade"
       />
```

![image](https://github.com/user-attachments/assets/04225778-1adb-4317-8bb7-51a490ddb0f8)

Issue Number: N/A

## What is the new behavior?

The VisualParent FontSize override now only happens if the FontIcon was using the default WPF FontSize. (as in, no custom sizes were applied)  

![image](https://github.com/user-attachments/assets/8da5de5c-7b98-45d9-bdc1-42a579ea4eb1)  

## Other information

There's arguably still a problem with this fix if you want a FontIcon whose size coincidentally matches `SystemFonts.MessageFontSize` within say, a HyperLinkButton with a FontSize of 20. But that'd require deeper architectural changes to handle properly... 
