### PR TITLE
fix: progress ring initialization exception #1356

### DIFF
--- a/src/Wpf.Ui/Controls/Arc/Arc.cs
+++ b/src/Wpf.Ui/Controls/Arc/Arc.cs
@@ -57,7 +57,7 @@ public class Arc : Shape
         // Modify the metadata of the StrokeStartLineCap dependency property.
         StrokeStartLineCapProperty.OverrideMetadata(
             typeof(Arc),
-            new PropertyMetadata(PenLineCap.Round, PropertyChangedCallback)
+            new FrameworkPropertyMetadata(PenLineCap.Round, PropertyChangedCallback)
         );
     }
 


### PR DESCRIPTION
Fixes the initialization issue with the ProgressRing control

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Trying to use the ProgressRing throws an exception at runtime: "Metadata override and base metadata must be of the same type or derived type"

Issue Number: 1356

## What is the new behavior?

The progress ring works as expected.

-
-

## Other information

The issue was in the static constructor for the Arc control.  
