### PR TITLE
feat(controls): Add setting border color + fix background extending inside `FluentWindow`

### DIFF
--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -110,7 +110,7 @@ public class FluentWindow : System.Windows.Window
 
         if (Utilities.IsOSWindows11OrNewer)
         {
-            UnsafeNativeMethods.ApplyBorderColor(this, ApplicationAccentColorManager.PrimaryAccent);
+            UnsafeNativeMethods.ApplyBorderColor(this, ApplicationAccentColorManager.SystemAccent);
         }
 
         base.OnSourceInitialized(e);

--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -280,16 +280,26 @@ public class FluentWindow : System.Windows.Window
     /// </summary>
     protected virtual void SetWindowChrome()
     {
-        WindowChrome.SetWindowChrome(
-                                     this,
-                                     new WindowChrome
-                                     {
-                                         CaptionHeight = 0,
-                                         CornerRadius = default,
-                                         GlassFrameThickness = WindowBackdropType == WindowBackdropType.None ? new Thickness(0.00001) : new Thickness(-1), // 0.00001 so there's no glass frame drawn around the window, but the border is still drawn.
-                                         ResizeBorderThickness = ResizeMode == ResizeMode.NoResize ? default : new Thickness(4),
-                                         UseAeroCaptionButtons = false,
-                                     }
-                                    );
+        try
+        {
+            if (Utilities.IsCompositionEnabled)
+            {
+                WindowChrome.SetWindowChrome(
+                                          this,
+                                          new WindowChrome
+                                          {
+                                              CaptionHeight = 0,
+                                              CornerRadius = default,
+                                              GlassFrameThickness = WindowBackdropType == WindowBackdropType.None ? new Thickness(0.00001) : new Thickness(-1), // 0.00001 so there's no glass frame drawn around the window, but the border is still drawn.
+                                              ResizeBorderThickness = ResizeMode == ResizeMode.NoResize ? default : new Thickness(4),
+                                              UseAeroCaptionButtons = false,
+                                          }
+                                         );
+            }
+        }
+        catch (COMException)
+        {
+            // Ignored.
+        }
     }
 }

--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -4,7 +4,9 @@
 // All Rights Reserved.
 
 using System.Windows.Shell;
+using Wpf.Ui.Appearance;
 using Wpf.Ui.Interop;
+using Wpf.Ui.Win32;
 
 // ReSharper disable once CheckNamespace
 namespace Wpf.Ui.Controls;
@@ -105,6 +107,11 @@ public class FluentWindow : System.Windows.Window
         OnCornerPreferenceChanged(default, WindowCornerPreference);
         OnExtendsContentIntoTitleBarChanged(default, ExtendsContentIntoTitleBar);
         OnBackdropTypeChanged(default, WindowBackdropType);
+
+        if (Utilities.IsOSWindows11OrNewer)
+        {
+            UnsafeNativeMethods.ApplyBorderColor(this, ApplicationAccentColorManager.PrimaryAccent);
+        }
 
         base.OnSourceInitialized(e);
     }

--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -84,6 +84,17 @@ public class FluentWindow : System.Windows.Window
     public FluentWindow()
     {
         SetResourceReference(StyleProperty, typeof(FluentWindow));
+
+        if (Utilities.IsOSWindows11OrNewer)
+        {
+            ApplicationThemeManager.Changed += (_, _) =>
+            {
+                if (IsActive)
+                {
+                    UnsafeNativeMethods.ApplyBorderColor(this, ApplicationAccentColorManager.SystemAccent);
+                }
+            };
+        }
     }
 
     /// <summary>

--- a/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
+++ b/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
@@ -85,8 +85,7 @@ public static class UnsafeNativeMethods
     /// <returns><see langword="true"/> if invocation of native Windows function succeeds.</returns>
     public static bool ApplyBorderColor(IntPtr handle, Color color)
     {
-        int colorNum = (color.B << 16) | (color.G << 8) | color.R;
-        return ApplyBorderColor(handle, colorNum);
+        return ApplyBorderColor(handle, (color.B << 16) | (color.G << 8) | color.R);
     }
 
     /// <summary>

--- a/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
+++ b/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
@@ -70,10 +70,32 @@ public static class UnsafeNativeMethods
     /// <summary>
     /// Tries to apply the color of the border.
     /// </summary>
+    /// <param name="window">The window.</param>
+    /// <param name="color">The color.</param>
+    /// <returns><see langword="true" /> if invocation of native Windows function succeeds.</returns>
+    public static bool ApplyBorderColor(Window window, int color) =>
+        GetHandle(window, out IntPtr windowHandle)
+     && ApplyBorderColor(windowHandle, color);
+
+    /// <summary>
+    /// Tries to apply the color of the border.
+    /// </summary>
     /// <param name="handle">The handle.</param>
     /// <param name="color">The color.</param>
     /// <returns><see langword="true"/> if invocation of native Windows function succeeds.</returns>
     public static bool ApplyBorderColor(IntPtr handle, Color color)
