### PR TITLE
feat: add `CanClose` property to TitleBar component

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -140,6 +140,14 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
         new PropertyMetadata(true)
     );
 
+    /// <summary>Identifies the <see cref="CanClose"/> dependency property.</summary>
+    public static readonly DependencyProperty CanCloseProperty = DependencyProperty.Register(
+        nameof(CanClose),
+        typeof(bool),
+        typeof(TitleBar),
+        new PropertyMetadata(true)
+    );
+
     /// <summary>Identifies the <see cref="CanMaximize"/> dependency property.</summary>
     public static readonly DependencyProperty CanMaximizeProperty = DependencyProperty.Register(
         nameof(CanMaximize),
@@ -313,6 +321,15 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
     {
         get => (bool)GetValue(ShowCloseProperty);
         set => SetValue(ShowCloseProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the closing window functionality is enabled.
+    /// </summary>
+    public bool CanClose
+    {
+        get => (bool)GetValue(CanCloseProperty);
+        set => SetValue(CanCloseProperty, value);
     }
 
     /// <summary>
@@ -508,6 +525,11 @@ public class TitleBar : System.Windows.Controls.Control, IThemeControl
 
     private void CloseWindow()
     {
+        if (!CanClose)
+        {
+            return;
+        }
+
         Debug.WriteLine(
             $"INFO | {typeof(TitleBar)}.CloseWindow:ForceShutdown -  {ForceShutdown}",
             "Wpf.Ui.TitleBar"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using `TitleBar` component and clicking close button of it, there is no way to prevent window from closing.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `CanClose` defaults to `true`, which is the current behavior.
- When setting `CanClose` to `false`, `CloseWindow` method will return immediately so window won't open. To prevent user from using `ForceShutdown` property by accident,  setting `CanClose` to `false` takes higher priority to `ForceShutdown` property.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Why we need this property?  
Before closing window, we may need to let user confirm their progress before the window actually close.  
In [MSDN documentation](https://learn.microsoft.com/en-us/dotnet/api/system.windows.window.closing?view=windowsdesktop-9.0), we can easily archive this by combining `Window.Closing` event and `MessageBox.Show` method.  
The problem is, WPF UI provides `ContentDialogService` which can open a fancy dialog for user to confirm, but that unfortunately, is not supported in `Window.Closing` event: Window will close directly without letting user confirm, see the sample code below:  

> I'm NOT using MVVM behaviors event triggers below in order to simplify illustration code.

```cs
public ContentDialogService ContentDialogService { get; set; }
private async void MyFluentWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e) {
    // the `await` simply does not "block" whole window, so the window just close directly without popping out the `ContentDialog`
    if (ContentDialogResult.Primary != await this.ContentDialogService.ShowAsync(new ContentDialog() { 
        Title = "Please Confirm",
        Content = "Sure to close window? Edits may not be saved.",
        PrimaryButtonText = "Yes, Close",
        CloseButtonText = "No",
        IsSecondaryButtonEnabled = false,
    }, default)) {
        e.Cancel = true;
    }
}
```

To address this issue, we can simply set `TitleBar.CanClose` to `false`, and use `TitleBar.CloseClicked` event to manually close window:  

```cs
private async void titleBar_CloseClicked(TitleBar sender, System.Windows.RoutedEventArgs args) {
    if (ContentDialogResult.Primary == await this.ContentDialogService.ShowAsync(new ContentDialog() {
        Title = "Please Confirm",
        Content = "Sure to close window? Edits may not be saved.",
        PrimaryButtonText = "Yes, Close",
        CloseButtonText = "No",
        IsSecondaryButtonEnabled = false,
    }, default)) {
        this.Close();
    }
}
```

In xaml:  

```xaml
<ui:TitleBar
    x:Name="titleBar"
    CanClose="False"
    CloseClicked="titleBar_CloseClicked"
    Title="Title" />
```

So that's why I'm adding `CanClose` property to `TitleBar` component.