### PR TITLE
fix(controls): `ComboBox` not respecting container

### DIFF
--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -260,6 +260,7 @@
                                     Focusable="False"
                                     IsOpen="{TemplateBinding IsDropDownOpen}"
                                     Placement="{TemplateBinding Popup.Placement}"
+                                    PlacementTarget="{Binding ElementName=ContentBorder}"
                                     PopupAnimation="{TemplateBinding Popup.PopupAnimation}"
                                     VerticalOffset="1">
                                     <Border


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, the ComboBox dropdown is placed wrong if for example the height or paddings are changed. 
![image](https://github.com/user-attachments/assets/5ccf977e-99e4-4922-be8d-87096a5ade71)

Old:
![image](https://github.com/user-attachments/assets/43cd93a4-d826-481e-a7f1-a9272cd65974)

New:
![image](https://github.com/user-attachments/assets/1f2160d8-6a17-4d81-93ca-736cdefbb83f)

Basically it should be placed around the container. WinUI also does this.