### PR TITLE
Add IsCloseButtonEnabled to MessageBox and make button border padding configurable

### DIFF
--- a/src/Wpf.Ui/Controls/MessageBox/MessageBox.cs
+++ b/src/Wpf.Ui/Controls/MessageBox/MessageBox.cs
@@ -115,6 +115,14 @@ public class MessageBox : System.Windows.Window
         new PropertyMetadata(true)
     );
 
+    /// <summary>Identifies the <see cref="IsCloseButtonEnabled"/> dependency property.</summary>
+    public static readonly DependencyProperty IsCloseButtonEnabledProperty = DependencyProperty.Register(
+        nameof(IsCloseButtonEnabled),
+        typeof(bool),
+        typeof(MessageBox),
+        new PropertyMetadata(true)
+    );
+
     /// <summary>Identifies the <see cref="TemplateButtonCommand"/> dependency property.</summary>
     public static readonly DependencyProperty TemplateButtonCommandProperty = DependencyProperty.Register(
         nameof(TemplateButtonCommand),
@@ -214,7 +222,16 @@ public class MessageBox : System.Windows.Window
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the <see cref="MessageBox"/> primary button is enabled.
+    /// Gets or sets a value indicating whether the <see cref="MessageBox"/> close button is enabled.
+    /// </summary>
+    public bool IsCloseButtonEnabled
+    {
+        get => (bool)GetValue(IsCloseButtonEnabledProperty);
+        set => SetValue(IsCloseButtonEnabledProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the <see cref="MessageBox"/> secondary button is enabled.
     /// </summary>
     public bool IsSecondaryButtonEnabled
     {
@@ -223,7 +240,7 @@ public class MessageBox : System.Windows.Window
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the <see cref="MessageBox"/> secondary button is enabled.
+    /// Gets or sets a value indicating whether the <see cref="MessageBox"/> primary button is enabled.
     /// </summary>
     public bool IsPrimaryButtonEnabled
     {

--- a/src/Wpf.Ui/Controls/MessageBox/MessageBox.xaml
+++ b/src/Wpf.Ui/Controls/MessageBox/MessageBox.xaml
@@ -15,6 +15,7 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Background" Value="{DynamicResource MessageBoxBackground}" />
         <Setter Property="FontSize" Value="14" />
+        <Setter Property="Padding" Value="12" />
         <Setter Property="Foreground" Value="{DynamicResource MessageBoxForeground}" />
         <Setter Property="TextElement.FontWeight" Value="Regular" />
         <Setter Property="WindowStyle" Value="ToolWindow" />
@@ -84,7 +85,7 @@
 
                                 <Border
                                     Grid.Row="2"
-                                    Padding="12"
+                                    Padding="{TemplateBinding Padding}"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Bottom"
                                     BorderBrush="{DynamicResource MessageBoxSeparatorBorderBrush}"
@@ -138,6 +139,7 @@
                         </Trigger>
                         <Trigger Property="IsPrimaryButtonEnabled" Value="False">
                             <Setter TargetName="PrimaryColumn" Property="Width" Value="0" />
+                            <Setter TargetName="FirstSpacer" Property="Width" Value="0" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -151,6 +153,10 @@
                         <Trigger Property="IsSecondaryButtonEnabled" Value="False">
                             <Setter TargetName="FirstSpacer" Property="Width" Value="0" />
                             <Setter TargetName="SecondaryColumn" Property="Width" Value="0" />
+                        </Trigger>
+                        <Trigger Property="IsCloseButtonEnabled" Value="False">
+                            <Setter TargetName="CloseColumn" Property="Width" Value="0" />
+                            <Setter TargetName="SecondSpacer" Property="Width" Value="0" />
                         </Trigger>
                         <Trigger Property="PrimaryButtonText" Value="">
                             <Setter Property="IsPrimaryButtonEnabled" Value="False" />


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Every instance of ui:MessageBox comes with a Close button that can't be removed.  
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Padding of the MessageBox can be configured instead of the hardcoded 12
- Close Button can be hidden in case you only need the Primary/Secondary Buttons 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
