### PR TITLE
fix: Clean-up NumberBox: focus repeat event-args debug-output cursor

### DIFF
--- a/src/Wpf.Ui/Controls/Button/Button.xaml
+++ b/src/Wpf.Ui/Controls/Button/Button.xaml
@@ -17,6 +17,78 @@
     <Thickness x:Key="ButtonBorderThemeThickness">1</Thickness>
     <Thickness x:Key="ButtonIconMargin">0,0,8,0</Thickness>
 
+    <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}">
+        <!--  Universal WPF UI focus  -->
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
+        <!--  Universal WPF UI focus  -->
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{StaticResource ButtonBorderThemeThickness}" />
+        <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+        <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                    <Border
+                        x:Name="ContentBorder"
+                        Width="{TemplateBinding Width}"
+                        Height="{TemplateBinding Height}"
+                        MinWidth="{TemplateBinding MinWidth}"
+                        MinHeight="{TemplateBinding MinHeight}"
+                        Padding="{TemplateBinding Padding}"
+                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding Border.CornerRadius}">
+                        <ContentPresenter
+                            x:Name="ContentPresenter"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            TextElement.Foreground="{TemplateBinding Foreground}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsPressed" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsPressed" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
+                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="DefaultButtonStyle" TargetType="{x:Type Button}">
         <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
@@ -109,20 +181,27 @@
                         -->
                     </Border>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsPressed" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsPressed" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
+                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -397,6 +476,7 @@
         </Style.Triggers>
     </Style>
 
+    <Style BasedOn="{StaticResource DefaultRepeatButtonStyle}" TargetType="{x:Type RepeatButton}" />
     <Style BasedOn="{StaticResource DefaultButtonStyle}" TargetType="{x:Type Button}" />
     <Style BasedOn="{StaticResource DefaultUiButtonStyle}" TargetType="{x:Type controls:Button}" />
 

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -5,11 +5,12 @@
 
 // This Source Code is partially based on the source code provided by the .NET Foundation.
 
-/* TODO: Mask (with placeholder); Clipboard paste; */
-/* TODO: Constant decimals when formatting. Although this can actually be done with NumberFormatter. */
-/* TODO: Disable expression by default */
-/* TODO: Lock to digit characters only by property */
+// TODO: Mask (with placeholder); Clipboard paste;
+// TODO: Constant decimals when formatting. Although this can actually be done with NumberFormatter.
+// TODO: Disable expression by default
+// TODO: Lock to digit characters only by property
 
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 
@@ -19,8 +20,16 @@ namespace Wpf.Ui.Controls;
 /// <summary>
 /// Represents a control that can be used to display and edit numbers.
 /// </summary>
-public class NumberBox : Wpf.Ui.Controls.TextBox
+[TemplatePart(Name = PART_ClearButton, Type = typeof(Button))]
+[TemplatePart(Name = PART_InlineIncrementButton, Type = typeof(RepeatButton))]
+[TemplatePart(Name = PART_InlineDecrementButton, Type = typeof(RepeatButton))]
+public partial class NumberBox : Wpf.Ui.Controls.TextBox
 {
+    // Template part names
+    private const string PART_ClearButton = nameof(PART_ClearButton);
+    private const string PART_InlineIncrementButton = nameof(PART_InlineIncrementButton);
+    private const string PART_InlineDecrementButton = nameof(PART_InlineDecrementButton);
+
     private bool _valueUpdating;
 
     /// <summary>Identifies the <see cref="Value"/> dependency property.</summary>
@@ -114,7 +123,7 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
     public static readonly RoutedEvent ValueChangedEvent = EventManager.RegisterRoutedEvent(
         nameof(ValueChanged),
         RoutingStrategy.Bubble,
-        typeof(RoutedEventHandler),
+        typeof(NumberBoxValueChangedEvent),
         typeof(NumberBox)
     );
 
@@ -211,7 +220,7 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
     /// <summary>
     /// Occurs after the user triggers evaluation of new input by pressing the Enter key, clicking a spin button, or by changing focus.
     /// </summary>
-    public event RoutedEventHandler ValueChanged
+    public event NumberBoxValueChangedEvent ValueChanged
     {
         add => AddHandler(ValueChangedEvent, value);
         remove => RemoveHandler(ValueChangedEvent, value);
@@ -233,10 +242,8 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
     }
 
     /// <inheritdoc />
-    protected override void OnKeyUp(KeyEventArgs e)
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
-        base.OnKeyUp(e);
-
         if (IsReadOnly)
         {
             return;
@@ -246,16 +253,30 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
         {
             case Key.PageUp:
                 StepValue(LargeChange);
+                e.Handled = true;
                 break;
             case Key.PageDown:
                 StepValue(-LargeChange);
+                e.Handled = true;
                 break;
             case Key.Up:
                 StepValue(SmallChange);
+                e.Handled = true;
                 break;
             case Key.Down:
                 StepValue(-SmallChange);
+                e.Handled = true;
                 break;
+        }
+
+        base.OnPreviewKeyDown(e);
+    }
+
+    /// <inheritdoc />
+    protected override void OnPreviewKeyUp(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
             case Key.Enter:
                 if (TextWrapping != TextWrapping.Wrap)
                 {
@@ -263,36 +284,17 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
                     MoveCaretToTextEnd();
                 }
 
+                e.Handled = true;
                 break;
-        }
-    }
 
