### PR TITLE
Set ComboBox MinWidth on Border, not on Popup itself

### DIFF
--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -253,7 +253,6 @@
                                 </Grid>
                                 <Popup
                                     x:Name="Popup"
-                                    MinWidth="{TemplateBinding ActualWidth}"
                                     VerticalAlignment="Center"
                                     AllowsTransparency="True"
                                     Focusable="False"
@@ -263,6 +262,7 @@
                                     VerticalOffset="1">
                                     <Border
                                         x:Name="DropDownBorder"
+                                        MinWidth="{TemplateBinding ActualWidth}"
                                         Margin="0"
                                         Padding="0,4,0,6"
                                         Background="{DynamicResource ComboBoxDropDownBackground}"


### PR DESCRIPTION
Fixes #599; credit to @jschroedl

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When adding an item to a combo box after initial layout, with the parent having a horizontal layout (e.g., a `StackPanel Orientation="Horizontal"`), no space is provided for the added item.

Issue Number: #599

## What is the new behavior?

The new item now appears.
