### PR TITLE
Fix: ToggleButton interaction problem in SplitButton

### DIFF
--- a/src/Wpf.Ui/Controls/SplitButton/SplitButton.xaml
+++ b/src/Wpf.Ui/Controls/SplitButton/SplitButton.xaml
@@ -42,6 +42,8 @@
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Border
                         x:Name="ContentBorder"
+                        Margin="0,-1,-1,-1"
+                        Padding="11,0"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
@@ -119,7 +121,6 @@
                             <Border
                                 Grid.Column="1"
                                 Margin="0"
-                                Padding="{TemplateBinding Padding}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness,
                                                                   Converter={StaticResource RightSplitThicknessConverter}}"


### PR DESCRIPTION
* fix: ToggleButton interaction problem in SplitButton

The flyout is displayed only when the button's image is clicked precisely, and this is inconvenient for the user.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The flyout is displayed only when the red area is clicked, and the button command is executed when any other area is clicked.

![image](https://github.com/user-attachments/assets/769b7759-22b4-4ef7-a9e0-2043efaa124b)


Issue Number: [#1179] - Style Enhancement

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The flyout is displayed when any area of the ToggleButton is clicked.

![image](https://github.com/user-attachments/assets/1f4ce6eb-1479-4ed0-8a7d-a96233f14b67)