-    /// <inheritdoc />
-    protected override void OnTemplateButtonClick(string? parameter)
-    {
-        System.Diagnostics.Debug.WriteLine(
-            $"INFO: {typeof(NumberBox)} button clicked with param: {parameter}",
-            "Wpf.Ui.NumberBox"
-        );
-
-        switch (parameter)
-        {
-            case "clear":
-                OnClearButtonClick();
-
+            case Key.Escape:
+                UpdateTextToValue();
+                e.Handled = true;
                 break;
-            case "increment":
-                StepValue(SmallChange);
 
-                break;
-            case "decrement":
-                StepValue(-SmallChange);
-
-                break;
         }
 
-        // NOTE: Focus looks and works well with mouse and Clear button. But it sucks for spin buttons
-        _ = Focus();
+        base.OnPreviewKeyUp(e);
     }
 
     /// <inheritdoc />
@@ -316,12 +318,11 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
     }*/
 
     /// <inheritdoc />
-    protected override void OnTemplateChanged(
-        System.Windows.Controls.ControlTemplate oldTemplate,
-        System.Windows.Controls.ControlTemplate newTemplate
-    )
+    public override void OnApplyTemplate()
     {
-        base.OnTemplateChanged(oldTemplate, newTemplate);
+        SubscribeToButtonClickEvent<System.Windows.Controls.Button>(PART_ClearButton, () => OnClearButtonClick());
+        SubscribeToButtonClickEvent<RepeatButton>(PART_InlineIncrementButton, () => StepValue(SmallChange));
+        SubscribeToButtonClickEvent<RepeatButton>(PART_InlineDecrementButton, () => StepValue(-SmallChange));
 
         // If Text has been set, but Value hasn't, update Value based on Text.
         if (string.IsNullOrEmpty(Text) && Value != null)
@@ -331,6 +332,21 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
         else
         {
             UpdateTextToValue();
+        }
+
+        base.OnApplyTemplate();
+    }
+
+    private void SubscribeToButtonClickEvent<TButton>(string elementName, Action action)
+        where TButton : ButtonBase
+    {
+        if (GetTemplateChild(elementName) is TButton button)
+        {
+            button.Click += (s, e) =>
+            {
+                Debug.InfoWriteLineForButtonClick(s);
+                action();
+            };
         }
     }
 
@@ -360,7 +376,7 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
 
         if (!Equals(newValue, oldValue))
         {
-            RaiseEvent(new RoutedEventArgs(ValueChangedEvent));
+            RaiseEvent(new NumberBoxValueChangedEventArgs(oldValue, newValue, this));
         }
 
         UpdateTextToValue();
