### PR TITLE
Fixed FrameMargin being overwritten by OnTitleBarChanged.

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -240,7 +240,7 @@ public partial class NavigationView
         nameof(FrameMargin),
         typeof(Thickness),
         typeof(NavigationView),
-        new FrameworkPropertyMetadata(default(Thickness))
+        new FrameworkPropertyMetadata(FrameMarginDefault)
     );
 
     /// <summary>
@@ -650,7 +650,6 @@ public partial class NavigationView
 
         if (e.NewValue is null && e.OldValue is TitleBar oldValue)
         {
-            navigationView.FrameMargin = new Thickness(0);
             oldValue.Margin = new Thickness(0);
 
             if (navigationView.AutoSuggestBox?.Margin == AutoSuggestBoxMarginDefault)
@@ -666,7 +665,6 @@ public partial class NavigationView
             return;
         }
 
-        navigationView.FrameMargin = FrameMarginDefault;
         titleBar.Margin = TitleBarPaneOpenMarginDefault;
 
         if (navigationView.AutoSuggestBox?.Margin is { Bottom: 0, Left: 0, Right: 0, Top: 0 })


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Even if you set the FrameMargin of ui:NavigationView to 0, FrameMarginDefault is always set.
- Setting FrameMarginDefault where the FrameMargin dependency property is registered works fine.
<img width="1376" height="937" alt="OverwriteFrameMargin_2025-08-24_12h58_28" src="https://github.com/user-attachments/assets/84251775-a6aa-48d8-8914-f62ee61630cb" />

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
