### PR TITLE
fix: #1341: MenuItem template binding error

### DIFF
--- a/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
+++ b/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
@@ -77,12 +77,12 @@
                     <!-- TextBlock added so that screen readers don't try to read Icon -->
                     <TextBlock Grid.Column="0"
                         Grid.ColumnSpan="3"
-                        Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
-                        Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Width="{TemplateBinding Width}"
+                        Height="{TemplateBinding Height}"
                         Margin="-10"
                         FontSize="1"
                         Opacity="0"
-                        Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Text="{TemplateBinding AutomationProperties.Name}"
                         Background="Black"/>
                 </Grid>
 
@@ -194,12 +194,12 @@
                 <!-- TextBlock added so that screen readers don't try to read Icon -->
                 <TextBlock Grid.Column="0"
                    Grid.ColumnSpan="3"
-                   Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
-                   Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Width="{TemplateBinding Width}"
+                   Height="{TemplateBinding Height}"
                    Margin="-10"
                    FontSize="1"
                    Opacity="0"
-                   Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Text="{TemplateBinding AutomationProperties.Name}"
                    Background="Black"/>
             </Grid>
         </Border>
@@ -288,12 +288,12 @@
                 <!-- TextBlock added so that screen readers don't try to read Icon -->
                 <TextBlock Grid.Column="0"
                    Grid.ColumnSpan="5"
-                   Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
-                   Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Width="{TemplateBinding Width}"
+                   Height="{TemplateBinding Height}"
                    Margin="-10"
                    FontSize="1"
                    Opacity="0"
-                   Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                   Text="{TemplateBinding AutomationProperties.Name}"
                    Background="Black"/>
             </Grid>
         </Border>
@@ -369,12 +369,12 @@
                     <!-- Fix double narration from mousing over the button and then the associated text -->
                     <TextBlock Grid.Column="0"
                         Grid.ColumnSpan="3"
-                        Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
-                        Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Width="{TemplateBinding Width}"
+                        Height="{TemplateBinding Height}"
                         Margin="-10"
                         FontSize="1"
                         Opacity="0"
-                        Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
+                        Text="{TemplateBinding AutomationProperties.Name}"
                         Background="Black"/>
                 </Grid>
             </Border>

--- a/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
+++ b/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
@@ -74,16 +74,18 @@
                         ContentSource="Header"
                         RecognizesAccessKey="True"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
-                    <!-- TextBlock added so that screen readers don't try to read Icon -->
-                    <TextBlock Grid.Column="0"
+                    <!--  TextBlock added so that screen readers don't try to read Icon  -->
+                    <TextBlock
+                        Grid.Column="0"
                         Grid.ColumnSpan="3"
                         Width="{TemplateBinding Width}"
                         Height="{TemplateBinding Height}"
                         Margin="-10"
+                        Background="Black"
                         FontSize="1"
+                        IsHitTestVisible="False"
                         Opacity="0"
-                        Text="{TemplateBinding AutomationProperties.Name}"
-                        Background="Black"/>
+                        Text="{TemplateBinding AutomationProperties.Name}" />
                 </Grid>
 
                 <Popup
@@ -191,16 +193,18 @@
                     ContentSource="Header"
                     RecognizesAccessKey="True"
                     TextElement.Foreground="{TemplateBinding Foreground}" />
-                <!-- TextBlock added so that screen readers don't try to read Icon -->
-                <TextBlock Grid.Column="0"
-                   Grid.ColumnSpan="3"
-                   Width="{TemplateBinding Width}"
-                   Height="{TemplateBinding Height}"
-                   Margin="-10"
-                   FontSize="1"
-                   Opacity="0"
-                   Text="{TemplateBinding AutomationProperties.Name}"
-                   Background="Black"/>
+                <!--  TextBlock added so that screen readers don't try to read Icon  -->
+                <TextBlock
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    Width="{TemplateBinding Width}"
+                    Height="{TemplateBinding Height}"
+                    Margin="-10"
+                    Background="Black"
+                    FontSize="1"
+                    IsHitTestVisible="False"
+                    Opacity="0"
+                    Text="{TemplateBinding AutomationProperties.Name}" />
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -284,17 +288,19 @@
                     FontSize="11"
                     Foreground="{DynamicResource TextFillColorDisabledBrush}"
                     Text="{TemplateBinding InputGestureText}" />
-                
-                <!-- TextBlock added so that screen readers don't try to read Icon -->
-                <TextBlock Grid.Column="0"
-                   Grid.ColumnSpan="5"
-                   Width="{TemplateBinding Width}"
-                   Height="{TemplateBinding Height}"
-                   Margin="-10"
-                   FontSize="1"
-                   Opacity="0"
-                   Text="{TemplateBinding AutomationProperties.Name}"
-                   Background="Black"/>
+
+                <!--  TextBlock added so that screen readers don't try to read Icon  -->
+                <TextBlock
+                    Grid.Column="0"
+                    Grid.ColumnSpan="4"
+                    Width="{TemplateBinding Width}"
+                    Height="{TemplateBinding Height}"
+                    Margin="-10"
+                    Background="Black"
+                    FontSize="1"
+                    IsHitTestVisible="False"
+                    Opacity="0"
+                    Text="{TemplateBinding AutomationProperties.Name}" />
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -365,17 +371,19 @@
                             FontSize="{TemplateBinding FontSize}"
                             Symbol="ChevronRight20" />
                     </Grid>
