### PR TITLE
Re-attach toggle button click handler after navigation

### DIFF
--- a/src/Wpf.Ui/Controls/SplitButton/SplitButton.cs
+++ b/src/Wpf.Ui/Controls/SplitButton/SplitButton.cs
@@ -13,7 +13,7 @@ namespace Wpf.Ui.Controls;
 /// Represents a button with two parts that can be invoked separately. One part behaves like a standard button and the other part invokes a flyout.
 /// </summary>
 [TemplatePart(Name = TemplateElementToggleButton, Type = typeof(ToggleButton))]
-public class SplitButton : Wpf.Ui.Controls.Button
+public class SplitButton : Button
 {
     /// <summary>
     /// Template element represented by the <c>ToggleButton</c> name.
@@ -75,6 +75,40 @@ public class SplitButton : Wpf.Ui.Controls.Button
 
             self.ReleaseTemplateResources();
         };
+        Loaded += static (sender, _) =>
+        {
+            var self = (SplitButton)sender;
+            if (self.SplitButtonToggleButton != null)
+            {
+                self.AttachToggleButtonClick();
+            }
+        };
+    }
+
+    protected virtual void AttachTemplateResources()
+    {
+        base.OnApplyTemplate();
+
+        if (GetTemplateChild(TemplateElementToggleButton) is ToggleButton toggleButton)
+        {
+            SplitButtonToggleButton = toggleButton;
+            AttachToggleButtonClick();
+        }
+        else
+        {
+            throw new NullReferenceException(
+                $"Element {nameof(TemplateElementToggleButton)} of type {typeof(ToggleButton)} not found in {typeof(SplitButton)}"
+            );
+        }
+    }
+
+    private void AttachToggleButtonClick()
+    {
+        if (SplitButtonToggleButton != null)
+        {
+            SplitButtonToggleButton.Click -= OnSplitButtonToggleButtonOnClick;
+            SplitButtonToggleButton.Click += OnSplitButtonToggleButtonOnClick;
+        }
     }
 
     private static void OnFlyoutChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -127,9 +161,7 @@ public class SplitButton : Wpf.Ui.Controls.Button
         if (GetTemplateChild(TemplateElementToggleButton) is ToggleButton toggleButton)
         {
             SplitButtonToggleButton = toggleButton;
-
-            SplitButtonToggleButton.Click -= OnSplitButtonToggleButtonOnClick;
-            SplitButtonToggleButton.Click += OnSplitButtonToggleButtonOnClick;
+            AttachToggleButtonClick();
         }
         else
         {
@@ -158,7 +190,7 @@ public class SplitButton : Wpf.Ui.Controls.Button
         _contextMenu.SetCurrentValue(ContextMenu.PlacementTargetProperty, this);
         _contextMenu.SetCurrentValue(
             ContextMenu.PlacementProperty,
-            System.Windows.Controls.Primitives.PlacementMode.Bottom
+            PlacementMode.Bottom
         );
         _contextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The toggle button part of the SplitButton stops working if you navigate away from a page and then come back to it using the PageService navigation and the page is registered using AddSingleton.

The problem appears to be how the toggle button Click event is registered and unregistered. The toggle button Click event is registered in the OnApplyTemplate routine which is only executed the first time the page is displayed. It's unregistered in an Unloaded event which executes every time you navigate away from the page, so the second and subsequent times you navigate to the page, the Click event is no longer registered and that part of the SplitButton stops working.

This problem has been referenced here, but I don't see a committed functional solution anywhere: #1179 

## What is the new behavior?

The SplitButton now correctly reattaches the ToggleButton click event handler after navigating away from and back to the page. This ensures the toggle portion of the button remains functional even when the page is registered as a singleton and reused via the PageService.

