### PR TITLE
TitleBar Header and TrailingContent IsHitTestVisible

### DIFF
--- a/src/Wpf.Ui/Extensions/UiElementExtensions.cs
+++ b/src/Wpf.Ui/Extensions/UiElementExtensions.cs
@@ -26,7 +26,7 @@ internal static class UiElementExtensions
 
             Point mousePosRelative = element.PointFromScreen(mousePosScreen);
 
-            return bounds.Contains(mousePosRelative);
+            return bounds.Contains(mousePosRelative) && element.IsHitTestVisible;
         }
         catch
         {


### PR DESCRIPTION
…e, then user is not able to click on the UIElement.

When TitleBar is customised with TextBlock only and with IsHitVisible set false, then allow user to click on the TextBlock and able to select & move the window.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [/ ] Update
- [ ] Bugfix
- [/ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

TitleBar Header and TrailingContent makes user unable to click to select window and move window.

Issue Number: N/A

## What is the new behavior?

If set 'IsHitTestVisible' of UIElement of Header or TrailingContent to False, then user will not be able to hit on the UIElement and be able to select the window (and move the window, if they want to).

## Other information

N/A
