### PR TITLE
TitleBar Buttons not working in some cases

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -232,4 +232,39 @@ public class TitleBarButton : Wpf.Ui.Controls.Button
             ),
         };
     }
+
+    PresentationSource presentationSource = null;
+
+	protected bool IsMouseOverElement(nint lParam)
+	{
+		System.Drawing.Point winPoint;
+		bool gotCursorPos = User32.GetCursorPos(out winPoint);
+
+		if (!gotCursorPos)
+		{
+			int fallbackX = unchecked((short)((long)lParam & 0xFFFF));
+			int fallbackY = unchecked((short)(((long)lParam >> 16) & 0xFFFF));
+			winPoint = new System.Drawing.Point(fallbackX, fallbackY);
+		}
+
+		var screenPoint = new System.Windows.Point(winPoint.X, winPoint.Y);
+
+		presentationSource ??= PresentationSource.FromVisual(this);
+
+		if (presentationSource?.CompositionTarget != null)
+		{
+			screenPoint = presentationSource.CompositionTarget.TransformFromDevice.Transform(screenPoint);
+		}
+
+		var localPoint = this.PointFromScreen(screenPoint);
+
+		var hitTestRect = 
+            new System.Windows.Rect(
+			0,
+			0,
+			this.ActualWidth,
+			this.ActualHeight);
+
+		return hitTestRect.Contains(localPoint);
+	}
 }

--- a/src/Wpf.Ui/Interop/User32.cs
+++ b/src/Wpf.Ui/Interop/User32.cs
@@ -1450,7 +1450,7 @@ internal static class User32
     [DllImport(Libraries.User32, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool GetCursorPos([Out] out WinDef.POINT lpPoint);
-    [DllImport(Libraries.User32), SetLastError = true)]
+    [DllImport(Libraries.User32, SetLastError = true)]
 	public static extern bool GetCursorPos(out System.Drawing.Point lpPoint);
     
 

--- a/src/Wpf.Ui/Interop/User32.cs
+++ b/src/Wpf.Ui/Interop/User32.cs
@@ -1450,6 +1450,9 @@ internal static class User32
     [DllImport(Libraries.User32, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool GetCursorPos([Out] out WinDef.POINT lpPoint);
+    [DllImport(Libraries.User32), SetLastError = true)]
+	public static extern bool GetCursorPos(out System.Drawing.Point lpPoint);
+    
 
     [DllImport(Libraries.User32)]
     public static extern bool UnionRect(out WinDef.RECT rcDst, ref WinDef.RECT rc1, ref WinDef.RECT rc2);


### PR DESCRIPTION
This fix addresses an issue that occurred when detecting whether the mouse was hovering over one of the TitleBar buttons (such as minimize, maximize, or close) of a window. 
The previous method of detecting the mouse position could lead to incorrect results, particularly when the pointer was moved quickly from outside to inside the window.

## Pull request type

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When creating an instance of a window with a valid parent and displaying it using ShowDialog (I can reproduce this issue only with modal windows), there's sometimes a behavior where you are unable to click any of the titlebar buttons.
 The only way to resolve this issue is by first giving focus to the content of the window and then returning focus to the titlebar area, making it difficult to interact with the titlebar buttons.

Issue Number: N/A

## What is the new behavior?

- Fixed MouseOver detection: The logic for detecting mouse hover over the TitleBar buttons has been improved. The method now consistently detects the mouse position by using an interop function to ensure the accuracy of this calculation.
- Correct transformation of coordinates: The transformation from screen coordinates to local window coordinates is now checked, even when device scaling or window transformations are in place, ensuring accurate hit testing on the TitleBar buttons.


## Other information

N/A
