### PR TITLE
Fix FluentWindow background with None backdrop extending into window

### DIFF
--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -103,7 +103,7 @@ public class FluentWindow : System.Windows.Window
     protected override void OnSourceInitialized(EventArgs e)
     {
         OnCornerPreferenceChanged(default, WindowCornerPreference);
-        OnExtendsContentIntoTitleBarChanged(default, ExtendsContentIntoTitleBar);
+        OnExtendsContentIntoTitleBarChanged(false, ExtendsContentIntoTitleBar);
         OnBackdropTypeChanged(default, WindowBackdropType);
 
         base.OnSourceInitialized(e);
@@ -182,10 +182,11 @@ public class FluentWindow : System.Windows.Window
             return;
         }
 
+        SetWindowChrome();
+
         if (newValue == WindowBackdropType.None)
         {
             _ = WindowBackdrop.RemoveBackdrop(this);
-
             return;
         }
 
@@ -233,20 +234,23 @@ public class FluentWindow : System.Windows.Window
         // AllowsTransparency = true;
         SetCurrentValue(WindowStyleProperty, WindowStyle.SingleBorderWindow);
 
-        WindowChrome.SetWindowChrome(
-            this,
-            new WindowChrome
-            {
-                CaptionHeight = 0,
-                CornerRadius = default,
-                GlassFrameThickness = new Thickness(-1),
-                ResizeBorderThickness = ResizeMode == ResizeMode.NoResize ? default : new Thickness(4),
-                UseAeroCaptionButtons = false,
-            }
-        );
-
         // WindowStyleProperty.OverrideMetadata(typeof(FluentWindow), new FrameworkPropertyMetadata(WindowStyle.SingleBorderWindow));
         // AllowsTransparencyProperty.OverrideMetadata(typeof(FluentWindow), new FrameworkPropertyMetadata(false));
         _ = UnsafeNativeMethods.RemoveWindowTitlebarContents(this);
+    }
+
+    private void SetWindowChrome()
+    {
+        WindowChrome.SetWindowChrome(
+                                     this,
+                                     new WindowChrome
+                                     {
+                                         CaptionHeight = 0,
+                                         CornerRadius = default,
+                                         GlassFrameThickness = WindowBackdropType == WindowBackdropType.None ? new Thickness(1) : new Thickness(-1),
+                                         ResizeBorderThickness = ResizeMode == ResizeMode.NoResize ? default : new Thickness(4),
+                                         UseAeroCaptionButtons = false,
+                                     }
+                                    );
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Due to using `GlassFrameThickness` of `-1`, it looks like the background extends into the Window with `WindowBackdropType.None`.

<img width="251" height="493" alt="image" src="https://github.com/user-attachments/assets/06f7b747-e03b-4ee9-afe0-a57de7a357e5" />


## What is the new behavior?
Use a `GlassFrameThickness` of `1` if `WindowBackdropType.None` is used.

