### PR TITLE
Fix bug #1323 - add Margin to `BulletDecorator` to apply the `CheckBox.Padding` property

### DIFF
--- a/src/Wpf.Ui/Controls/CheckBox/CheckBox.xaml
+++ b/src/Wpf.Ui/Controls/CheckBox/CheckBox.xaml
@@ -60,6 +60,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type CheckBox}">
                     <BulletDecorator
+                        Margin="{TemplateBinding Padding}"
                         HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                         VerticalAlignment="{TemplateBinding VerticalAlignment}"
                         Background="Transparent">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1323 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added the `Margin` property to the `BulletDecorator` in the `CheckBox`'s `ControlTemplate`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Was this:
![image](https://github.com/user-attachments/assets/e0aa67a0-5f66-4df8-b66a-2c13cc12663f)
Is now:
![image](https://github.com/user-attachments/assets/969c3949-be07-4324-915c-76019c44538e)