@@ -384,10 +400,7 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
 
     private void StepValue(double? change)
     {
-        System.Diagnostics.Debug.WriteLine(
-            $"INFO: {typeof(NumberBox)} {nameof(StepValue)} raised, change {change}",
-            "Wpf.Ui.NumberBox"
-        );
+        Debug.InfoWriteLine($"{typeof(NumberBox)} {nameof(StepValue)} raised, change {change}");
 
         // Before adjusting the value, validate the contents of the textbox so we don't override it.
         ValidateInput();
@@ -469,12 +482,10 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
 
     private static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is not NumberBox numberBox)
+        if (d is NumberBox numberBox)
         {
-            return;
+            numberBox.OnValueChanged(d, (double?)e.OldValue);
         }
-
-        numberBox.OnValueChanged(d, (double?)e.OldValue);
     }
 
     private static void OnNumberFormatterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -485,5 +496,40 @@ public class NumberBox : Wpf.Ui.Controls.TextBox
                 $"{nameof(NumberFormatter)} must implement {typeof(INumberParser)}"
             );
         }
+    }
+
+    private static partial class Debug
+    {
+        public static partial void InfoWriteLine(string debugLine);
+
+        public static partial void InfoWriteLineForButtonClick(object sender);
+
+#if DEBUG
+        public static partial void InfoWriteLine(string debugLine)
+        {
+            System.Diagnostics.Debug.WriteLine($"INFO: {debugLine}", "Wpf.Ui.NumberBox");
+        }
+
+        public static partial void InfoWriteLineForButtonClick(object sender)
+        {
+            var buttonName = (sender is System.Windows.Controls.Primitives.ButtonBase element)
+                ? element.Name
+                : throw new InvalidCastException(nameof(sender));
+
+            InfoWriteLine($"{typeof(NumberBox)} {buttonName} clicked");
+        }
+
+#else
+        public static partial void InfoWriteLine(string debugLine)
+        {
+            // Do nothing in non-DEBUG builds
+        }
+
+        public static partial void InfoWriteLineForButtonClick(object sender)
+        {
+            // Do nothing in non-DEBUG builds
+        }
+
+#endif // DEBUG
     }
 }

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -32,6 +32,7 @@
         <!--  Universal WPF UI ContextMenu  -->
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+        <Setter Property="Cursor" Value="Arrow" />
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource NumberBoxBorderThemeThickness}" />
@@ -71,108 +72,97 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <ContentControl
-                                    x:Name="ControlIconLeft"
-                                    Grid.Column="0"
-                                    Margin="{StaticResource NumberBoxLeftIconMargin}"
-                                    Padding="0"
-                                    VerticalAlignment="Top"
-                                    Content="{TemplateBinding Icon}"
-                                    FontSize="16"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False" />
-                                <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">
-                                    <controls:PassiveScrollViewer
-                                        x:Name="PART_ContentHost"
-                                        Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
-                                        TextElement.Foreground="{TemplateBinding Foreground}" />
-                                    <TextBlock
-                                        x:Name="PlaceholderTextBox"
-                                        Margin="0"
-                                        Padding="1,0"
+                                <Grid Grid.Column="0" Background="Transparent">
+                                    <ContentControl
+                                        x:Name="ControlIconLeft"
+                                        Margin="{StaticResource NumberBoxLeftIconMargin}"
+                                        Padding="0"
                                         VerticalAlignment="Top"
-                                        Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                        Text="{TemplateBinding PlaceholderText}" />
+                                        Content="{TemplateBinding Icon}"
+                                        FontSize="16"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        IsTabStop="False" />
+                                </Grid>
+                                <Grid
+                                    x:Name="TextContentArea"
+                                    Grid.Column="1"
+                                    Background="Transparent">
+                                    <Grid Margin="{TemplateBinding Padding}">
+                                        <controls:PassiveScrollViewer
+                                            x:Name="PART_ContentHost"
+                                            Style="{DynamicResource DefaultTextBoxScrollViewerStyle}"
+                                            TextElement.Foreground="{TemplateBinding Foreground}" />
+                                        <TextBlock
+                                            x:Name="PlaceholderTextBox"
+                                            Margin="0"
+                                            Padding="1,0"
+                                            VerticalAlignment="Top"
+                                            Foreground="{DynamicResource TextControlPlaceholderForeground}"
+                                            Text="{TemplateBinding PlaceholderText}" />
+                                    </Grid>
                                 </Grid>
                                 <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
