### PR TITLE
Disable NavigationViewContentPresenter refreshing from keyboard

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
@@ -140,9 +140,21 @@ public class NavigationViewContentPresenter : Frame
         if (e.ChangedButton is MouseButton.XButton1 or MouseButton.XButton2)
         {
             e.Handled = true;
+            return;
         }
 
         base.OnMouseDown(e);
+    }
+
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.F5)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        base.OnPreviewKeyDown(e);
     }
 
     protected virtual void OnNavigating(System.Windows.Navigation.NavigatingCancelEventArgs eventArgs)


### PR DESCRIPTION
Now **NavigationViewContentPresenter** inherits keyboard navigation from Frame. 

I suggest that **NavigationViewContentPresenter** should not be updated when pressing `F5`. This triggers the **Navigating** event and **INavigationAware** notifications. It also reloads the page itself.

This behaviour of Frame is fine when it is displaying Web content, but we use it to navigate the Desktop application.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes