### PR TITLE
Fix NavigationViewBasePaneButtonStyle using wrong colors and animation

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewBasePaneButtonStyle.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewBasePaneButtonStyle.xaml
@@ -62,7 +62,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="LayoutRoot" Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+                            <Setter TargetName="LayoutRoot" Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="LayoutRoot" Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
@@ -78,7 +81,7 @@
                                         Storyboard.TargetName="IconScaleTransform"
                                         Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                                         From="1.0"
-                                        To="0.85"
+                                        To="0.66"
                                         Duration="0:0:0.08" />
                                 </Storyboard>
                             </BeginStoryboard>
@@ -89,7 +92,7 @@
                                     <DoubleAnimation
                                         Storyboard.TargetName="IconScaleTransform"
                                         Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
-                                        From="0.85"
+                                        From="0.66"
                                         To="1.0"
                                         Duration="0:0:0.08" />
                                 </Storyboard>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

1. The mouseover/pressed colors are wrong, I've corrected them to match WinUI.
2. The animation didn't scale down enough compared to WinUI.

New version:

https://github.com/user-attachments/assets/e300b6d4-707b-460e-9c52-b2f6302cddc8