-                                <controls:Button
-                                    x:Name="ClearButton"
+                                <StackPanel
                                     Grid.Column="2"
-                                    Width="{StaticResource NumberBoxButtonHeight}"
-                                    Height="{StaticResource NumberBoxButtonHeight}"
-                                    Margin="{StaticResource NumberBoxButtonMargin}"
-                                    Padding="{StaticResource NumberBoxButtonPadding}"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Top"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Appearance="Secondary"
                                     Background="Transparent"
-                                    BorderBrush="Transparent"
-                                    Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
-                                    CommandParameter="clear"
-                                    Cursor="Arrow"
-                                    Foreground="{DynamicResource TextControlButtonForeground}"
-                                    IsTabStop="False">
-                                    <controls:Button.Icon>
+                                    Orientation="Horizontal">
+                                    <Button
+                                        x:Name="PART_ClearButton"
+                                        Width="{StaticResource NumberBoxButtonHeight}"
+                                        Height="{StaticResource NumberBoxButtonHeight}"
+                                        Margin="{StaticResource NumberBoxButtonMargin}"
+                                        Padding="{StaticResource NumberBoxButtonPadding}"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Top"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Background="Transparent"
+                                        BorderBrush="Transparent"
+                                        Focusable="False"
+                                        Foreground="{DynamicResource TextControlButtonForeground}"
+                                        IsTabStop="False">
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="Dismiss24" />
-                                    </controls:Button.Icon>
-                                </controls:Button>
-                                <controls:Button
-                                    x:Name="InlineIncrementButton"
-                                    Grid.Column="3"
-                                    Width="{StaticResource NumberBoxButtonHeight}"
-                                    Height="{StaticResource NumberBoxButtonHeight}"
-                                    Margin="{StaticResource NumberBoxButtonMargin}"
-                                    Padding="{StaticResource NumberBoxButtonPadding}"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Top"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Appearance="Secondary"
-                                    Background="Transparent"
-                                    BorderBrush="Transparent"
-                                    Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
-                                    CommandParameter="increment"
-                                    Cursor="Arrow"
-                                    Foreground="{DynamicResource TextControlButtonForeground}"
-                                    IsTabStop="False"
-                                    Visibility="Collapsed">
-                                    <controls:Button.Icon>
+                                    </Button>
+                                    <RepeatButton
+                                        x:Name="PART_InlineIncrementButton"
+                                        Width="{StaticResource NumberBoxButtonHeight}"
+                                        Height="{StaticResource NumberBoxButtonHeight}"
+                                        Margin="{StaticResource NumberBoxButtonMargin}"
+                                        Padding="{StaticResource NumberBoxButtonPadding}"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Top"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Background="Transparent"
+                                        BorderBrush="Transparent"
+                                        Foreground="{DynamicResource TextControlButtonForeground}"
+                                        IsTabStop="False"
+                                        Visibility="Collapsed">
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronUp24" />
-                                    </controls:Button.Icon>
-                                </controls:Button>
-                                <controls:Button
-                                    x:Name="InlineDecrementButton"
-                                    Grid.Column="4"
-                                    Width="{StaticResource NumberBoxButtonHeight}"
-                                    Height="{StaticResource NumberBoxButtonHeight}"
-                                    Margin="{StaticResource NumberBoxButtonMargin}"
-                                    Padding="{StaticResource NumberBoxButtonPadding}"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Top"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Appearance="Secondary"
-                                    Background="Transparent"
-                                    BorderBrush="Transparent"
-                                    Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
-                                    CommandParameter="decrement"
-                                    Cursor="Arrow"
-                                    FontSize="{StaticResource NumberBoxButtonIconSize}"
-                                    Foreground="{DynamicResource TextControlButtonForeground}"
-                                    IsTabStop="False"
-                                    Visibility="Collapsed">
-                                    <controls:Button.Icon>
+                                    </RepeatButton>
+                                    <RepeatButton
+                                        x:Name="PART_InlineDecrementButton"
+                                        Width="{StaticResource NumberBoxButtonHeight}"
+                                        Height="{StaticResource NumberBoxButtonHeight}"
+                                        Margin="{StaticResource NumberBoxButtonMargin}"
+                                        Padding="{StaticResource NumberBoxButtonPadding}"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Top"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Background="Transparent"
+                                        BorderBrush="Transparent"
+                                        FontSize="{StaticResource NumberBoxButtonIconSize}"
+                                        Foreground="{DynamicResource TextControlButtonForeground}"
+                                        IsTabStop="False"
+                                        Visibility="Collapsed">
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronDown24" />
-                                    </controls:Button.Icon>
-                                </controls:Button>
+                                    </RepeatButton>
+                                </StackPanel>
                                 <ContentControl
                                     x:Name="ControlIconRight"
