### PR TITLE
Bring back the workaround for #1126

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.xaml
@@ -173,11 +173,13 @@
                                     Grid.Column="1"
                                     ButtonType="Minimize" />
 
+                                <!-- This button has HitTestVisible=false to workaround an issue with touch input firing twice. -->
+                                <!-- Maximizing is handled through the WM_NCLBUTTONUP hwndhook, so this button is only cosmetic. --> 
                                 <controls:TitleBarButton
                                     x:Name="PART_MaximizeButton"
                                     Grid.Column="2"
                                     ButtonType="Maximize"
-                                    IsHitTestVisible="True" />
+                                    IsHitTestVisible="False" />
 
                                 <controls:TitleBarButton
                                     x:Name="PART_CloseButton"


### PR DESCRIPTION
This brings back the workaround for touch input triggering the maximize button twice that got removed by #1366 .

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
Using a touchscreen to interact with the maximize button in an app using WPFUI will trigger it twice, maximizing and restoring the window in quick succession. 

Issue Number: #1126

## What is the new behavior?

Touch only maximizes or restores the app once. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
