### PR TITLE
Fix TooltipText binding bug

### DIFF
--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -385,7 +385,6 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
             return;
         }
 
-        notifyIcon.TooltipText = e.NewValue as string ?? string.Empty;
         notifyIcon.internalNotifyIconManager.TooltipText = notifyIcon.TooltipText;
         _ = notifyIcon.internalNotifyIconManager.ModifyToolTip();
     }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- The `TooltipText` binding in `NotifyIcon` is missing

Issue Number: #1426 

## What is the new behavior?

- The `TooltipText` binding in `NotifyIcon` is correct

## Other information

|Now|Should be|
|-|-|
|![Image](https://github.com/user-attachments/assets/47a41c7a-7801-4432-a15e-e37df5286ab0)|![Image](https://github.com/user-attachments/assets/dab26051-e6db-48c6-8b1e-5a3f225341ae)|
