### PR TITLE
Fix HeaderContent not respecting bindings.

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.AttachedProperties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.AttachedProperties.cs
@@ -20,8 +20,18 @@ public partial class NavigationView
         "HeaderContent",
         typeof(object),
         typeof(NavigationView),
-        new FrameworkPropertyMetadata(null)
+        new FrameworkPropertyMetadata(null, OnHeaderContentChanged)
     );
+
+    private static void OnHeaderContentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not FrameworkElement frameworkElement)
+        {
+            return;
+        }
+
+        GetNavigationParent(frameworkElement)?.NotifyHeaderContentChanged(frameworkElement, e.NewValue);
+    }
 
     /// <summary>Helper for getting <see cref="HeaderContentProperty"/> from <paramref name="target"/>.</summary>
     /// <param name="target"><see cref="FrameworkElement"/> to read <see cref="HeaderContentProperty"/> from.</param>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Base.cs
@@ -63,6 +63,8 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
 
     protected Dictionary<Type, INavigationViewItem> PageTypeNavigationViewsDictionary { get; } = [];
 
+    protected Dictionary<FrameworkElement, INavigationViewItem> PageToNavigationItemDictionary { get; } = [];
+
     private readonly ObservableCollection<string> _autoSuggestBoxItems = [];
     private readonly ObservableCollection<NavigationViewBreadcrumbItem> _breadcrumbBarItems = [];
 
@@ -126,6 +128,7 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
 
         PageIdOrTargetTagNavigationViewsDictionary.Clear();
         PageTypeNavigationViewsDictionary.Clear();
+        PageToNavigationItemDictionary.Clear();
 
         ClearJournal();
 
@@ -507,6 +510,16 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(e), e.Action, $"Unsupported action: {e.Action}");
+        }
+
+        UpdateBreadcrumbContents();
+    }
+
+    private void UpdateBreadcrumbContents()
+    {
+        foreach (var breadcrumbItem in _breadcrumbBarItems)
+        {
+            breadcrumbItem.UpdateFromSource();
         }
     }
 }

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewBreadcrumbItem.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewBreadcrumbItem.cs
@@ -9,15 +9,33 @@
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
 
-internal class NavigationViewBreadcrumbItem
+internal class NavigationViewBreadcrumbItem : DependencyObject
 {
+    public static readonly DependencyProperty ContentProperty = DependencyProperty.Register(
+        nameof(Content),
+        typeof(object),
+        typeof(NavigationViewBreadcrumbItem),
+        new PropertyMetadata(null));
+
     public NavigationViewBreadcrumbItem(INavigationViewItem item)
     {
-        Content = item.Content;
         PageId = item.Id;
+        SourceItem = item;
+        Content = item.Content;
     }
 
-    public object Content { get; }
+    public object Content
+    {
+        get => GetValue(ContentProperty);
+        set => SetValue(ContentProperty, value);
+    }
 
     public string PageId { get; }
+
+    public INavigationViewItem SourceItem { get; }
+
+    public void UpdateFromSource()
+    {
+        SetCurrentValue(ContentProperty, SourceItem.Content);
+    }
 }


### PR DESCRIPTION
This commit fixes a bug that occurs if you use a binding with `ui:NavigationView.HeaderContent` when the `DataContext` is passed in through navigation.

This particularly affects multi-level navigation when you add the DataContext to the navigation, effectively preventing the correct titles from being rendered as breadcrumb titles.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

In a multi-level navigation scenario, when navigating using `INavigationService.NavigateWithHierarchy()` (and passing a data context), if you then try to bind any value from the `DataContext` to `wpfui:NavigationView.HeaderContent`, the binding will fail to work on the first page load. 

If you navigate back and forward, the breadcrumbs will update with the previous value of the binding.

Issue Number: #889 (possibly related)

## What is the new behavior?

This PR does changes several things to achieve the goal of being able to bind to `NavigationView.HeaderContent`.

1. Turns `NavigationViewBreadcrumbItem` into `DependencyObject`, and adds a `ContentProperty` dependency property to be able to react to updates.
2. Adds a dictionary to `NavigationView` to build a map between `Page`s and `INavigationViewItem`s. This allows it to look up `INavigationViewItem`s when a new value is assigned to `NavigationView.HeaderContent`.
3. Changes the order of `ApplyAttachedProperties` and `UpdateContent`, so the `DataContext` is available before the `HeaderContent`.
4. Sets `NavigationParentProperty` for any `Page` that gets navigated to, so `HeaderContent` can look up which `NavigationView` to notify about its content changing.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I have a reproduction of this issue in a separate -- but relatively large -- project, and I have been testing this fix against that project. I was uncertain of how to provide a reproduction in this repository, and I have therefore not included it yet. I would be happy to add one if necessary.

I am also not an expert in WPF, and have therefore used an LLM to help me understand the intricacies of this code, but all code in this PR was written by me. I have a feeling that there may be a simpler method to resolving this issue, but I have failed to find it.