### PR TITLE
fix issue #1405, AutoSuggestBox tab problems

### DIFF
--- a/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
+++ b/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
@@ -92,6 +92,7 @@
     </Style>
 
     <Style x:Key="DefaultUiAutoSuggestBoxStyle" TargetType="{x:Type controls:AutoSuggestBox}">
+        <Setter Property="Focusable" Value="False" /> <!-- ensure that the outer control is not focusable-->
         <Setter Property="MaxSuggestionListHeight" Value="240" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
@@ -116,9 +117,11 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:AutoSuggestBox}">
-                    <Grid>
+                    <Grid >
                         <controls:TextBox
                             x:Name="PART_TextBox"
+                            TabIndex="{TemplateBinding TabIndex}"
+                            IsTabStop="{TemplateBinding IsTabStop}"
                             Grid.Row="0"
                             Icon="{TemplateBinding Icon}"
                             IconPlacement="Right"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The AutoSuggestBox doesn't work well with keyboard data entry via TabIndex and IsTabStop

Issue Number: #1405 

## What is the new behavior?

Just a few minor XAML tweaks to allow a user to tab over to an AutoSuggestBox and begin typing.  Also stopped allowing focus on the outer portion of the control, and allow TabIndex and IsTabStop to be passed directly to the textbox part of the control.

-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
