### PR TITLE
🐛 pin footer menu items to prevent scrolling

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
@@ -289,11 +289,13 @@
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <!--  Back and Toggle buttons  -->
+                        <!--  Pane Header (Fixed)  -->
                         <Grid Grid.Row="0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -331,7 +333,7 @@
                                 </controls:Button.Content>
                             </controls:Button>
 
-                            <!--  Pane header  -->
+                            <!--  Pane Header  -->
                             <ContentPresenter
                                 Grid.Row="2"
                                 Margin="0"
@@ -341,7 +343,7 @@
                             <ContentPresenter
                                 x:Name="AutoSuggestBoxContentPresenter"
                                 Grid.Row="3"
-                                Margin="0"
+                                Margin="0,0,0,6"
                                 Content="{TemplateBinding AutoSuggestBox}" />
 
                             <controls:Button
@@ -353,57 +355,74 @@
                                 Visibility="Collapsed" />
                         </Grid>
 
-                        <!--  Menu items  -->
-                        <controls:DynamicScrollViewer
+                        <!--  Separator/Shadow for Top  -->
+                        <Border
                             Grid.Row="1"
+                            Height="1"
+                            Margin="0,4,0,4"
+                            Background="{DynamicResource LeftNavigationViewSeparatorBrush}" />
+
+                        <!--  Scrollable Menu Items  -->
+                        <controls:DynamicScrollViewer
+                            x:Name="PART_ScrollViewer"
+                            Grid.Row="2"
                             Margin="0,0,-4,0"
                             Padding="0,0,4,0"
                             CanContentScroll="True"
                             HorizontalScrollBarVisibility="Disabled"
                             VerticalScrollBarVisibility="Auto">
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <ItemsControl
-                                    x:Name="PART_MenuItemsItemsControl"
-                                    Grid.Row="0"
-                                    Focusable="False"
-                                    KeyboardNavigation.DirectionalNavigation="Contained"
-                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                    ScrollViewer.VerticalScrollBarVisibility="Disabled">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <StackPanel Margin="0" IsItemsHost="True" />
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                </ItemsControl>
-                                <ItemsControl
-                                    x:Name="PART_FooterMenuItemsItemsControl"
-                                    Grid.Row="1"
-                                    Margin="0,0,0,4"
-                                    Focusable="False"
-                                    KeyboardNavigation.DirectionalNavigation="Contained"
-                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                    ScrollViewer.VerticalScrollBarVisibility="Disabled">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <StackPanel Margin="0" IsItemsHost="True" />
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                </ItemsControl>
-                            </Grid>
+                            <ItemsControl
+                                x:Name="PART_MenuItemsItemsControl"
+                                Focusable="False"
+                                KeyboardNavigation.DirectionalNavigation="Contained"
+                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Margin="0" IsItemsHost="True" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                            </ItemsControl>
                         </controls:DynamicScrollViewer>
 
-                        <!--  Pane footer  -->
-                        <ContentPresenter
-                            Grid.Row="2"
-                            Margin="0"
-                            Content="{TemplateBinding PaneFooter}" />
+                        <!--  Separator/Shadow for Footer  -->
+                        <Border
+                            Grid.Row="3"
+                            Height="1"
+                            Margin="0,4,0,4"
+                            Background="{DynamicResource LeftNavigationViewSeparatorBrush}" />
+
+                        <!--  Footer (Fixed)  -->
+                        <Grid Grid.Row="4">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <ItemsControl
+                                x:Name="PART_FooterMenuItemsItemsControl"
+                                Grid.Row="0"
+                                Margin="0,0,0,4"
+                                Focusable="False"
+                                KeyboardNavigation.DirectionalNavigation="Contained"
+                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Margin="0" IsItemsHost="True" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                            </ItemsControl>
+
+                            <ContentPresenter
+                                Grid.Row="1"
+                                Margin="0"
+                                Content="{TemplateBinding PaneFooter}" />
+                        </Grid>
                     </Grid>
                 </Border>
             </Grid>
+
             <Border
                 Grid.Column="1"
                 Margin="{TemplateBinding FrameMargin}"
@@ -417,7 +436,7 @@
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
 
-                    <!--  Header  -->
+                    <!--  Header (e.g., BreadcrumbBar)  -->
                     <ContentPresenter
                         Grid.Row="0"
                         Margin="0"
@@ -432,7 +451,7 @@
                         Transition="{TemplateBinding Transition}"
                         TransitionDuration="{TemplateBinding TransitionDuration}" />
 
-                    <!--  Overlay  -->
+                    <!--  Overlay (e.g., SnackbarPresenter)  -->
                     <ContentPresenter
                         Grid.Row="0"
                         Grid.RowSpan="2"

--- a/src/Wpf.Ui/Resources/Theme/Dark.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Dark.xaml
@@ -681,4 +681,12 @@
     <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="TreeViewItemForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="TreeViewItemSelectionIndicatorForeground" Color="{DynamicResource SystemAccentColorPrimary}" />
+
+    <!--  LeftNavigationViewTemplate  -->
+    <LinearGradientBrush x:Key="LeftNavigationViewSeparatorBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="Transparent" />
+        <GradientStop Offset="0.3" Color="#555555" />
+        <GradientStop Offset="0.7" Color="#555555" />
+        <GradientStop Offset="1" Color="Transparent" />
+    </LinearGradientBrush>
 </ResourceDictionary>

--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -682,4 +682,12 @@
     <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="TreeViewItemForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="TreeViewItemSelectionIndicatorForeground" Color="{DynamicResource SystemAccentColorPrimary}" />
+
+    <!--  LeftNavigationViewTemplate  -->
+    <LinearGradientBrush x:Key="LeftNavigationViewSeparatorBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="#F5F5F5" />
+        <GradientStop Offset="0.3" Color="#E0E0E0" />
+        <GradientStop Offset="0.7" Color="#E0E0E0" />
+        <GradientStop Offset="1" Color="#FAFAFA" />
+    </LinearGradientBrush>
 </ResourceDictionary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

**In `LeftNavigationViewTemplate`:**

- at the bottom of the menu item (PART_FooterMenuItemsItemsControl) nested within DynamicScrollViewer, with the main course of a single scroll
- It does not meet users' interaction expectations for fixed bottom menus (such as Settings/exit buttons)
- Visually, there is a lack of a separation line between the menu area and the bottom

## What is the new behavior?

**`LeftNavigationViewTemplate` changes:**

- The bottom menu is now fixed and not affected by the scrolling of the main menu
- New dividing lines are added to clarify the visual hierarchy
- Structural adjustment：

```xml
<!-- Before -->
DynamicScrollViewer
  ├─ MenuItems
  └─ FooterItems

<!-- After -->
DynamicScrollViewer
Separator
Fixed FooterItems
```

## Other information

- - The Footer is always fixed at the bottom, and the interaction is more in line with the specifications of modern navigation controls such as Windows 11

![bugfix-LeftNavigation](https://github.com/user-attachments/assets/389b08bb-fb7b-4f59-a65b-ced81a02011a)

**Scope of influence:**

- Only affects using`LeftNavigationViewTemplate`NavigationView instance

