### PR TITLE
Fix CanContentScrollProperty.OverrideMetadata

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewContentPresenter.cs
@@ -89,10 +89,13 @@ public class NavigationViewContentPresenter : Frame
             new FrameworkPropertyMetadata(JournalOwnership.UsesParentJournal)
         );
 
-        ScrollViewer.CanContentScrollProperty.OverrideMetadata(
-            typeof(Page),
-            new FrameworkPropertyMetadata(true)
-        );
+        if (ScrollViewer.CanContentScrollProperty.GetMetadata(typeof(Page)) == ScrollViewer.CanContentScrollProperty.DefaultMetadata)
+        {
+            ScrollViewer.CanContentScrollProperty.OverrideMetadata(
+                typeof(Page),
+                new FrameworkPropertyMetadata(true)
+            );
+        }
     }
 
     public NavigationViewContentPresenter()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When using plugins (run as an plugin .dll rather than an .exe), where each plugin can use wpf.ui, OverrideMetadata is called twice, which causes an exception.

![image](https://github.com/user-attachments/assets/ce93169b-fe7b-4bd7-af5d-b8eb8f87fd76)

## What is the new behavior?

Added a check to disable overriding a property if it has already been done