### PR TITLE
fix: remove all build warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -355,7 +355,6 @@ dotnet_diagnostic.SA1009.severity = none
 
 # Hide warnings when using the new() expression from C# 9.
 dotnet_diagnostic.SA1000.severity = none
-
 dotnet_diagnostic.SA1011.severity = none
 dotnet_diagnostic.SA1101.severity = none
 
@@ -389,12 +388,16 @@ dotnet_diagnostic.SA1634.severity = none
 dotnet_diagnostic.SA1652.severity = none
 
 
-
 # Additional Stylecop Analyzers
 dotnet_diagnostic.SA1111.severity = none
 dotnet_diagnostic.SA1121.severity = none
 dotnet_diagnostic.SA1204.severity = none
 dotnet_diagnostic.SA1208.severity = none
+dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
+                                         # 15000+ warnings in the solution
+dotnet_diagnostic.CA1510.severity = none # Use ArgumentNullException throw helper
+                                         # doesn't work with older versions of .NET
+                                         
 dotnet_diagnostic.SA1518.severity = none
 dotnet_diagnostic.SA1615.severity = none
 dotnet_diagnostic.SA1502.severity = none
@@ -407,9 +410,5 @@ dotnet_diagnostic.WPF0071.severity = none # Add ValueConversion attribute
 dotnet_diagnostic.WPF0070.severity = none # Add default field to converter
 
 # Suppress some IDE warnings
+dotnet_diagnostic.IDE0130.severity = none # Hide warnings about namespaces not matching folder structure
 dotnet_diagnostic.IDE0290.severity = none # Use primary constructor
-dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
-                                         # 15000+ warnings in the solution
-dotnet_diagnostic.CA1510.severity = none # Use ArgumentNullException throw helper
-                                         # doesn't work with older versions of .NET
-                                         

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,30 +1,30 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Lepo.i18n" Version="2.0.0" />
     <PackageVersion Include="Lepo.i18n.DependencyInjection" Version="2.0.0" />
     <PackageVersion Include="Lepo.i18n.Wpf" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.CoreUtility" Version="17.2.3194" />
-    <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.10.40171" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.11.414" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2592.51" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
+    <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.12.4039" ExcludeAssets="runtime" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageVersion Include="NativeMethods" Version="0.0.3" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="PolySharp" Version="1.14.1" />
-    <PackageVersion Include="ReflectionEventing" Version="3.0.1" />
-    <PackageVersion Include="ReflectionEventing.DependencyInjection" Version="3.0.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="ReflectionEventing" Version="3.1.0" />
+    <PackageVersion Include="ReflectionEventing.DependencyInjection" Version="3.1.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Drawing.Common" Version="8.0.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="9.0.1" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="WpfAnalyzers" Version="4.1.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
-    <PackageVersion Include="xunit" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
   </ItemGroup>
 </Project>

--- a/src/Wpf.Ui.Abstractions/Controls/INavigationAware.cs
+++ b/src/Wpf.Ui.Abstractions/Controls/INavigationAware.cs
@@ -14,7 +14,6 @@ public interface INavigationAware
     /// Asynchronously handles the event that is fired after the component is navigated to.
     /// </summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
-
     Task OnNavigatedToAsync();
 
     /// <summary>