-                                    Grid.Column="5"
+                                    Grid.Column="3"
                                     Margin="{StaticResource NumberBoxRightIconMargin}"
                                     Padding="0"
                                     VerticalAlignment="Top"
@@ -196,20 +186,20 @@
                             <Setter TargetName="PlaceholderTextBox" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                         <Trigger Property="ShowClearButton" Value="False">
-                            <Setter TargetName="ClearButton" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="ClearButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_ClearButton" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_ClearButton" Property="Margin" Value="0" />
                         </Trigger>
                         <Trigger Property="ClearButtonEnabled" Value="False">
-                            <Setter TargetName="ClearButton" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="ClearButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_ClearButton" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_ClearButton" Property="Margin" Value="0" />
                         </Trigger>
                         <Trigger Property="SpinButtonPlacementMode" Value="Hidden">
-                            <Setter TargetName="InlineIncrementButton" Property="Margin" Value="0" />
-                            <Setter TargetName="InlineDecrementButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_InlineIncrementButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_InlineDecrementButton" Property="Margin" Value="0" />
                         </Trigger>
                         <Trigger Property="SpinButtonPlacementMode" Value="Inline">
-                            <Setter TargetName="InlineIncrementButton" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="InlineDecrementButton" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PART_InlineIncrementButton" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PART_InlineDecrementButton" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IconPlacement" Value="Left">
                             <Setter TargetName="ControlIconRight" Property="Visibility" Value="Collapsed" />
@@ -240,13 +230,14 @@
                         </MultiTrigger>
                         <Trigger Property="IsReadOnly" Value="True">
                             <Setter Property="SpinButtonPlacementMode" Value="Hidden" />
-                            <Setter TargetName="ClearButton" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="ClearButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_ClearButton" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_ClearButton" Property="Margin" Value="0" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="True">
-                            <Setter Property="Cursor" Value="IBeam" />
+                            <Setter TargetName="TextContentArea" Property="Cursor" Value="IBeam" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="TextContentArea" Property="Cursor" Value="Arrow" />
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
                             <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
                             <Setter TargetName="AccentBorder" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBoxValueChangedEventArgs.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBoxValueChangedEventArgs.cs
@@ -14,10 +14,18 @@ public class NumberBoxValueChangedEventArgs : RoutedEventArgs
     /// <summary>
     /// Initializes a new instance of the <see cref="NumberBoxValueChangedEventArgs" /> class. />
     /// </summary>