+    {
+        int colorNum = (color.B << 16) | (color.G << 8) | color.R;
+        return ApplyBorderColor(handle, colorNum);
+    }
+
+    /// <summary>
+    /// Tries to apply the color of the border.
+    /// </summary>
+    /// <param name="handle">The handle.</param>
+    /// <param name="color">The color.</param>
+    /// <returns><see langword="true"/> if invocation of native Windows function succeeds.</returns>
+    public static bool ApplyBorderColor(IntPtr handle, int color)
     {
         if (handle == IntPtr.Zero)
         {
@@ -85,8 +107,7 @@ public static class UnsafeNativeMethods
             return false;
         }
 
-        int colorNum = (color.B << 16) | (color.G << 8) | color.R;
-        return Dwmapi.DwmSetWindowAttribute(handle, Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR, ref colorNum, sizeof(int)) == 0;
+        return Dwmapi.DwmSetWindowAttribute(handle, Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR, ref color, sizeof(int)) == 0;
     }
 
     /// <summary>

--- a/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
+++ b/src/Wpf.Ui/Interop/UnsafeNativeMethods.cs
@@ -49,15 +49,44 @@ public static class UnsafeNativeMethods
 
         int pvAttribute = (int)UnsafeReflection.Cast(cornerPreference);
 
-        // TODO: Validate HRESULT
-        _ = Dwmapi.DwmSetWindowAttribute(
+        return Dwmapi.DwmSetWindowAttribute(
             handle,
             Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE,
             ref pvAttribute,
             Marshal.SizeOf(typeof(int))
-        );
+        ) == 0;
+    }
 
-        return true;
+    /// <summary>
+    /// Tries to apply the color of the border.
+    /// </summary>
+    /// <param name="window">The window.</param>
+    /// <param name="color">The color.</param>
+    /// <returns><see langword="true" /> if invocation of native Windows function succeeds.</returns>
+    public static bool ApplyBorderColor(Window window, Color color) =>
+        GetHandle(window, out IntPtr windowHandle)
+     && ApplyBorderColor(windowHandle, color);
+
+    /// <summary>
+    /// Tries to apply the color of the border.
+    /// </summary>
+    /// <param name="handle">The handle.</param>
+    /// <param name="color">The color.</param>
+    /// <returns><see langword="true"/> if invocation of native Windows function succeeds.</returns>
+    public static bool ApplyBorderColor(IntPtr handle, Color color)
+    {
+        if (handle == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        if (!User32.IsWindow(handle))
+        {
+            return false;
+        }
+
+        int colorNum = (color.B << 16) | (color.G << 8) | color.R;
+        return Dwmapi.DwmSetWindowAttribute(handle, Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR, ref colorNum, sizeof(int)) == 0;
     }
 
     /// <summary>
@@ -93,10 +122,7 @@ public static class UnsafeNativeMethods
             dwAttribute = Dwmapi.DWMWINDOWATTRIBUTE.DMWA_USE_IMMERSIVE_DARK_MODE_OLD;
         }
 
-        // TODO: Validate HRESULT
-        _ = Dwmapi.DwmSetWindowAttribute(handle, dwAttribute, ref pvAttribute, Marshal.SizeOf(typeof(int)));
-
-        return true;
+        return Dwmapi.DwmSetWindowAttribute(handle, dwAttribute, ref pvAttribute, Marshal.SizeOf(typeof(int))) == 0;
     }
 
     /// <summary>
@@ -132,10 +158,7 @@ public static class UnsafeNativeMethods
             dwAttribute = Dwmapi.DWMWINDOWATTRIBUTE.DMWA_USE_IMMERSIVE_DARK_MODE_OLD;
         }
 
-        // TODO: Validate HRESULT
-        _ = Dwmapi.DwmSetWindowAttribute(handle, dwAttribute, ref pvAttribute, Marshal.SizeOf(typeof(int)));
-
-        return true;
+        return Dwmapi.DwmSetWindowAttribute(handle, dwAttribute, ref pvAttribute, Marshal.SizeOf(typeof(int))) == 0;
     }
 
     /// <summary>
@@ -214,15 +237,12 @@ public static class UnsafeNativeMethods
             return false;
         }
 
-        // TODO: Validate HRESULT
-        _ = Dwmapi.DwmSetWindowAttribute(
+        return Dwmapi.DwmSetWindowAttribute(
             handle,
             Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE,
             ref backdropPvAttribute,
             Marshal.SizeOf(typeof(int))
-        );
-
-        return true;
+        ) == 0;
     }
 
     /// <summary>
@@ -296,15 +316,12 @@ public static class UnsafeNativeMethods
     {
         var backdropPvAttribute = 0x1; // Enable
 
-        // TODO: Validate HRESULT
-        _ = Dwmapi.DwmSetWindowAttribute(
+        return Dwmapi.DwmSetWindowAttribute(
             handle,
             Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_MICA_EFFECT,
             ref backdropPvAttribute,
             Marshal.SizeOf(typeof(int))
-        );
-
-        return true;
+        ) == 0;
     }
 
     /// <summary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, WPF-UI doesn't set the border color based on accent. This adds that.
Old left, right new.

<img width="317" height="249" alt="image" src="https://github.com/user-attachments/assets/fdcb4dbb-aac5-42b7-a3e5-79efac34a3f0" />
