### PR TITLE
Improve string comparison performance

### DIFF
--- a/src/Wpf.Ui/Appearance/ApplicationAccentColorManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationAccentColorManager.cs
@@ -3,7 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using Wpf.Ui.Extensions;
 using Wpf.Ui.Interop;
 
 namespace Wpf.Ui.Appearance;

--- a/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationThemeManager.cs
@@ -142,7 +142,7 @@ public static class ApplicationThemeManager
 
         ResourceDictionary[] resourcesRemove = frameworkElement
             .Resources.MergedDictionaries.Where(e => e.Source is not null)
-            .Where(e => e.Source.ToString().ToLower().Contains(LibraryNamespace))
+            .Where(e => e.Source.ToString().Contains(LibraryNamespace, StringComparison.OrdinalIgnoreCase))
             .ToArray();
 
         foreach (ResourceDictionary? resource in UiApplication.Current.Resources.MergedDictionaries)
@@ -288,19 +288,19 @@ public static class ApplicationThemeManager
             return;
         }
 
-        string themeUri = themeDictionary.Source.ToString().Trim().ToLower();
+        string themeUri = themeDictionary.Source.ToString();
 
-        if (themeUri.Contains("light"))
+        if (themeUri.Contains("light", StringComparison.OrdinalIgnoreCase))
         {
             _cachedApplicationTheme = ApplicationTheme.Light;
         }
 
-        if (themeUri.Contains("dark"))
+        if (themeUri.Contains("dark", StringComparison.OrdinalIgnoreCase))
         {
             _cachedApplicationTheme = ApplicationTheme.Dark;
         }
 
-        if (themeUri.Contains("highcontrast"))
+        if (themeUri.Contains("highcontrast", StringComparison.OrdinalIgnoreCase))
         {
             _cachedApplicationTheme = ApplicationTheme.HighContrast;
         }

--- a/src/Wpf.Ui/Appearance/ResourceDictionaryManager.cs
+++ b/src/Wpf.Ui/Appearance/ResourceDictionaryManager.cs
@@ -46,19 +46,17 @@ internal class ResourceDictionaryManager
             return null;
         }
 
