### PR TITLE
Invoke INavigationAware callbacks on UI thread

### DIFF
--- a/samples/Wpf.Ui.Demo.Mvvm/ViewModels/ViewModel.cs
+++ b/samples/Wpf.Ui.Demo.Mvvm/ViewModels/ViewModel.cs
@@ -10,11 +10,11 @@ namespace Wpf.Ui.Demo.Mvvm.ViewModels;
 public abstract class ViewModel : ObservableObject, INavigationAware
 {
     /// <inheritdoc />
-    public virtual async Task OnNavigatedToAsync()
+    public virtual Task OnNavigatedToAsync()
     {
-        using CancellationTokenSource cts = new();
+        OnNavigatedTo();
 
-        await DispatchAsync(OnNavigatedTo, cts.Token);
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -24,11 +24,11 @@ public abstract class ViewModel : ObservableObject, INavigationAware
     public virtual void OnNavigatedTo() { }
 
     /// <inheritdoc />
-    public virtual async Task OnNavigatedFromAsync()
+    public virtual Task OnNavigatedFromAsync()
     {
-        using CancellationTokenSource cts = new();
+        OnNavigatedFrom();
 
-        await DispatchAsync(OnNavigatedFrom, cts.Token);
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -36,20 +36,4 @@ public abstract class ViewModel : ObservableObject, INavigationAware
     /// </summary>
     // ReSharper disable once MemberCanBeProtected.Global
     public virtual void OnNavigatedFrom() { }
-
-    /// <summary>
-    /// Dispatches the specified action on the UI thread.
-    /// </summary>
-    /// <param name="action">The action to be dispatched.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    protected static async Task DispatchAsync(Action action, CancellationToken cancellationToken)
-    {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-
-        await Application.Current.Dispatcher.InvokeAsync(action);
-    }
 }

--- a/src/Wpf.Ui.Gallery/ViewModels/ViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/ViewModel.cs
@@ -8,11 +8,11 @@ namespace Wpf.Ui.Gallery.ViewModels;
 public abstract partial class ViewModel : ObservableObject, INavigationAware
 {
     /// <inheritdoc />
-    public virtual async Task OnNavigatedToAsync()
+    public virtual Task OnNavigatedToAsync()
     {
-        using CancellationTokenSource cts = new();
+        OnNavigatedTo();
 
-        await DispatchAsync(OnNavigatedTo, cts.Token);
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -22,11 +22,11 @@ public abstract partial class ViewModel : ObservableObject, INavigationAware
     public virtual void OnNavigatedTo() { }
 
     /// <inheritdoc />
-    public virtual async Task OnNavigatedFromAsync()
+    public virtual Task OnNavigatedFromAsync()
     {
-        using CancellationTokenSource cts = new();
+        OnNavigatedFrom();
 
-        await DispatchAsync(OnNavigatedFrom, cts.Token);
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -34,20 +34,4 @@ public abstract partial class ViewModel : ObservableObject, INavigationAware
     /// </summary>
     // ReSharper disable once MemberCanBeProtected.Global
     public virtual void OnNavigatedFrom() { }
-
-    /// <summary>
-    /// Dispatches the specified action on the UI thread.
-    /// </summary>
-    /// <param name="action">The action to be dispatched.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    protected static async Task DispatchAsync(Action action, CancellationToken cancellationToken)
-    {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-
-        await Application.Current.Dispatcher.InvokeAsync(action);
-    }
 }

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
@@ -211,27 +211,32 @@ public class NavigationViewContentPresenter : Frame
     )]
     private static void NotifyContentAboutNavigating(object content, Func<INavigationAware, Task> function)
     {
+        async void PerformNotify(INavigationAware navigationAware)
+        {
+            await function(navigationAware).ConfigureAwait(false);
+        }
+
         switch (content)
         {
             // The order in which the OnNavigatedToAsync/OnNavigatedFromAsync methods of View and ViewModel are called
             // is not guaranteed
             case INavigationAware navigationAwareNavigationContent:
-                _ = Task.Run(() => function(navigationAwareNavigationContent)).ConfigureAwait(false);
+                PerformNotify(navigationAwareNavigationContent);
                 if (
                     navigationAwareNavigationContent
                         is FrameworkElement { DataContext: INavigationAware viewModel }
                     && !ReferenceEquals(viewModel, navigationAwareNavigationContent)
                 )
                 {
-                    _ = Task.Run(() => function(viewModel)).ConfigureAwait(false);
+                    PerformNotify(viewModel);
                 }
 
                 break;
             case INavigableView<object> { ViewModel: INavigationAware navigationAwareNavigableViewViewModel }:
-                _ = Task.Run(() => function(navigationAwareNavigableViewViewModel)).ConfigureAwait(false);
+                PerformNotify(navigationAwareNavigableViewViewModel);
                 break;
             case FrameworkElement { DataContext: INavigationAware navigationAwareCurrentContent }:
-                _ = Task.Run(() => function(navigationAwareCurrentContent)).ConfigureAwait(false);
+                PerformNotify(navigationAwareCurrentContent);
                 break;
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

`INavigationAware` callbacks are invoked on the thread pool, and exceptions are silently discarded.

Issue Number: #1306 

## What is the new behavior?

- Callbacks are invoked on the UI thread.
- Unhandled exceptions will break when thrown if debugging in Visual Studio, then bubbled up to the `AppDomain.CurrentDomain.UnhandledException` event.

## Other Information

I have also removed the now-unnecessary UI dispatching code from the demo and gallery base view models.