--- a/src/Wpf.Ui.Abstractions/NavigationException.cs
+++ b/src/Wpf.Ui.Abstractions/NavigationException.cs
@@ -11,14 +11,15 @@ namespace Wpf.Ui.Abstractions;
 public sealed class NavigationException : Exception
 {
     /// <summary>
-    /// Initializes a new instance of the NavigationException class with a specified error message.
+    /// Initializes a new instance of the <see cref="NavigationException"/> class with a specified error message.
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     public NavigationException(string message)
         : base(message) { }
 
     /// <summary>
-    /// Initializes a new instance of the NavigationException class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// Initializes a new instance of the <see cref="NavigationException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
     /// </summary>
     /// <param name="e">The exception that is the cause of the current exception.</param>
     /// <param name="message">The message that describes the error.</param>

--- a/src/Wpf.Ui.Abstractions/Wpf.Ui.Abstractions.csproj
+++ b/src/Wpf.Ui.Abstractions/Wpf.Ui.Abstractions.csproj
@@ -6,6 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Abstractions for the WPF UI.</Description>
     <CommonTags>$(CommonTags);abstractions;standard</CommonTags>
+    <_SilenceIsAotCompatibleUnsupportedWarning>true</_SilenceIsAotCompatibleUnsupportedWarning>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wpf.Ui.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Wpf.Ui.DependencyInjection/ServiceCollectionExtensions.cs
@@ -18,7 +18,6 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-
     public static IServiceCollection AddNavigationViewPageProvider(this IServiceCollection services)
     {
         _ = services.AddSingleton<

--- a/src/Wpf.Ui.DependencyInjection/Wpf.Ui.DependencyInjection.csproj
+++ b/src/Wpf.Ui.DependencyInjection/Wpf.Ui.DependencyInjection.csproj
@@ -6,6 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Dependency injection for the WPF UI.</Description>
     <CommonTags>$(CommonTags);dependency;injection;abstractions;standard</CommonTags>
+    <_SilenceIsAotCompatibleUnsupportedWarning>true</_SilenceIsAotCompatibleUnsupportedWarning>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wpf.Ui.Extension/Wpf.Ui.Extension.csproj
+++ b/src/Wpf.Ui.Extension/Wpf.Ui.Extension.csproj
@@ -90,12 +90,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="runtime">
-      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="license.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/Wpf.Ui.Gallery/Controllers/MonacoController.cs
+++ b/src/Wpf.Ui.Gallery/Controllers/MonacoController.cs
@@ -56,7 +56,7 @@ public class MonacoController
         var languageId =
             monacoLanguage == MonacoLanguage.ObjectiveC ? "objective-c" : monacoLanguage.ToString().ToLower();
 
-        await _webView.ExecuteScriptAsync(
+        _ = await _webView.ExecuteScriptAsync(
             "monaco.editor.setModelLanguage(" + EditorObject + $".getModel(), \"{languageId}\");"
         );
     }
@@ -65,7 +65,7 @@ public class MonacoController
     {
         var literalContents = SymbolDisplay.FormatLiteral(contents, false);
 
-        await _webView.ExecuteScriptAsync(EditorObject + $".setValue(\"{literalContents}\");");
+        _ = await _webView.ExecuteScriptAsync(EditorObject + $".setValue(\"{literalContents}\");");
     }
 
     public void DispatchScript(string script)
@@ -75,6 +75,6 @@ public class MonacoController
             return;
         }
 
-        Application.Current.Dispatcher.InvokeAsync(async () => await _webView!.ExecuteScriptAsync(script));
+        _ = Application.Current.Dispatcher.InvokeAsync(async () => await _webView!.ExecuteScriptAsync(script));
     }
 }

--- a/src/Wpf.Ui.Gallery/Controls/GalleryNavigationPresenter.xaml.cs
+++ b/src/Wpf.Ui.Gallery/Controls/GalleryNavigationPresenter.xaml.cs
@@ -50,7 +50,7 @@ public class GalleryNavigationPresenter : System.Windows.Controls.Control
 
         if (pageType is not null)
         {
-            navigationService.Navigate(pageType);
+            _ = navigationService.Navigate(pageType);
         }
 
         System.Diagnostics.Debug.WriteLine(

--- a/src/Wpf.Ui.Gallery/ViewModels/Windows/MonacoWindowViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Windows/MonacoWindowViewModel.cs
@@ -54,7 +54,7 @@ public partial class MonacoWindowViewModel : ViewModel
         Microsoft.Web.WebView2.Core.CoreWebView2NavigationCompletedEventArgs e
     )
     {
-        DispatchAsync(InitializeEditorAsync);
+        _ = DispatchAsync(InitializeEditorAsync);
     }
 
     private static DispatcherOperation<TResult> DispatchAsync<TResult>(Func<TResult> callback)

