### PR TITLE
Fix ToolTip taking parent lineheight and size into account

### DIFF
--- a/src/Wpf.Ui/Controls/ToolTip/ToolTip.xaml
+++ b/src/Wpf.Ui/Controls/ToolTip/ToolTip.xaml
@@ -12,6 +12,8 @@
         <Setter Property="Height" Value="Auto" />
         <Setter Property="Width" Value="Auto" />
         <Setter Property="TextElement.FontSize" Value="12" />
+        <Setter Property="TextElement.FontWeight" Value="Normal" />
+        <Setter Property="TextBlock.LineHeight" Value="16" />
         <Setter Property="TextBlock.TextAlignment" Value="Justify" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ToolTipForeground}" />
         <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

ToolTip currently sets the internal FontSize to 12, that's OK, but the LineHeight and FontWeight should also be set to ensure that if you have a parent element (e.g., a TextBlock) with say FontWeight SemiBold and LineHeight 28, these don't get used by ToolTip, which looks like a huge amount of padding at the bottom due to the line height. 