-        resourceLookup = resourceLookup.ToLower().Trim();
-
         foreach (ResourceDictionary t in applicationDictionaries)
         {
             string resourceDictionaryUri;
 
             if (t?.Source != null)
             {
-                resourceDictionaryUri = t.Source.ToString().ToLower().Trim();
+                resourceDictionaryUri = t.Source.ToString();
 
                 if (
-                    resourceDictionaryUri.Contains(SearchNamespace)
-                    && resourceDictionaryUri.Contains(resourceLookup)
+                    resourceDictionaryUri.Contains(SearchNamespace, StringComparison.OrdinalIgnoreCase)
+                    && resourceDictionaryUri.Contains(resourceLookup, StringComparison.OrdinalIgnoreCase)
                 )
                 {
                     return t;
@@ -72,11 +70,11 @@ internal class ResourceDictionaryManager
                     continue;
                 }
 
-                resourceDictionaryUri = t1.Source.ToString().ToLower().Trim();
+                resourceDictionaryUri = t1.Source.ToString();
 
                 if (
-                    !resourceDictionaryUri.Contains(SearchNamespace)
-                    || !resourceDictionaryUri.Contains(resourceLookup)
+                    !resourceDictionaryUri.Contains(SearchNamespace, StringComparison.OrdinalIgnoreCase)
+                    || !resourceDictionaryUri.Contains(resourceLookup, StringComparison.OrdinalIgnoreCase)
                 )
                 {
                     continue;
@@ -107,17 +105,15 @@ internal class ResourceDictionaryManager
             return false;
         }
 
-        resourceLookup = resourceLookup.ToLower().Trim();
-
         for (var i = 0; i < applicationDictionaries.Count; i++)
         {
             string sourceUri;
 
             if (applicationDictionaries[i]?.Source != null)
             {
-                sourceUri = applicationDictionaries[i].Source.ToString().ToLower().Trim();
+                sourceUri = applicationDictionaries[i].Source.ToString();
 
-                if (sourceUri.Contains(SearchNamespace) && sourceUri.Contains(resourceLookup))
+                if (sourceUri.Contains(SearchNamespace, StringComparison.OrdinalIgnoreCase) && sourceUri.Contains(resourceLookup, StringComparison.OrdinalIgnoreCase))
                 {
                     applicationDictionaries[i] = new() { Source = newResourceUri };
 
@@ -134,11 +130,10 @@ internal class ResourceDictionaryManager
 
                 sourceUri = applicationDictionaries[i]
                     .MergedDictionaries[j]
-                    .Source.ToString()
-                    .ToLower()
-                    .Trim();
+                    .Source
+                    .ToString();
 
-                if (!sourceUri.Contains(SearchNamespace) || !sourceUri.Contains(resourceLookup))
+                if (!sourceUri.Contains(SearchNamespace, StringComparison.OrdinalIgnoreCase) || !sourceUri.Contains(resourceLookup, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/src/Wpf.Ui/Appearance/SystemThemeManager.cs
+++ b/src/Wpf.Ui/Appearance/SystemThemeManager.cs
@@ -69,60 +69,58 @@ public static class SystemThemeManager
 
         if (!string.IsNullOrEmpty(currentTheme))
         {
-            currentTheme = currentTheme.ToLower().Trim();
-
             // This may be changed in the next versions, check the Insider previews
-            if (currentTheme.Contains("basic.theme"))
+            if (currentTheme.Contains("basic.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.Light;
             }
 
-            if (currentTheme.Contains("aero.theme"))
+            if (currentTheme.Contains("aero.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.Light;
             }
 
-            if (currentTheme.Contains("dark.theme"))
+            if (currentTheme.Contains("dark.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.Dark;
             }
 
-            if (currentTheme.Contains("hcblack.theme"))
+            if (currentTheme.Contains("hcblack.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.HCBlack;
             }
 
-            if (currentTheme.Contains("hcwhite.theme"))
+            if (currentTheme.Contains("hcwhite.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.HCWhite;
             }
 
-            if (currentTheme.Contains("hc1.theme"))
+            if (currentTheme.Contains("hc1.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.HC1;
             }
 
-            if (currentTheme.Contains("hc2.theme"))
+            if (currentTheme.Contains("hc2.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.HC2;
             }
 
-            if (currentTheme.Contains("themea.theme"))
+            if (currentTheme.Contains("themea.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.Glow;
             }
 
-            if (currentTheme.Contains("themeb.theme"))
+            if (currentTheme.Contains("themeb.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.CapturedMotion;
             }
 
-            if (currentTheme.Contains("themec.theme"))
+            if (currentTheme.Contains("themec.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.Sunrise;
             }
 
-            if (currentTheme.Contains("themed.theme"))
+            if (currentTheme.Contains("themed.theme", StringComparison.OrdinalIgnoreCase))
             {
                 return SystemTheme.Flow;
             }

--- a/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -551,13 +551,13 @@ public class AutoSuggestBox : System.Windows.Controls.ItemsControl, IIconControl
             return;
         }
 
-        var splitText = text.ToLowerInvariant().Split(' ');
+        var splitText = text.Split(' ');
         var suitableItems = OriginalItemsSource
             .Cast<object>()
             .Where(item =>
             {
-                var itemText = GetStringFromObj(item)?.ToLowerInvariant();
-                return splitText.All(key => itemText?.Contains(key) ?? false);
+                var itemText = GetStringFromObj(item);
+                return splitText.All(key => itemText?.Contains(key, StringComparison.OrdinalIgnoreCase) ?? false);
             })
             .ToList();
 

--- a/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItem.cs
+++ b/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItem.cs
@@ -5,7 +5,7 @@
 
 /* Based on Windows UI Library */
 
-using Wpf.Ui.Converters;
+
 
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;

--- a/src/Wpf.Ui/Controls/EventIdentifier.cs
+++ b/src/Wpf.Ui/Controls/EventIdentifier.cs
@@ -3,8 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using Wpf.Ui.Extensions;
-
 namespace Wpf.Ui.Controls;
 
 /// <summary>

--- a/src/Wpf.Ui/Controls/GridView/GridViewRowPresenter.cs
+++ b/src/Wpf.Ui/Controls/GridView/GridViewRowPresenter.cs
@@ -3,9 +3,7 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using System.Reflection;
-using System.Windows.Controls;
-
+// ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 
 /// <summary>

--- a/src/Wpf.Ui/Controls/IconElement/IconElementConverter.cs
+++ b/src/Wpf.Ui/Controls/IconElement/IconElementConverter.cs
@@ -3,8 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using Wpf.Ui.Extensions;
-
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/IconElement/IconSourceElement.cs
+++ b/src/Wpf.Ui/Controls/IconElement/IconSourceElement.cs
@@ -4,7 +4,6 @@
 // All Rights Reserved.
 
 using System.Windows.Markup;
-using Wpf.Ui.Converters;
 
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;

--- a/src/Wpf.Ui/Controls/IconElement/SymbolIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElement/SymbolIcon.cs
@@ -3,8 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using Wpf.Ui.Extensions;
-
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/TextBlock/TextBlock.cs
+++ b/src/Wpf.Ui/Controls/TextBlock/TextBlock.cs
@@ -3,8 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using Wpf.Ui.Extensions;
-
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/TextBox/TextBox.cs
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.cs
@@ -5,7 +5,6 @@
 
 using System.Diagnostics;
 using System.Windows.Controls;
-using Wpf.Ui.Converters;
 using Wpf.Ui.Input;
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -6,7 +6,6 @@
 using System.Diagnostics;
 using System.Windows.Input;
 using Wpf.Ui.Designer;
-using Wpf.Ui.Extensions;
 using Wpf.Ui.Input;
 using Wpf.Ui.Interop;
 

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -5,7 +5,6 @@
 
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
-using Wpf.Ui.Extensions;
 using Wpf.Ui.Interop;
 
 // ReSharper disable once CheckNamespace

--- a/src/Wpf.Ui/Extensions/StringExtensions.cs
+++ b/src/Wpf.Ui/Extensions/StringExtensions.cs
@@ -1,0 +1,26 @@
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+#if NETFRAMEWORK
+using System.Diagnostics.Contracts;
+
+namespace Wpf.Ui.Extensions;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    ///     Returns a value indicating whether a specified string occurs within this string, using the specified comparison rules.
+    /// </summary>
+    /// <param name="source">Source string.</param>
+    /// <param name="value">The string to seek.</param>
+    /// <param name="comparison">One of the enumeration values that specifies the rules to use in the comparison.</param>
+    /// <returns>true if the value parameter occurs within this string, or if value is the empty string (""); otherwise, false.</returns>
+    [Pure]
+    public static bool Contains(this string source, string value, StringComparison comparison)
+    {
+        return source.IndexOf(value, comparison) >= 0;
+    }
+}
+#endif

--- a/src/Wpf.Ui/GlobalUsings.cs
+++ b/src/Wpf.Ui/GlobalUsings.cs
@@ -13,3 +13,4 @@ global using System.Threading.Tasks;
 global using System.Windows;
 global using System.Windows.Interop;
 global using System.Windows.Media;
+global using Wpf.Ui.Extensions;

--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -132,7 +132,7 @@ public class UiApplication
         return application
             .Resources.MergedDictionaries.Where(e => e.Source is not null)
             .Any(e =>
-                e.Source.ToString().ToLower().Contains(Appearance.ApplicationThemeManager.LibraryNamespace)
+                e.Source.ToString().Contains(Appearance.ApplicationThemeManager.LibraryNamespace, StringComparison.OrdinalIgnoreCase)
             );
     }
 }


### PR DESCRIPTION
The current version of the comparison is extremely inefficient. As you know `ToLower` is a rather slow operation, which may reduce performance for comparing a large number of strings. The best way is to use overloading with `StringComparison` support. But it is not available in **Net framework**.

I added the code and description from .Net 9 to support the method on any target framework. To prevent **using** from being marked unused in **Net core** and accidentally deleted, I added global using for extensions in the UI package.

Additionally I removed the `Trim` call, for URI comparison, URI does not support spaces and such call is useless, every call I debugged, everything compares correctly, previous behaviour is preserved with performance increase.

Before:
```C#
"text".Trim().ToLower().Contains("Text")
```

Now:
```C#
"text".Contains("Text", StringComparison.OrdinalIgnoreCase)
```

Benchmark for string `pack://application:,,,/Wpf.Ui;component/Resources/Theme/Light.xaml`:

| Method                     | Mean     | Error    | StdDev   | Allocated |
|--------------------------- |---------:|---------:|---------:|----------:|
| ToLower                    | 37.22 ns | 2.117 ns | 3.103 ns |     160 B |
| OrdinalIgnoreCase          | 13.61 ns | 0.138 ns | 0.203 ns |         - |
| InvariantCultureIgnoreCase | 92.63 ns | 0.656 ns | 0.962 ns |         - |

`StringComparison.OrdinalIgnoreCase` 3 times faster without memory allocation.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