-    /// <param name="oldValue">The value of the <see cref="NumberBox.Value"/> property before the change
-    /// reported by the relevant event or state change.</param>
-    /// <param name="newValue">The value of the <see cref="NumberBox.Value"/> property after the change
-    /// reported by the relevant event or state change.</param>
+    /// <param name="oldValue">
+    ///     The value of the <see cref="NumberBox.Value"/> property before the change
+    ///     reported by the relevant event or state change.
+    /// </param>
+    /// <param name="newValue">
+    ///     The value of the <see cref="NumberBox.Value"/> property after the change
+    ///     reported by the relevant event or state change.
+    /// </param>
+    /// <param name="source">
+    ///     An alternate source that will be reported when the event is handled. This pre-populates
+    ///     the <see cref="System.Windows.RoutedEventArgs.Source" /> property.
+    /// </param>
     internal NumberBoxValueChangedEventArgs(double? oldValue, double? newValue, object source)
         : base(NumberBox.ValueChangedEvent, source)
     {

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBoxValueChangedEventArgs.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBoxValueChangedEventArgs.cs
@@ -1,9 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
 
+// This Source Code is partially based on the source code provided by the .NET Foundation.
+
+// ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 
 /// <summary>

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBoxValueChangedEventArgs.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBoxValueChangedEventArgs.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wpf.Ui.Controls;
+
+/// <summary>
+/// Provides information for the <see cref="NumberBox.ValueChanged" /> event.
+/// </summary>
+public class NumberBoxValueChangedEventArgs : RoutedEventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NumberBoxValueChangedEventArgs" /> class. />
+    /// </summary>
+    /// <param name="oldValue">The value of the <see cref="NumberBox.Value"/> property before the change
+    /// reported by the relevant event or state change.</param>
+    /// <param name="newValue">The value of the <see cref="NumberBox.Value"/> property after the change
+    /// reported by the relevant event or state change.</param>
+    internal NumberBoxValueChangedEventArgs(double? oldValue, double? newValue, object source)
+        : base(NumberBox.ValueChangedEvent, source)
+    {
+        this.OldValue = oldValue;
+        this.NewValue = newValue;
+    }
+
+    /// <summary>Gets the value of the <see cref="NumberBox.Value"/> property before the change.</summary>
+    /// <returns>The property value before the change.</returns>
+    public double? OldValue { get; private set; }
+
+    /// <summary>Gets the value of the <see cref="NumberBox.Value"/> property after the change.</summary>
+    /// <returns>The property value after the change.</returns>
+    public double? NewValue { get; private set; }
+}
+
+public delegate void NumberBoxValueChangedEvent(object sender, NumberBoxValueChangedEventArgs args);


### PR DESCRIPTION
## Pull request type
- [x] Bugfix

## What is the current behavior?
The `Wpf.Ui.Controls.NumberBox` has several issues. Three of these are described in the following issue numbers:

Issue Numbers: #1325, #1326, #1327

#1325 [NumberBox focus flashes when using increment, decrement, and clear buttons](https://github.com/lepoco/wpfui/issues/1325)
![Image](https://github.com/user-attachments/assets/bc681cd3-8116-4eea-9a45-2f9bb9c2100c)
#1326 [NumberBox holding UpArrow, DownArrow, PageUp, PageDown keys do not repeat, nor do the increment and decrement buttons](https://github.com/lepoco/wpfui/issues/1326)
![Image](https://github.com/user-attachments/assets/86c05590-c05c-4a3b-9330-c65a54149796)
#1327 [TextBox's IBeam cursor when mouse moves over icon and button margins #1327](https://github.com/lepoco/wpfui/issues/1327)(https://github.com/lepoco/wpfui/issues/1327)
![Image](https://github.com/user-attachments/assets/bc441f00-ef4c-4a22-b59d-dc44b00307df)

## What is the new behavior?

#1325 [NumberBox focus flashes when using increment, decrement, and clear buttons](https://github.com/lepoco/wpfui/issues/1325)
![Image](https://github.com/user-attachments/assets/1b582178-3884-4cea-a07c-63034afbddce)
#1326 [NumberBox holding UpArrow, DownArrow, PageUp, PageDown keys do not repeat, nor do the increment and decrement buttons](https://github.com/lepoco/wpfui/issues/1326)
![Image](https://github.com/user-attachments/assets/4ba31956-bb6e-4a5f-86ea-1973a32a2925)
#1327 [TextBox's IBeam cursor when mouse moves over icon and button margins #1327](https://github.com/lepoco/wpfui/issues/1327)(https://github.com/lepoco/wpfui/issues/1327)
![Image](https://github.com/user-attachments/assets/143de435-e0dc-4054-be46-978e52b5ec47)


## Other information

TODO: Describe the individual changes.
