### PR TITLE
fix(controls): `DropDownButton` not working inside ToolBar overflow

### DIFF
--- a/src/Wpf.Ui/Controls/DropDownButton/DropDownButton.cs
+++ b/src/Wpf.Ui/Controls/DropDownButton/DropDownButton.cs
@@ -18,7 +18,7 @@ public class DropDownButton : Button
 
     public DropDownButton()
     {
-        PreviewMouseLeftButtonUp += OnDropDownButtonOnPreviewMouseLeftButtonUp;
+        PreviewMouseLeftButtonUp += OnPreviewMouseLeftButtonUp;
     }
 
     /// <summary>Identifies the <see cref="Flyout"/> dependency property.</summary>
@@ -93,7 +93,7 @@ public class DropDownButton : Button
 
     protected virtual void OnIsDropDownOpenChanged(bool currentValue) { }
 
-    private void OnDropDownButtonOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    private void OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
         if (_contextMenu is null)
         {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

If you have a dropdown button inside a ToolBar overflow container, it's closing the overflow. Change the Click handler instead to a PreviewMouseLeftButtonUp, which is also what SplitButton does per PR https://github.com/lepoco/wpfui/pull/1498/, so it'll handle everything correctly.