### PR TITLE
[Bug] Window Title Bar and Maximize Icon Not Updated Correctly When Restoring Maximized State via Code #1453

### DIFF
--- a/src/Wpf.Ui/Controls/ClientAreaBorder/ClientAreaBorder.cs
+++ b/src/Wpf.Ui/Controls/ClientAreaBorder/ClientAreaBorder.cs
@@ -146,6 +146,9 @@ public class ClientAreaBorder : System.Windows.Controls.Border, IThemeControl
         {
             newWindow.StateChanged -= OnWindowStateChanged; // Unsafe
             newWindow.StateChanged += OnWindowStateChanged;
+            Thickness padding =
+            newWindow.WindowState == WindowState.Maximized ? WindowChromeNonClientFrameThickness : default;
+            SetCurrentValue(PaddingProperty, padding);
             newWindow.Closing += OnWindowClosing;
         }
 

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -447,6 +447,11 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
 
         _currentWindow =
             System.Windows.Window.GetWindow(this) ?? throw new InvalidOperationException("Window is null");
+        if (_currentWindow.WindowState == WindowState.Maximized)
+        {
+            SetCurrentValue(IsMaximizedProperty, true);
+            _currentWindow.SetCurrentValue(Window.WindowStateProperty, WindowState.Maximized);
+        }
         _currentWindow.StateChanged += OnParentWindowStateChanged;
         _currentWindow.ContentRendered += OnWindowContentRendered;
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update  
- [x] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, renaming)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] Documentation content changes  

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when a window is maximized programmatically (e.g., `WindowState = Maximized` in code), the title bar may not visually adjust correctly, and the client area does not provide appropriate padding. This results in content overlapping with the system-reserved areas (such as the taskbar or screen edges), and the maximize button may not reflect the correct state.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Title bar now visually updates correctly when the window is maximized via code.
- Proper padding is applied to the client area, ensuring that UI elements are not hidden or cut off at the edges.
- The maximize button reflects the correct state, even when maximized programmatically.
- Changes are encapsulated in `ClientAreaBorder.cs` for maintainability and clarity.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This fix ensures consistency between manual and programmatic window maximization. It improves UX for developers who customize their window behavior via code without relying on the user manually clicking the maximize button.
