### PR TITLE
AutoSuggestBox when using in a list will override the value of binded…

### DIFF
--- a/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
+++ b/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
@@ -123,7 +123,7 @@
                             Icon="{TemplateBinding Icon}"
                             IconPlacement="Right"
                             PlaceholderText="{TemplateBinding PlaceholderText}"
-                            Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Text, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" />
+                            Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                         <Popup
                             x:Name="PART_SuggestionsPopup"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

AutosuggestTextbox does not support two way binding of text
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1283

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- AutoSuggestTextbox now supports two way binding of text
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
