### PR TITLE
Fix typo in Gallery's radio button page

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/RadioButtonPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/RadioButtonPage.xaml
@@ -46,7 +46,7 @@
                     Grid.Column="1"
                     Command="{Binding ViewModel.RadioButtonCheckboxCheckedCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:RadioButtonPage}, Mode=OneWay}"
                     CommandParameter="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}"
-                    Content="Disable RadioButton's" />
+                    Content="Disable radio buttons" />
             </Grid>
         </controls:ControlExample>
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Issue Number: N/A

Possessive form typo in the caption of the checkbox that disables the radio buttons.

![image](https://github.com/user-attachments/assets/75600ec5-6c49-427b-bfda-d563c5581ec5)

## What is the new behavior?

Changed checkbox caption to _Disable radio buttons_.

## Other information

I chose _Disable radio buttons_ as opposed to _Disable RadioButtons_ to conform with the writing style used in other similar checkboxes for other control previews. For example:

- In the `ToggleButton` page, the checkbox caption is _Disable toggle button_.
- In the `Button` page, the checkbox caption is _Disable button_.
