### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/Wpf.Ui/Controls/SplitButton/SplitButton.cs
+++ b/src/Wpf.Ui/Controls/SplitButton/SplitButton.cs
@@ -176,7 +176,8 @@ public class SplitButton : Button
     /// </summary>
     protected virtual void ReleaseTemplateResources()
     {
-        SplitButtonToggleButton.Click -= OnSplitButtonToggleButtonOnClick;
+        if (SplitButtonToggleButton != null)
+            SplitButtonToggleButton.Click -= OnSplitButtonToggleButtonOnClick;
     }
 
     private void OnSplitButtonToggleButtonOnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Under some cases, a NullReferenceException can be thrown by SplitButton:
```
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException: Object reference not set to an instance of an object.
   at Wpf.Ui.Controls.SplitButton.ReleaseTemplateResources()
   at Wpf.Ui.Controls.SplitButton.<>c.<.ctor>b__14_0(Object sender, RoutedEventArgs _)
```


## What is the new behavior?

Checks if type is non-null.