--- a/src/Wpf.Ui.SyntaxHighlight/Controls/CodeBlock.cs
+++ b/src/Wpf.Ui.SyntaxHighlight/Controls/CodeBlock.cs
@@ -40,21 +40,21 @@ public class CodeBlock : System.Windows.Controls.ContentControl
     );
 
     /// <summary>
-    /// Formatted <see cref="System.Windows.Controls.ContentControl.Content"/>.
+    /// Gets the formatted <see cref="System.Windows.Controls.ContentControl.Content"/>.
     /// </summary>
-    public object SyntaxContent
+    public object? SyntaxContent
     {
         get => GetValue(SyntaxContentProperty);
         internal set => SetValue(SyntaxContentProperty, value);
     }
 
     /// <summary>
-    /// Command triggered after clicking the control button.
+    /// Gets the command triggered after clicking the control button.
     /// </summary>
     public IRelayCommand ButtonCommand => (IRelayCommand)GetValue(ButtonCommandProperty);
 
     /// <summary>
-    /// Creates new instance and assigns <see cref="ButtonCommand"/> default action.
+    /// Initializes a new instance of the <see cref="CodeBlock"/> class, and assigns <see cref="ButtonCommand"/> default action.
     /// </summary>
     public CodeBlock()
     {
@@ -94,7 +94,7 @@ public class CodeBlock : System.Windows.Controls.ContentControl
         richTextBox.Document.Blocks.Clear();
         richTextBox.Document.Blocks.Add(Highlighter.FormatAsParagraph(_sourceCode));
 
-        SyntaxContent = richTextBox;
+        SetCurrentValue(SyntaxContentProperty, richTextBox);
     }
 
     private void OnTemplateButtonClick(string? _)

--- a/src/Wpf.Ui.SyntaxHighlight/Highlighter.cs
+++ b/src/Wpf.Ui.SyntaxHighlight/Highlighter.cs
@@ -4,7 +4,7 @@
 // All Rights Reserved.
 
 // TODO: This class is work in progress.
-
+//
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -38,17 +38,18 @@ internal static class Highlighter
     private const string EntityPattern = /* language=regex */
         @"(&[a-zA-Z0-9#]+;)";
 
-    //private const string PunctuationPattern = /* language=regex */
+    // private const string PunctuationPattern = /* language=regex */
     //    @"(!==?|(?:[[\\] ()\{\}.:;,+\\-?=!]|&lt;|&gt;)+|&&|\\|\\|)";
 
-    //private const string NumberPattern = /* language=regex */
+    // private const string NumberPattern = /* language=regex */
     //    @"(-? (?:\.\d+|\d+(?:\.\d+)?))";
 
-    //private const string BooleanPattern = /* language=regex */
+    // private const string BooleanPattern = /* language=regex */
     //    "\b(true|false)\b";
 
-    //private const string AttributePattern = /* language=regex */
-    //    "(\\s*)([a-zA-Z\\d\\-:]+)=(\" | ')(.*?)\\3";
+    // private const string AttributePattern = /* language=regex */
+    //     "(\\s*)([a-zA-Z\\d\\-:]+)=(\" | ')(.*?)\\3";
+    ////
 
     public static Paragraph FormatAsParagraph(
         string code,

--- a/src/Wpf.Ui.SyntaxHighlight/Markup/SyntaxHighlightDictionary.cs
+++ b/src/Wpf.Ui.SyntaxHighlight/Markup/SyntaxHighlightDictionary.cs
@@ -21,7 +21,8 @@ public class SyntaxHighlightDictionary : ResourceDictionary
         "pack://application:,,,/Wpf.Ui.SyntaxHighlight;component/SyntaxHighlight.xaml";
 
     /// <summary>
-    /// Default constructor defining <see cref="ResourceDictionary.Source"/> of the <c>WPF UI</c> syntax highlight dictionary.
+    /// Initializes a new instance of the <see cref="SyntaxHighlightDictionary"/> class.
+    /// It sets the <see cref="ResourceDictionary.Source"/> of the <c>WPF UI</c> syntax highlight dictionary.
     /// </summary>
     public SyntaxHighlightDictionary() => Source = new Uri(DictionaryUri, UriKind.Absolute);
 }

