### PR TITLE
Update TabControl Header MinWidth from 180 to 120

### DIFF
--- a/src/Wpf.Ui/Controls/TabControl/TabControl.xaml
+++ b/src/Wpf.Ui/Controls/TabControl/TabControl.xaml
@@ -76,7 +76,7 @@
                     <Grid x:Name="Root">
                         <Border
                             x:Name="Border"
-                            MinWidth="180"
+                            MinWidth="120"
                             MinHeight="36"
                             Margin="0"
                             Padding="6"


### PR DESCRIPTION
Update TabControl Header MinWidth from 180 to 120

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

MinWidth of TabControl Header as 180 makes tab header arranged into 2 rows when there are more than 5 tabs.

Issue Number: N/A

## What is the new behavior?

Width of TabControl Header is shorter thus can fit more tabs in 1 row.

## Other information

NA
