### PR TITLE
Fix FontSize reference

### DIFF
--- a/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElement/FontIcon.cs
@@ -110,22 +110,13 @@ public class FontIcon : IconElement
 
     protected TextBlock? TextBlock { get; set; }
 
+    public FontIcon()
+    {
+        SetCurrentValue(FontSizeProperty, UiApplication.Current.Resources["DefaultIconFontSize"]);
+    }
+
     protected override UIElement InitializeChildren()
     {
-        if (FontSize.Equals(SystemFonts.MessageFontSize))
-        {
-            SetResourceReference(FontSizeProperty, "DefaultIconFontSize");
-
-            // If the FontSize is the default, set it to the parent's FontSize.
-            if (
-                VisualParent is not null
-                && TextElement.GetFontSize(VisualParent) != SystemFonts.MessageFontSize
-            )
-            {
-                SetCurrentValue(FontSizeProperty, TextElement.GetFontSize(VisualParent));
-            }
-        }
-
         TextBlock = new TextBlock
         {
             Style = null,


### PR DESCRIPTION
Now when using **FontIcon** in a DLL application (not exe), because of the difference in the order of resource initialisation, the **SetResourceReference** call overwrites the user-defined value, and binds strictly on the resource value. The patch fixes this and initialises not as a reference but as a value

I think **VisualParent** check is also unnecessary because **FrameworkPropertyMetadataOptions.Inherits** is used.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

![rider64_xg54L01psh](https://github.com/user-attachments/assets/d5b15083-2049-47a0-be91-5f8465c70b32)

## What is the new behavior?

![rider64_q9iogyHb2V](https://github.com/user-attachments/assets/f9a8f9cb-6b6a-435e-a75c-90d8ab3396ff)