--- a/src/Wpf.Ui.Tray/Hicon.cs
+++ b/src/Wpf.Ui.Tray/Hicon.cs
@@ -5,7 +5,7 @@
 
 // TODO: This class is the only reason for using System.Drawing.Common.
 // It is worth looking for a way to get hIcon without using it.
-
+//
 using System.Drawing;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;

--- a/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
+++ b/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
@@ -177,7 +177,7 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
         }
 
         // Without setting the handler window at the front, menu may appear behind the taskbar
-        Interop.User32.SetForegroundWindow(HookWindow.Handle);
+        _ = Interop.User32.SetForegroundWindow(HookWindow.Handle);
         ContextMenuService.SetPlacement(ContextMenu, PlacementMode.MousePoint);
 
         // ContextMenu.ApplyMica();
@@ -259,7 +259,7 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
             "Wpf.Ui.NotifyIcon"
         );
 
-        Unregister();
+        _ = Unregister();
     }
 
     /// <inheritdoc />

--- a/src/Wpf.Ui.Tray/Interop/Shell32.cs
+++ b/src/Wpf.Ui.Tray/Interop/Shell32.cs
@@ -11,6 +11,7 @@ namespace Wpf.Ui.Tray.Interop;
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning disable SA1401 // Fields should be private
+#pragma warning disable CA1060 // Move pinvokes to native methods class
 
 /// <summary>
 /// The Windows UI provides users with access to a wide variety of objects necessary to run applications and manage the operating system.
@@ -178,3 +179,4 @@ internal static class Shell32
 
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning restore SA1401 // Fields should be private
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui.Tray/Interop/User32.cs
+++ b/src/Wpf.Ui.Tray/Interop/User32.cs
@@ -11,6 +11,7 @@ namespace Wpf.Ui.Tray.Interop;
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1300 // Element should begin with upper-case letter
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable CA1060 // Move pinvokes to native methods class
 
 /// <summary>
 /// USER procedure declarations, constant definitions and macros.
@@ -1546,3 +1547,4 @@ internal static class User32
 
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui.Tray/NotifyIconService.cs
+++ b/src/Wpf.Ui.Tray/NotifyIconService.cs
@@ -7,6 +7,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
+
 namespace Wpf.Ui.Tray;
 
 /// <summary>
@@ -119,3 +121,5 @@ public class NotifyIconService : INotifyIconService
         internalNotifyIconManager.MiddleDoubleClick += OnMiddleDoubleClick;
     }
 }
+
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable

--- a/src/Wpf.Ui/Appearance/ObservedWindow.cs
+++ b/src/Wpf.Ui/Appearance/ObservedWindow.cs
@@ -15,7 +15,7 @@ internal class ObservedWindow
     private readonly HwndSource _source;
 
     /// <summary>
-    /// Initializes a new instance of the ObservedWindow class.
+    /// Initializes a new instance of the <see cref="ObservedWindow"/> class.
     /// </summary>
     /// <param name="handle">The handle of the window.</param>
     /// <param name="backdrop">The backdrop type of the window.</param>

--- a/src/Wpf.Ui/Controls/Arc/Arc.cs
+++ b/src/Wpf.Ui/Controls/Arc/Arc.cs
@@ -52,13 +52,14 @@ public class Arc : Shape
         new PropertyMetadata(SweepDirection.Clockwise, PropertyChangedCallback)
     );
 
-    /// <summary>Identifies the <see cref="StrokeStartLineCap"/> dependency property.</summary>
-    public static readonly DependencyProperty StrokeStartLineCapProperty = DependencyProperty.Register(
-        nameof(StrokeStartLineCap),
-        typeof(PenLineCap),
-        typeof(Arc),
-        new PropertyMetadata(PenLineCap.Round, PropertyChangedCallback)
-    );
+    static Arc()
+    {
+        // Modify the metadata of the StrokeStartLineCap dependency property.
+        StrokeStartLineCapProperty.OverrideMetadata(
+            typeof(Arc),
+            new PropertyMetadata(PenLineCap.Round, PropertyChangedCallback));
+
+    }
 
     /// <summary>
     /// Gets or sets the initial angle from which the arc will be drawn.
