### PR TITLE
Bug fix: MessageBox does not appear center owner for maximized windows

### DIFF
--- a/src/Wpf.Ui/Controls/MessageBox/MessageBox.cs
+++ b/src/Wpf.Ui/Controls/MessageBox/MessageBox.cs
@@ -356,7 +356,7 @@ public class MessageBox : System.Windows.Window
             case WindowStartupLocation.CenterOwner:
                 if (
                     !CanCenterOverWPFOwner()
-                    || Owner.WindowState is WindowState.Maximized or WindowState.Minimized
+                    || Owner.WindowState is WindowState.Minimized
                 )
                 {
                     CenterWindowOnScreen();


### PR DESCRIPTION
Bug fix: MessageBox does not appear center owner for maximized windows even when WindowStartupLocation is set to WindowStartupLocation.CenterOwner

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
MessageBox appears center screen even when WindowStartupLocation.CenterOwner is set with maximized windows

Issue Number: N/A

## What is the new behavior?


MessageBox properly appears center owner for maximized windows

## Other information


