### PR TITLE
fix(controls): Tooltips, context menu, and comboboxes drop shadow

### DIFF
--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -181,10 +181,10 @@
                         <Border
                             x:Name="ContentBorder"
                             Grid.Row="0"
-                            MinWidth="{TemplateBinding MinWidth}"
-                            MinHeight="{TemplateBinding MinHeight}"                            
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MinHeight="{TemplateBinding MinHeight}"
                             Padding="0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
@@ -262,36 +262,50 @@
                                     Placement="{TemplateBinding Popup.Placement}"
                                     PopupAnimation="{TemplateBinding Popup.PopupAnimation}"
                                     VerticalOffset="1">
-                                    <Border
-                                        x:Name="DropDownBorder"
-                                        MinWidth="{TemplateBinding ActualWidth}"
-                                        Margin="0"
-                                        Padding="0,4,0,6"
-                                        Background="{DynamicResource ComboBoxDropDownBackground}"
-                                        BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="{DynamicResource PopupCornerRadius}"
-                                        SnapsToDevicePixels="True">
-                                        <Border.RenderTransform>
-                                            <TranslateTransform />
-                                        </Border.RenderTransform>
-                                        <Grid>
-                                            <controls:DynamicScrollViewer
-                                                MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                                                Margin="0"
-                                                HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                SnapsToDevicePixels="True"
-                                                TextElement.FontSize="{TemplateBinding FontSize}"
-                                                TextElement.FontWeight="{TemplateBinding FontWeight}"
-                                                TextElement.Foreground="{TemplateBinding Foreground}"
-                                                VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                                                <StackPanel
-                                                    IsItemsHost="True"
-                                                    KeyboardNavigation.DirectionalNavigation="Contained"
-                                                    TextElement.FontSize="{TemplateBinding FontSize}" />
-                                            </controls:DynamicScrollViewer>
-                                        </Grid>
-                                    </Border>
+                                    <controls:EffectThicknessDecorator
+                                        AnimationDelay="00:00:00.167"
+                                        AnimationElement="{Binding ElementName=DropDownBorder}"
+                                        Thickness="30,0,30,30">
+                                        <Border
+                                            x:Name="DropDownBorder"
+                                            MinWidth="{TemplateBinding ActualWidth}"
+                                            Margin="0"
+                                            Padding="0,4,0,6"
+                                            Background="{DynamicResource ComboBoxDropDownBackground}"
+                                            BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="{DynamicResource PopupCornerRadius}"
+                                            SnapsToDevicePixels="True">
+                                            <Border.RenderTransform>
+                                                <TranslateTransform />
+                                            </Border.RenderTransform>
+                                            <Border.Effect>
+                                                <DropShadowEffect
+                                                    BlurRadius="20"
+                                                    Direction="270"
+                                                    Opacity="0.135"
+                                                    ShadowDepth="10"
+                                                    Color="#202020" />
+                                            </Border.Effect>
+
+                                            <Grid>
+                                                <controls:DynamicScrollViewer
+                                                    MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                                    Margin="0"
+                                                    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                    SnapsToDevicePixels="True"
+                                                    TextElement.FontSize="{TemplateBinding FontSize}"
+                                                    TextElement.FontWeight="{TemplateBinding FontWeight}"
+                                                    TextElement.Foreground="{TemplateBinding Foreground}"
+                                                    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                                    <StackPanel
+                                                        IsItemsHost="True"
+                                                        KeyboardNavigation.DirectionalNavigation="Contained"
+                                                        TextElement.FontSize="{TemplateBinding FontSize}" />
+                                                </controls:DynamicScrollViewer>
+                                            </Grid>
+                                        </Border>
+                                    </controls:EffectThicknessDecorator>
                                 </Popup>
                             </Grid>
                         </Border>

--- a/src/Wpf.Ui/Controls/ContextMenu/ContextMenu.xaml
+++ b/src/Wpf.Ui/Controls/ContextMenu/ContextMenu.xaml
@@ -5,7 +5,10 @@
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
     <Style x:Key="UiContextMenu" TargetType="{x:Type ContextMenu}">
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ContextMenuForeground}" />
@@ -23,22 +26,32 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ContextMenu}">
-                    <Border
-                        x:Name="Border"
-                        Padding="0,3,0,3"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="1"
-                        CornerRadius="8">
-                        <Border.RenderTransform>
-                            <TranslateTransform />
-                        </Border.RenderTransform>
-                        <StackPanel
-                            ClipToBounds="True"
-                            IsItemsHost="True"
-                            KeyboardNavigation.DirectionalNavigation="Cycle"
-                            Orientation="Vertical" />
-                    </Border>
+                    <controls:EffectThicknessDecorator Thickness="30">
+                        <Border
+                            x:Name="Border"
+                            Padding="0,3,0,3"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="8">
+                            <Border.Effect>
+                                <DropShadowEffect
+                                    BlurRadius="20"
+                                    Direction="270"
+                                    Opacity="0.135"
+                                    ShadowDepth="10"
+                                    Color="#202020" />
+                            </Border.Effect>
+                            <Border.RenderTransform>
+                                <TranslateTransform />
+                            </Border.RenderTransform>
+                            <StackPanel
+                                ClipToBounds="True"
+                                IsItemsHost="True"
+                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                Orientation="Vertical" />
+                        </Border>
+                    </controls:EffectThicknessDecorator>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsOpen" Value="True">
                             <Trigger.EnterActions>