@@ -85,13 +86,6 @@ public class Arc : Shape
     {
         get => (SweepDirection)GetValue(SweepDirectionProperty);
         set => SetValue(SweepDirectionProperty, value);
-    }
-
-    // TODO: Should we?
-    public new PenLineCap StrokeStartLineCap
-    {
-        get { return (PenLineCap)GetValue(StrokeStartLineCapProperty); }
-        set { SetValue(StrokeStartLineCapProperty, value); }
     }
 
     /// <summary>

--- a/src/Wpf.Ui/Controls/Arc/Arc.cs
+++ b/src/Wpf.Ui/Controls/Arc/Arc.cs
@@ -58,7 +58,6 @@ public class Arc : Shape
         StrokeStartLineCapProperty.OverrideMetadata(
             typeof(Arc),
             new PropertyMetadata(PenLineCap.Round, PropertyChangedCallback));
-
     }
 
     /// <summary>

--- a/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItem.cs
+++ b/src/Wpf.Ui/Controls/BreadcrumbBar/BreadcrumbBarItem.cs
@@ -5,8 +5,6 @@
 
 /* Based on Windows UI Library */
 
-
-
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 

--- a/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.cs
+++ b/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.cs
@@ -81,7 +81,7 @@ public class DynamicScrollBar : System.Windows.Controls.Primitives.ScrollBar
     {
         base.OnMouseEnter(e);
 
-        UpdateScroll().GetAwaiter();
+        _ = UpdateScrollAsync();
     }
 
     /// <summary>
@@ -91,10 +91,10 @@ public class DynamicScrollBar : System.Windows.Controls.Primitives.ScrollBar
     {
         base.OnMouseLeave(e);
 
-        UpdateScroll().GetAwaiter();
+        _ = UpdateScrollAsync();
     }
 
-    private async Task UpdateScroll()
+    private async Task UpdateScrollAsync()
     {
         var currentEvent = _interactiveIdentifier.GetNext();
         var shouldScroll = IsMouseOver || _isScrolling;
@@ -131,7 +131,7 @@ public class DynamicScrollBar : System.Windows.Controls.Primitives.ScrollBar
 
         bar._isScrolling = !bar._isScrolling;
 
-        bar.UpdateScroll().GetAwaiter();
+        _ = bar.UpdateScrollAsync();
     }
 
     private static void OnIsInteractedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -148,6 +148,6 @@ public class DynamicScrollBar : System.Windows.Controls.Primitives.ScrollBar
 
         bar._isInteracted = !bar._isInteracted;
 
