### PR TITLE
Allow specifying a background for a ListViewItem

### DIFF
--- a/src/Wpf.Ui/Controls/ListView/ListViewItem.xaml
+++ b/src/Wpf.Ui/Controls/ListView/ListViewItem.xaml
@@ -10,12 +10,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
+    <SolidColorBrush x:Key="ListViewItemBackground">Transparent</SolidColorBrush>
+
     <ControlTemplate x:Key="NullViewItemTemplate" TargetType="{x:Type controls:ListViewItem}">
         <Border
             x:Name="Border"
             Margin="0"
             Padding="0"
-            Background="Transparent"
+            Background="{DynamicResource ListViewItemBackground}"
             BorderThickness="1"
             CornerRadius="{TemplateBinding Border.CornerRadius}">
             <Grid>
@@ -53,7 +55,7 @@
             x:Name="Border"
             Margin="0"
             Padding="0"
-            Background="Transparent"
+            Background="{DynamicResource ListViewItemBackground}"
             BorderBrush="{TemplateBinding Border.BorderBrush}"
             BorderThickness="{TemplateBinding Border.BorderThickness}"
             CornerRadius="{TemplateBinding Border.CornerRadius}">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, the ListViewItems are fixed to Transparent with no way to override this behavior. This adds a new property that can be used to specify the color.