### PR TITLE
Fix TextBox clear button design

### DIFF
--- a/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
+++ b/src/Wpf.Ui/Controls/TextBox/TextBox.xaml
@@ -192,7 +192,11 @@
                         Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}"
                         Cursor="Arrow"
                         Foreground="{DynamicResource TextControlButtonForeground}"
-                        IsTabStop="False">
+                        IsTabStop="False"
+                        MouseOverBackground="{DynamicResource SubtleFillColorSecondaryBrush}"
+                        MouseOverBorderBrush="Transparent"
+                        PressedBackground="{DynamicResource SubtleFillColorTertiaryBrush}"
+                        PressedBorderBrush="Transparent">
                         <controls:Button.Icon>
                             <controls:SymbolIcon FontSize="{TemplateBinding FontSize}" Symbol="Dismiss24" />
                         </controls:Button.Icon>
@@ -253,6 +257,7 @@
                     <Condition Property="IsEnabled" Value="True" />
                     <Condition Property="IsMouseOver" Value="True" />
                     <Condition Property="IsFocused" Value="False" />
+                    <Condition SourceName="ClearButton" Property="IsFocused" Value="False" />
                 </MultiTrigger.Conditions>
                 <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource TextControlBackgroundPointerOver}" />
             </MultiTrigger>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, the clear button of a TextBox has a wrong design, it doesn't have the right hover colors and has a border. This addresses it to match WinUI. I also fixed focus loss on clear button to match WinUI.

<img width="1621" height="150" alt="image" src="https://github.com/user-attachments/assets/bfb2d4e0-a16f-4655-9bb2-e696518b35f3" />