--- a/src/Wpf.Ui/Controls/EffectThicknessDecorator.cs
+++ b/src/Wpf.Ui/Controls/EffectThicknessDecorator.cs
@@ -1,0 +1,158 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace Wpf.Ui.Controls;
+
+public class EffectThicknessDecorator : Decorator
+{
+    public static readonly DependencyProperty ThicknessProperty =
+        DependencyProperty.Register(nameof(Thickness), typeof(Thickness), typeof(EffectThicknessDecorator), new PropertyMetadata(new Thickness(35), OnThicknessChanged));
+
+    private PopupContainer? _popupContainer;
+
+    public EffectThicknessDecorator()
+    {
+        SizeChanged += (_, _) => UpdateLayout();
+    }
+
+    /// <summary>
+    /// Gets or sets the thickness of the effect around the containing element.
+    /// </summary>
+    public Thickness Thickness
+    {
+        get { return (Thickness)GetValue(ThicknessProperty); }
+        set { SetValue(ThicknessProperty, value); }
+    }
+
+    /// <inheritdoc />
+    protected override int VisualChildrenCount => 1;
+
+    /// <inheritdoc />
+    protected override void OnVisualParentChanged(DependencyObject oldParent)
+    {
+        base.OnVisualParentChanged(oldParent);
+
+        if (IsInitialized)
+        {
+            SetPopupContainer();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Visual GetVisualChild(int index)
+    {
+        // Only 1 child...
+        return Child;
+    }
+
+    /// <inheritdoc />
+    protected override void OnInitialized(EventArgs e)
+    {
+        base.OnInitialized(e);
+
+        SetPopupContainer();
+    }
+
+    private void SetPopupContainer()
+    {
+        PopupContainer? popupContainer = null;
+
+        switch (VisualParent)
+        {
+            case ContextMenu contextMenu:
+                popupContainer = new PopupContainer(contextMenu);
+                break;
+            case ToolTip toolTip:
+                popupContainer = new PopupContainer(toolTip);
+                break;
+            default:
+                if (GetParentPopup(this) is { } parentPopup)
+                {
+                    popupContainer = new PopupContainer(parentPopup);
+                }
+
+                break;
+        }
+
+        if (_popupContainer?.FrameworkElement == popupContainer?.FrameworkElement)
+        {
+            return;
+        }
+
+        _popupContainer = popupContainer;
+        ApplyMargin();
+    }
+
+    private static Popup? GetParentPopup(FrameworkElement element)
+    {
+        while (true)
+        {
+            switch (element.Parent)
+            {
+                case Popup popup:
+                    return popup;
+                case FrameworkElement frameworkElement:
+                    element = frameworkElement;
+                    continue;
+            }
+
+            if (VisualTreeHelper.GetParent(element) is FrameworkElement parent)
+            {
+                element = parent;
+                continue;
+            }
+
+            return null;
+        }
+    }
+
+    private static void OnThicknessChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is EffectThicknessDecorator decorator)
+        {
+            decorator.ApplyMargin();
+        }
+    }
+
+    private void ApplyMargin()
+    {
+        _popupContainer?.SetMargin(Thickness);
+    }
+
+    private class PopupContainer
+    {
+        private readonly ContextMenu? _contextMenu;
+        private readonly Popup? _popup;
+        private readonly ToolTip? _toolTip;
+
+        public FrameworkElement? FrameworkElement => _contextMenu ?? _toolTip ?? _popup?.Child as FrameworkElement;
+
+        public PopupContainer(ContextMenu contextMenu)
+        {
+            _contextMenu = contextMenu;
+        }
+
+        public PopupContainer(ToolTip toolTip)
+        {
+            _toolTip = toolTip;
+        }
+
+        public PopupContainer(Popup popup)
+        {
+            _popup = popup;
+        }
+
+        public void SetMargin(Thickness margin)
+        {
+            if (FrameworkElement is { } frameworkElement)
+            {
+                frameworkElement.Margin = margin;
+            }
+        }
+    }
+}

