### PR TITLE
Design properties multi IDE support

### DIFF
--- a/src/Wpf.Ui/Markup/Design.cs
+++ b/src/Wpf.Ui/Markup/Design.cs
@@ -23,7 +23,8 @@ public static class Design
     private static readonly string[] DesignProcesses =
     [
         "devenv",
-        "dotnet"
+        "dotnet",
+        "RiderWpfPreviewerLauncher64"
     ];
 
     private static bool? _inDesignMode;

--- a/src/Wpf.Ui/Markup/Design.cs
+++ b/src/Wpf.Ui/Markup/Design.cs
@@ -20,8 +20,11 @@ namespace Wpf.Ui.Markup;
 /// </example>
 public static class Design
 {
-    private static readonly string DesignVsProcessName = "devenv";
-    private static readonly string DesignRiderProcessName = "dotnet";
+    private static readonly string[] DesignProcesses =
+    [
+        "devenv",
+        "dotnet"
+    ];
 
     private static bool? _inDesignMode;
 
@@ -34,12 +37,9 @@ public static class Design
                 DependencyPropertyDescriptor
                     .FromProperty(DesignerProperties.IsInDesignModeProperty, typeof(FrameworkElement))
                     .Metadata.DefaultValue
-            || System
+            || DesignProcesses.All(process => System
                 .Diagnostics.Process.GetCurrentProcess()
-                .ProcessName.StartsWith(DesignVsProcessName, StringComparison.Ordinal)
-            || System
-                .Diagnostics.Process.GetCurrentProcess()
-                .ProcessName.StartsWith(DesignRiderProcessName, StringComparison.Ordinal);
+                .ProcessName.StartsWith(process, StringComparison.Ordinal));
 
     public static readonly DependencyProperty BackgroundProperty = DependencyProperty.RegisterAttached(
         "Background",

--- a/src/Wpf.Ui/Markup/Design.cs
+++ b/src/Wpf.Ui/Markup/Design.cs
@@ -20,7 +20,8 @@ namespace Wpf.Ui.Markup;
 /// </example>
 public static class Design
 {
-    private const string DesignProcessName = "devenv";
+    private static readonly string DesignVsProcessName = "devenv";
+    private static readonly string DesignRiderProcessName = "dotnet";
 
     private static bool? _inDesignMode;
 
@@ -35,7 +36,10 @@ public static class Design
                     .Metadata.DefaultValue
             || System
                 .Diagnostics.Process.GetCurrentProcess()
-                .ProcessName.StartsWith(DesignProcessName, StringComparison.Ordinal);
+                .ProcessName.StartsWith(DesignVsProcessName, StringComparison.Ordinal)
+            || System
+                .Diagnostics.Process.GetCurrentProcess()
+                .ProcessName.StartsWith(DesignRiderProcessName, StringComparison.Ordinal);
 
     public static readonly DependencyProperty BackgroundProperty = DependencyProperty.RegisterAttached(
         "Background",

--- a/src/Wpf.Ui/Markup/Design.cs
+++ b/src/Wpf.Ui/Markup/Design.cs
@@ -37,7 +37,7 @@ public static class Design
                 DependencyPropertyDescriptor
                     .FromProperty(DesignerProperties.IsInDesignModeProperty, typeof(FrameworkElement))
                     .Metadata.DefaultValue
-            || DesignProcesses.All(process => System
+            || DesignProcesses.Any(process => System
                 .Diagnostics.Process.GetCurrentProcess()
                 .ProcessName.StartsWith(process, StringComparison.Ordinal));
 


### PR DESCRIPTION
Currently design properties are not supported by JetBrains Rider and are simply ignored. This patch adds support, for development not only in VS

```xml
ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}”
ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}”
```

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Rider skip design props

Issue Number: N/A

## What is the new behavior?

Now the XAML preview will be available in the different IDEs
