### PR TITLE
Fix Wpf.Ui.Controls.TextBlock default style

### DIFF
--- a/src/Wpf.Ui/Controls/TextBlock/TextBlock.cs
+++ b/src/Wpf.Ui/Controls/TextBlock/TextBlock.cs
@@ -39,6 +39,12 @@ public class TextBlock : System.Windows.Controls.TextBlock
         )
     );
 
+    public TextBlock()
+    {
+        var defaultFontTypography = (FontTypography)FontTypographyProperty.DefaultMetadata.DefaultValue;
+        SetResourceReference(StyleProperty, defaultFontTypography.ToResourceValue());
+    }
+
     /// <summary>
     /// Gets or sets the <see cref="FontTypography"/> of the text.
     /// </summary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

In the current version, the default style is not applied because the Update trigger is set, but there is no default initialization

![image](https://github.com/user-attachments/assets/efafdfe2-42b3-4654-b5b4-e0e199e65403)

Issue Number: N/A

## What is the new behavior?

Fixed, not default size works

![image](https://github.com/user-attachments/assets/67683a31-c6f7-421a-b131-b3941a5696d2)