-        bar.UpdateScroll().GetAwaiter();
+        _ = bar.UpdateScrollAsync();
     }
 }

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -464,20 +464,28 @@ public partial class NavigationView
         switch (e.Action)
         {
             case NotifyCollectionChangedAction.Add:
-                foreach (var item in e.NewItems)
+                if (e.NewItems is not null)
                 {
-                    collection.Add(item);
+                    foreach (var item in e.NewItems)
+                    {
+                        _ = collection.Add(item);
+                    }
                 }
+
                 break;
 
             case NotifyCollectionChangedAction.Remove:
-                foreach (var item in e.OldItems)
+                if (e.OldItems is not null && e.NewItems is not null)
                 {
-                    if (!e.NewItems.Contains(item))
+                    foreach (var item in e.OldItems)
                     {
-                        collection.Remove(item);
+                        if (!e.NewItems.Contains(item))
+                        {
+                            collection.Remove(item);
+                        }
                     }
                 }
+
                 break;
 
             case NotifyCollectionChangedAction.Move:
@@ -488,7 +496,11 @@ public partial class NavigationView
 
             case NotifyCollectionChangedAction.Replace:
                 collection.RemoveAt(e.OldStartingIndex);
-                collection.Insert(e.OldStartingIndex, e.NewItems[0]);
+                if (e.NewItems is not null)
+                {
+                    collection.Insert(e.OldStartingIndex, e.NewItems[0]);
+                }
+
                 break;
 
             case NotifyCollectionChangedAction.Reset:
@@ -521,12 +533,12 @@ public partial class NavigationView
         {
             foreach (var item in newItemsSource)
             {
-                navigationView.MenuItems.Add(item);
+                _ = navigationView.MenuItems.Add(item);
             }
         }
         else if (e.NewValue != null)
         {
-            navigationView.MenuItems.Add(e.NewValue);
+            _ = navigationView.MenuItems.Add(e.NewValue);
         }
 
         if (e.NewValue is INotifyCollectionChanged oc)
@@ -563,12 +575,12 @@ public partial class NavigationView
         {
             foreach (var item in newItemsSource)
             {
-                navigationView.FooterMenuItems.Add(item);
+                _ = navigationView.FooterMenuItems.Add(item);
             }
         }
         else if (e.NewValue != null)
         {
-            navigationView.FooterMenuItems.Add(e.NewValue);
+            _ = navigationView.FooterMenuItems.Add(e.NewValue);
         }
 
         if (e.NewValue is INotifyCollectionChanged oc)

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -9,7 +9,7 @@
 // TODO: Constant decimals when formatting. Although this can actually be done with NumberFormatter.
 // TODO: Disable expression by default
 // TODO: Lock to digit characters only by property
-
+//
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;

--- a/src/Wpf.Ui/Controls/Snackbar/SnackbarPresenter.cs
+++ b/src/Wpf.Ui/Controls/Snackbar/SnackbarPresenter.cs
@@ -77,7 +77,7 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter
 
         if (Content is null)
         {
-            ShowQueuedSnackbars(); // TODO: Fix detached process
+            _ = ShowQueuedSnackbarsAsync(); // TODO: Fix detached process
         }
     }
 
@@ -86,7 +86,7 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter
         await HideCurrent();
         await ShowSnackbar(snackbar);
 
-        await ShowQueuedSnackbars();
+        await ShowQueuedSnackbarsAsync();
     }
 
     public virtual async Task HideCurrent()
@@ -101,7 +101,7 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter
         ResetCancellationTokenSource();
     }
 