-                    
-                    <!-- Fix double narration from mousing over the button and then the associated text -->
-                    <TextBlock Grid.Column="0"
+
+                    <!--  Fix double narration from mousing over the button and then the associated text  -->
+                    <TextBlock
+                        Grid.Column="0"
                         Grid.ColumnSpan="3"
                         Width="{TemplateBinding Width}"
                         Height="{TemplateBinding Height}"
                         Margin="-10"
+                        Background="Black"
                         FontSize="1"
+                        IsHitTestVisible="False"
                         Opacity="0"
-                        Text="{TemplateBinding AutomationProperties.Name}"
-                        Background="Black"/>
+                        Text="{TemplateBinding AutomationProperties.Name}" />
                 </Grid>
             </Border>
 

--- a/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
+++ b/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
@@ -74,18 +74,6 @@
                         ContentSource="Header"
                         RecognizesAccessKey="True"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
-                    <!--  TextBlock added so that screen readers don't try to read Icon  -->
-                    <TextBlock
-                        Grid.Column="0"
-                        Grid.ColumnSpan="3"
-                        Width="{TemplateBinding Width}"
-                        Height="{TemplateBinding Height}"
-                        Margin="-10"
-                        Background="Black"
-                        FontSize="1"
-                        IsHitTestVisible="False"
-                        Opacity="0"
-                        Text="{TemplateBinding AutomationProperties.Name}" />
                 </Grid>
 
                 <Popup
@@ -193,18 +181,6 @@
                     ContentSource="Header"
                     RecognizesAccessKey="True"
                     TextElement.Foreground="{TemplateBinding Foreground}" />
-                <!--  TextBlock added so that screen readers don't try to read Icon  -->
-                <TextBlock
-                    Grid.Column="0"
-                    Grid.ColumnSpan="2"
-                    Width="{TemplateBinding Width}"
-                    Height="{TemplateBinding Height}"
-                    Margin="-10"
-                    Background="Black"
-                    FontSize="1"
-                    IsHitTestVisible="False"
-                    Opacity="0"
-                    Text="{TemplateBinding AutomationProperties.Name}" />
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -288,19 +264,6 @@
                     FontSize="11"
                     Foreground="{DynamicResource TextFillColorDisabledBrush}"
                     Text="{TemplateBinding InputGestureText}" />
-
-                <!--  TextBlock added so that screen readers don't try to read Icon  -->
-                <TextBlock
-                    Grid.Column="0"
-                    Grid.ColumnSpan="4"
-                    Width="{TemplateBinding Width}"
-                    Height="{TemplateBinding Height}"
-                    Margin="-10"
-                    Background="Black"
-                    FontSize="1"
-                    IsHitTestVisible="False"
-                    Opacity="0"
-                    Text="{TemplateBinding AutomationProperties.Name}" />
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -371,19 +334,6 @@
                             FontSize="{TemplateBinding FontSize}"
                             Symbol="ChevronRight20" />
                     </Grid>
-
-                    <!--  Fix double narration from mousing over the button and then the associated text  -->
-                    <TextBlock
-                        Grid.Column="0"
-                        Grid.ColumnSpan="3"
-                        Width="{TemplateBinding Width}"
-                        Height="{TemplateBinding Height}"
-                        Margin="-10"
-                        Background="Black"
-                        FontSize="1"
-                        IsHitTestVisible="False"
-                        Opacity="0"
-                        Text="{TemplateBinding AutomationProperties.Name}" />
                 </Grid>
             </Border>
 


### PR DESCRIPTION
Use more efficient `{TemplateBinding}` for `MenuItem` templates, which also fixes the incorrect `{Binding Path}` syntax for attached properties.

## Pull request type
- [x] Bugfix

## What is the current behavior?
Currently, at runtime when debugging, while using `MenuItem`, the following error is seen in the Output Window:
```
System.Windows.Data Error: 40 : BindingExpression path error: 'AutomationProperties' property not found on 'object' ''MenuItem' (Name='')'. BindingExpression:Path=AutomationProperties.Name; DataItem='MenuItem' (Name=''); target element is 'TextBlock' (Name=''); target property is 'Text' (type 'String')
```

Issue Number: Fixes #1341

## What is the new behavior?
The binding has been corrected to use `{TemplateBinding}` instead of the `{Binding}` with the path specified incorrectly for attached properties.

The previous template had these bindings:
```xaml
Width="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
Height="{Binding Height, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
Text="{Binding AutomationProperties.Name, RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}}"
```
Firstly, the `{Binding Path}` syntax for attached properties would have been `Path=(Automation.Text)`, with parenthesis.
Secondly, a more efficient `RelativeSource` would have been `{RelativeSource TemplatedParent}`.
Finally, switching to a `{TemplateBinding}` is the most efficient binding, and it uses simpler `Path` syntax.

The new template changes these bindings as follows:
```xaml
Width="{TemplateBinding Width}"
Height="{TemplateBinding Height}"
Text="{TemplateBinding AutomationProperties.Name}"
```

## Other information
`{Binding}` with `RelativeSource={RelativeSource TemplatedParent}` is only appropriate in the case when the non-typical binding properties are needed, such as `Mode=TwoWay`. The implied `Mode` for `{TemplateBinding}` is 'Mode=OneWay`.

I verified that there were no other such `XAML` errors in the commit e55d7d7badfbab0c055f05f61908954ef3bbad05 from @Difegue that introduced this bug.
