### PR TITLE
DataGrid: add support for RowBackground and AlternatingRowBackground

### DIFF
--- a/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
+++ b/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
@@ -121,7 +121,6 @@
                         Padding="{TemplateBinding Padding}"
                         HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                         VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                        Background="Transparent"
                         BorderBrush="Transparent"
                         BorderThickness="0"
                         SnapsToDevicePixels="True">
@@ -157,7 +156,6 @@
     <Style x:Key="DefaultDataGridRowStyle" TargetType="{x:Type DataGridRow}">
         <Setter Property="Margin" Value="0,2" />
         <Setter Property="Padding" Value="4" />
-        <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -182,7 +180,6 @@
                 <ControlTemplate TargetType="{x:Type DataGridRow}">
                     <Border
                         x:Name="DGR_Border"
-                        Background="Transparent"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="{DynamicResource ControlCornerRadius}"
@@ -376,7 +373,14 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                     </Border>
+
                     <ControlTemplate.Triggers>
+                        <Trigger Property="AlternationIndex" Value="0">
+                            <Setter TargetName="DGR_Border" Property="Background" Value="{Binding RowBackground, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                        </Trigger>
+                        <Trigger Property="AlternationIndex" Value="1">
+                            <Setter TargetName="DGR_Border" Property="Background" Value="{Binding AlternatingRowBackground, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
+                        </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsEnabled" Value="True" />


### PR DESCRIPTION
Add support for setting a row background, and optionally an alternating row background (e.g., alternating white/light grey stripes).

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Previously, the `RowBackground` and `AlternatingRowBackground` properties were effectively ignored, as the style/control template didn't evaluate them.

Issue Number: https://github.com/lepoco/wpfui/pull/1192#issuecomment-2639098821

## What is the new behavior?

The properties are now taken into account.

- if both properties are set, odd rows use `RowBackground`, and even rows use `AlternatingRowBackground`.
- if only `RowBackground` is set, all rows use that
- if neither is set, rows have a transparent background