### PR TITLE
Add IsTopAndFooterSeparatorVisible property to NavigationView component

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/INavigationView.cs
@@ -55,6 +55,11 @@ public interface INavigationView
     object? FooterMenuItemsSource { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the top and footer separators is visible.
+    /// </summary>
+    bool IsTopAndFooterSeparatorVisible { get; set; }
+
+    /// <summary>
     /// Gets the selected item.
     /// </summary>
     INavigationViewItem? SelectedItem { get; }

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -87,6 +87,14 @@ public partial class NavigationView
         new FrameworkPropertyMetadata(null, OnFooterMenuItemsSourceChanged)
     );
 
+    /// <summary>Identifies the <see cref="IsTopAndFooterSeparatorVisible"/> dependency property.</summary>
+    public static readonly DependencyProperty IsTopAndFooterSeparatorVisibleProperty = DependencyProperty.Register(
+        nameof(IsTopAndFooterSeparatorVisible),
+        typeof(bool),
+        typeof(NavigationView),
+        new FrameworkPropertyMetadata(true)
+    );
+
     /// <summary>Identifies the <see cref="ContentOverlay"/> dependency property.</summary>
     public static readonly DependencyProperty ContentOverlayProperty = DependencyProperty.Register(
         nameof(ContentOverlay),
@@ -313,6 +321,13 @@ public partial class NavigationView
                 SetValue(FooterMenuItemsSourceProperty, value);
             }
         }
+    }
+
+    /// <inheritdoc/>
+    public bool IsTopAndFooterSeparatorVisible
+    {
+        get => (bool)GetValue(IsTopAndFooterSeparatorVisibleProperty);
+        set => SetValue(IsTopAndFooterSeparatorVisibleProperty, value);
     }
 
     /// <inheritdoc/>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
@@ -357,6 +357,7 @@
 
                         <!--  Separator/Shadow for Top  -->
                         <Border
+                            x:Name="PART_TopSeparator"
                             Grid.Row="1"
                             Height="1"
                             Margin="0,4,0,4"
@@ -387,6 +388,7 @@
 
                         <!--  Separator/Shadow for Footer  -->
                         <Border
+                            x:Name="PART_FooterSeparator"
                             Grid.Row="3"
                             Height="1"
                             Margin="0,4,0,4"
@@ -500,6 +502,10 @@
             <Trigger Property="PaneTitle" Value="{x:Null}">
                 <Setter TargetName="PART_ToggleButton" Property="Content" Value="{x:Null}" />
                 <Setter TargetName="PART_ToggleButton" Property="HorizontalAlignment" Value="Left" />
+            </Trigger>
+            <Trigger Property="IsTopAndFooterSeparatorVisible" Value="False">
+                <Setter TargetName="PART_TopSeparator" Property="Visibility" Value="Collapsed" />
+                <Setter TargetName="PART_FooterSeparator" Property="Visibility" Value="Collapsed" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The NavigationView component has a separator at the top and another at the footer, but it is not possible to hide both.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added IsTopAndFooterSeparatorVisible property for NavigationView component.

![BkGfuuz38D](https://github.com/user-attachments/assets/23cce69f-e974-4438-908a-d41df906e284)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
