### PR TITLE
fix(controls): `TreeViewItem` going out of bounds

### DIFF
--- a/src/Wpf.Ui/Controls/TreeView/TreeViewItem.xaml
+++ b/src/Wpf.Ui/Controls/TreeView/TreeViewItem.xaml
@@ -97,7 +97,6 @@
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" MinWidth="19" />
-                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Rectangle
@@ -131,13 +130,11 @@
                         <Grid Grid.Row="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" MinWidth="19" />
-                                <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <ItemsPresenter
                                 x:Name="ItemsHost"
                                 Grid.Column="1"
-                                Grid.ColumnSpan="2"
                                 Visibility="Collapsed" />
                         </Grid>
                     </Grid>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Presumably this was copied from ui:TreeViewItem where an Icon exists, but this isn't present in the normal one. With "Auto" it goes out of the view if the text is too large (and you have a wrapping textblock). The fix is to use * to fill the remainder.