-    private async Task ShowQueuedSnackbars()
+    private async Task ShowQueuedSnackbarsAsync()
     {
         while (Queue.Count > 0 && !CancellationTokenSource.IsCancellationRequested)
         {

--- a/src/Wpf.Ui/Controls/SymbolFilled.cs
+++ b/src/Wpf.Ui/Controls/SymbolFilled.cs
@@ -18,7 +18,6 @@ public enum SymbolFilled
     Empty = 0x0,
 
     // Automatically generated, may contain bugs.
-
     AccessTime20 = 0xE000,
     Accessibility32 = 0xE001,
     Accessibility48 = 0xE002,

--- a/src/Wpf.Ui/Controls/SymbolRegular.cs
+++ b/src/Wpf.Ui/Controls/SymbolRegular.cs
@@ -18,7 +18,6 @@ public enum SymbolRegular
     Empty = 0x0,
 
     // Automatically generated, may contain bugs.
-
     AccessTime20 = 0xE000,
     Accessibility32 = 0xE001,
     Accessibility48 = 0xE002,

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -224,7 +224,7 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
     /// <summary>
     /// Gets or sets the content displayed in the left side of the <see cref="TitleBar"/>.
     /// </summary>
-    public object Header
+    public object? Header
     {
         get => GetValue(HeaderProperty);
         set => SetValue(HeaderProperty, value);
@@ -233,7 +233,7 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
     /// <summary>
     /// Gets or sets the content displayed in right side of the <see cref="TitleBar"/>.
     /// </summary>
-    public object TrailingContent
+    public object? TrailingContent
     {
         get => GetValue(TrailingContentProperty);
         set => SetValue(TrailingContentProperty, value);
@@ -394,11 +394,11 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
     public Action<TitleBar, System.Windows.Window>? MinimizeActionOverride { get; set; }
 
     private readonly TitleBarButton[] _buttons = new TitleBarButton[4];
+    private readonly TextBlock _titleBlock;
     private System.Windows.Window _currentWindow = null!;
 
     /*private System.Windows.Controls.Grid _mainGrid = null!;*/
     private System.Windows.Controls.ContentPresenter _icon = null!;
-    private readonly TextBlock _titleBlock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TitleBar"/> class and sets the default <see cref="FrameworkElement.Loaded"/> event.
@@ -411,11 +411,11 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
 
         _titleBlock = new TextBlock();
         _titleBlock.VerticalAlignment = VerticalAlignment.Center;
-        _titleBlock.SetBinding(
+        _ = _titleBlock.SetBinding(
             System.Windows.Controls.TextBlock.TextProperty,
             new Binding(nameof(Title)) { Source = this }
         );
-        _titleBlock.SetBinding(
+        _ = _titleBlock.SetBinding(
             System.Windows.Controls.TextBlock.FontSizeProperty,
             new Binding(nameof(FontSize)) { Source = this }
         );

--- a/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
+++ b/src/Wpf.Ui/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
@@ -425,10 +425,8 @@ public class VirtualizingWrapPanel : VirtualizingPanelBase
                 int rowCountInCacheBefore = (int)(cacheBeforeInPixel / GetHeight(ChildSize));
                 int rowCountInCacheAfter =
                     (
-                        (int)
-                            Math.Ceiling(
-                                (offsetInPixel + viewportHeight + cacheAfterInPixel) / GetHeight(ChildSize)
-                            )
+                        (int)Math.Ceiling(
+                            (offsetInPixel + viewportHeight + cacheAfterInPixel) / GetHeight(ChildSize))
                     ) - (int)Math.Ceiling((offsetInPixel + viewportHeight) / GetHeight(ChildSize));
 
                 startIndex = Math.Max(startIndex - (rowCountInCacheBefore * ItemsPerRowCount), 0);

--- a/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
+++ b/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs
@@ -241,11 +241,11 @@ public static class WindowBackdrop
             // Specifying DWMWA_COLOR_DEFAULT (value 0xFFFFFFFF) for the color will reset the window back to using the system's default behavior for the caption color.
             uint titlebarPvAttribute = 0xFFFFFFFE;
 
-            Dwmapi.DwmSetWindowAttribute(
+            _ = Dwmapi.DwmSetWindowAttribute(
                 windowSource.Handle,
                 Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_CAPTION_COLOR,
                 ref titlebarPvAttribute,
-                Marshal.SizeOf(typeof(uint))
+                sizeof(uint)
             );
         }
 

--- a/src/Wpf.Ui/Interop/Dwmapi.cs
+++ b/src/Wpf.Ui/Interop/Dwmapi.cs
@@ -17,6 +17,7 @@
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable CA1060 // Move pinvokes to native methods class
 
 using System.Runtime.InteropServices;
 
@@ -676,3 +677,4 @@ internal static class Dwmapi
 }
 
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui/Interop/Kernel32.cs
+++ b/src/Wpf.Ui/Interop/Kernel32.cs
@@ -16,6 +16,8 @@
 // ReSharper disable InconsistentNaming
 using System.Runtime.InteropServices;
 
+#pragma warning disable CA1060 // Move pinvokes to native methods class
+
 namespace Wpf.Ui.Interop;
 
 /// <summary>
@@ -45,3 +47,5 @@ internal class Kernel32
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool IsDebuggerPresent();
 }
+
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui/Interop/ShObjIdl.cs
+++ b/src/Wpf.Ui/Interop/ShObjIdl.cs
@@ -15,6 +15,8 @@
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable CA1060 // Move pinvokes to native methods class
+
 using System.Runtime.InteropServices;
 
 namespace Wpf.Ui.Interop;
@@ -238,3 +240,4 @@ internal static class ShObjIdl
 }
 
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui/Interop/Shell32.cs
+++ b/src/Wpf.Ui/Interop/Shell32.cs
@@ -16,6 +16,7 @@
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning disable SA1401 // Fields should be private
+#pragma warning disable CA1060 // Move pinvokes to native methods class
 
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -188,3 +189,4 @@ internal static class Shell32
 
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning restore SA1401 // Fields should be private
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
+++ b/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
@@ -376,7 +376,9 @@ public static class UnsafeNativeMethods
 
                     return Color.FromArgb(255, values[2], values[1], values[0]);
                 }
-                catch { }
+                catch
+                {
+                }
             }
         }
 

