### PR TITLE
fix: Check Intptr and HwndSource isn't Zero before using in TitleBar

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -595,7 +595,7 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
     }
 
     /// <summary>
-    ///     Listening window hooks after rendering window content to SizeToContent support
+    ///  Listening window hooks after rendering window content to SizeToContent support
     /// </summary>
     private void OnWindowContentRendered(object? sender, EventArgs e)
     {
@@ -607,8 +607,17 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
         window.ContentRendered -= OnWindowContentRendered;
 
         IntPtr handle = new WindowInteropHelper(window).Handle;
-        HwndSource windowSource =
-            HwndSource.FromHwnd(handle) ?? throw new InvalidOperationException("Window source is null");
+        if (handle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        HwndSource? windowSource = HwndSource.FromHwnd(handle);
+        if (windowSource == null)
+        {
+            return;
+        }
+
         windowSource.AddHook(HwndSourceHook);
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- When the user holds down the ESC key while a message box is open, the application crashes.
- Rapidly closing the window immediately after it appears leads to an “HWND = 0” error.
- In contrast, explicitly setting the window’s content to null does not cause a crash.

![453433093-6d004393-65b6-41ef-971b-30a97d0d92d3](https://github.com/user-attachments/assets/ed7c013f-8e21-4ea7-9575-0a9127e36a03)


Issue Number: #1383 

## What is the new behavior?

- Before interacting with a window, the code now verifies that the HWND value is non-zero, preventing invalid handle usage.
- When attaching hooks, it first confirms that the HwndSource instance is not null, ensuring it only adds hooks to valid sources.
- As a result, holding ESC key or rapidly closing the message box no longer triggers crashes or “HWND = 0” errors.

![MessageBox_RapidCloseAction](https://github.com/user-attachments/assets/c1c9f85a-68cf-4368-a73a-a257cf39c9d1)