--- a/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
+++ b/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
@@ -108,8 +108,9 @@
                                 <DropShadowEffect
                                     BlurRadius="20"
                                     Direction="270"
-                                    Opacity="0.25"
-                                    ShadowDepth="6" />
+                                    Opacity="0.135"
+                                    ShadowDepth="10"
+                                    Color="#202020" />
                             </Border.Effect>
                         </Border>
                     </Grid>
@@ -399,7 +400,7 @@
                 <Grid>
                     <Border
                         x:Name="SubmenuBorder"
-                        Margin="12,10,12,18"
+                        Margin="12,10,12,30"
                         Padding="0,3,0,3"
                         Background="{DynamicResource FlyoutBackground}"
                         BorderBrush="{DynamicResource FlyoutBorderBrush}"
@@ -416,8 +417,9 @@
                             <DropShadowEffect
                                 BlurRadius="20"
                                 Direction="270"
-                                Opacity="0.5"
-                                ShadowDepth="6" />
+                                Opacity="0.135"
+                                ShadowDepth="10"
+                                Color="#202020" />
                         </Border.Effect>
                     </Border>
                 </Grid>
@@ -584,8 +586,9 @@
                                 <DropShadowEffect
                                     BlurRadius="20"
                                     Direction="270"
-                                    Opacity="0.25"
-                                    ShadowDepth="6" />
+                                    Opacity="0.135"
+                                    ShadowDepth="10"
+                                    Color="#202020" />
                             </Border.Effect>
                         </Border>
                     </Grid>
@@ -906,8 +909,9 @@
                             <DropShadowEffect
                                 BlurRadius="20"
                                 Direction="270"
-                                Opacity="0.5"
-                                ShadowDepth="6" />
+                                Opacity="0.135"
+                                ShadowDepth="10"
+                                Color="#202020" />
                         </Border.Effect>
                     </Border>
                 </Grid>

--- a/src/Wpf.Ui/Controls/ToolTip/ToolTip.xaml
+++ b/src/Wpf.Ui/Controls/ToolTip/ToolTip.xaml
@@ -5,7 +5,10 @@
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
     <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
         <Setter Property="MaxWidth" Value="260" />
@@ -22,36 +25,38 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
-                    <Border
-                        Name="Border"
-                        Width="{TemplateBinding Width}"
-                        Height="{TemplateBinding Height}"
-                        MaxWidth="{TemplateBinding MaxWidth}"
-                        Padding="8"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="1"
-                        CornerRadius="4"
-                        SnapsToDevicePixels="True">
-                        <Border.Effect>
-                            <DropShadowEffect
-                                BlurRadius="30"
-                                Direction="0"
-                                Opacity="0.4"
-                                ShadowDepth="0"
-                                Color="#202020" />
-                        </Border.Effect>
-                        <ContentPresenter
-                            Margin="4"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Top">
-                            <ContentPresenter.Resources>
-                                <Style TargetType="{x:Type TextBlock}">
-                                    <Setter Property="TextWrapping" Value="WrapWithOverflow" />
-                                </Style>
-                            </ContentPresenter.Resources>
-                        </ContentPresenter>
-                    </Border>
+                    <controls:EffectThicknessDecorator Thickness="15">
+                        <Border
+                            Name="Border"
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Height}"
+                            MaxWidth="{TemplateBinding MaxWidth}"
+                            Padding="8"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            SnapsToDevicePixels="True">
+                            <Border.Effect>
+                                <DropShadowEffect
+                                    BlurRadius="10"
+                                    Direction="270"
+                                    Opacity="0.135"
+                                    ShadowDepth="5"
+                                    Color="#202020" />
+                            </Border.Effect>
+                            <ContentPresenter
+                                Margin="4"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top">
+                                <ContentPresenter.Resources>
+                                    <Style TargetType="{x:Type TextBlock}">
+                                        <Setter Property="TextWrapping" Value="WrapWithOverflow" />
+                                    </Style>
+                                </ContentPresenter.Resources>
+                            </ContentPresenter>
+                        </Border>
+                    </controls:EffectThicknessDecorator>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, the drop shadow used by tooltips and context menus are broken. This is because effects get clipped.
![image](https://github.com/user-attachments/assets/2a0a9009-b4cf-40b0-9f70-27deced309df)


## What is the new behavior?

 The solution is to add a decorator that wraps around it. I also updated the dropshadows to follow original colors (they were far too dark). The tooltips have less shadow than context menus in WinUI.

![image](https://github.com/user-attachments/assets/c4a7d3d9-bcc4-4bd1-b1d8-a60d269980d4)
![image](https://github.com/user-attachments/assets/6c275bc7-87ea-4ef9-94ca-bcb535392f9c)