--- a/src/Wpf.Ui/Interop/User32.cs
+++ b/src/Wpf.Ui/Interop/User32.cs
@@ -21,6 +21,7 @@ namespace Wpf.Ui.Interop;
 #pragma warning disable SA1300 // Element should begin with upper-case letter
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning disable SA1401 // Fields should be private
+#pragma warning disable CA1060 // Move pinvokes to native methods class
 
 /// <summary>
 /// USER procedure declarations, constant definitions and macros.
@@ -1598,3 +1599,4 @@ internal static class User32
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning restore SA1401 // Fields should be private
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui/Interop/UxTheme.cs
+++ b/src/Wpf.Ui/Interop/UxTheme.cs
@@ -20,6 +20,7 @@ namespace Wpf.Ui.Interop;
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable CA1060 // Move pinvokes to native methods class
 
 internal static class UxTheme
 {
@@ -174,3 +175,4 @@ internal static class UxTheme
 }
 
 #pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning restore CA1060 // Move pinvokes to native methods class

--- a/src/Wpf.Ui/Markup/Design.cs
+++ b/src/Wpf.Ui/Markup/Design.cs
@@ -20,7 +20,7 @@ namespace Wpf.Ui.Markup;
 /// </example>
 public static class Design
 {
-    private static readonly string DesignProcessName = "devenv";
+    private const string DesignProcessName = "devenv";
 
     private static bool? _inDesignMode;
 
@@ -29,12 +29,10 @@ public static class Design
     /// </summary>
     private static bool InDesignMode =>
         _inDesignMode ??=
-            (bool)
-                DependencyPropertyDescriptor
-                    .FromProperty(DesignerProperties.IsInDesignModeProperty, typeof(FrameworkElement))
-                    .Metadata.DefaultValue
-            || System
-                .Diagnostics.Process.GetCurrentProcess()
+            (bool)DependencyPropertyDescriptor
+                .FromProperty(DesignerProperties.IsInDesignModeProperty, typeof(FrameworkElement))
+                .Metadata.DefaultValue
+            || System.Diagnostics.Process.GetCurrentProcess()
                 .ProcessName.StartsWith(DesignProcessName, StringComparison.Ordinal);
 
     public static readonly DependencyProperty BackgroundProperty = DependencyProperty.RegisterAttached(

--- a/src/Wpf.Ui/Markup/FontIconExtension.cs
+++ b/src/Wpf.Ui/Markup/FontIconExtension.cs
@@ -49,7 +49,7 @@ public class FontIconExtension : MarkupExtension
 
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        FontIcon fontIcon = new() { Glyph = Glyph, FontFamily = FontFamily };
+        FontIcon fontIcon = new() { Glyph = Glyph!, FontFamily = FontFamily };
 
         if (FontSize > 0)
         {

--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -95,11 +95,14 @@ public class UiApplication
                     _resources.MergedDictionaries.Add(themesDictionary);
                     _resources.MergedDictionaries.Add(controlsDictionary);
                 }
-                catch { }
+                catch
+                {
+                }
             }
 
             return _application?.Resources ?? _resources;
         }
+
         set
         {
             if (_application is not null)


### PR DESCRIPTION
This cleans up all warnings that are generated when building `Wpf.Ui.sln`.

## Pull request type

- [x] Build related changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Numbers: #1332 and #1333

## What is the new behavior?

No warnings are generated when building.

## Other information

This PR closes #1332. Also closes #1333.