### PR TITLE
feat(windows): Added event to forward `TitleBar` HwndProc to avoid adding additional hooks and timing issues

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/HwndProcEventArgs.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/HwndProcEventArgs.cs
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+// ReSharper disable once CheckNamespace
+namespace Wpf.Ui.Controls;
+
+public class HwndProcEventArgs : EventArgs
+{
+    public bool Handled { get; set; }
+
+    public IntPtr? ReturnValue { get; set; }
+
+    public bool IsMouseOverDetectedHeaderContent { get; }
+
+    public IntPtr HWND { get; }
+
+    public int Message { get; }
+
+    public IntPtr WParam { get; }
+
+    public IntPtr LParam { get; }
+
+    internal HwndProcEventArgs(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, bool isMouseOverDetectedHeaderContent)
+    {
+        HWND = hwnd;
+        Message = msg;
+        WParam = wParam;
+        LParam = lParam;
+        IsMouseOverDetectedHeaderContent = isMouseOverDetectedHeaderContent;
+    }
+}

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -37,6 +37,8 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
 
     private DependencyObject? _parentWindow;
 
+    public event EventHandler<HwndProcEventArgs>? WndProcInvoked;
+
     /// <summary>Identifies the <see cref="ApplicationTheme"/> dependency property.</summary>
     public static readonly DependencyProperty ApplicationThemeProperty = DependencyProperty.Register(
         nameof(ApplicationTheme),
@@ -680,6 +682,15 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
             {
                 isMouseOverHeaderContent = headerRightUiElement?.IsMouseOverElement(lParam) ?? false;
             }
+        }
+
+        var e = new HwndProcEventArgs(hwnd, msg, wParam, lParam, isMouseOverHeaderContent);
+        WndProcInvoked?.Invoke(this, e);
+
+        if (e.ReturnValue != null)
+        {
+            handled = e.Handled;
+            return e.ReturnValue ?? IntPtr.Zero;
         }
 
         switch (message)


### PR DESCRIPTION
Customizing titlebar behavior has proven difficult ever since WPFUI switched to using a Hwnd Hook to process WM_xxx messages.  
Notably, customizing the drag regions requires either XAML hacks or additional hooks on top of the base WPFUI one.  

This change allows client apps to use and override `HwndSourceHook` if desired, to either add additional functionality or block the base one.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

`HwndSourceHook` cannot be interacted with in any way when using the Titlebar control

Issue Number: N/A

## What is the new behavior?

- An additional `WndProcInvoked` event has been added that can be subscribed to from the Titlebar
- This event is called with `HwndProcEventArgs` containing the hwnd and the hook when the titlebar receives a WM_xxxx message
- Client apps can use `e.Handled` to bypass WPFUI's handling of said messages

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
