### PR TITLE
Settable TitleBar FontWeight

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -419,6 +419,10 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
             System.Windows.Controls.TextBlock.FontSizeProperty,
             new Binding(nameof(FontSize)) { Source = this }
         );
+        _ = _titleBlock.SetBinding(
+            System.Windows.Controls.TextBlock.FontWeightProperty,
+            new Binding(nameof(FontWeight)) { Source = this }
+        );
         Header = _titleBlock;
 
         Loaded += OnLoaded;


### PR DESCRIPTION
## Feature request

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Fontweight is not settable for the TitleBar

## What is the new behavior?

now we can set the FontWeight of the TitleBar title

