### PR TITLE
fix(controls): `NavigationView` top separator

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
@@ -357,6 +357,7 @@
 
                         <!--  Separator/Shadow for Top  -->
                         <Border
+                            x:Name="PART_TopSeparator"
                             Grid.Row="1"
                             Height="1"
                             Margin="0,4,0,4"
@@ -494,8 +495,18 @@
                 <Setter TargetName="AutoSuggestBoxContentPresenter" Property="Visibility" Value="Collapsed" />
                 <Setter TargetName="PART_ToggleButton" Property="Content" Value="{x:Null}" />
             </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsBackButtonVisible" Value="Collapsed" />
+                    <Condition Property="IsPaneToggleVisible" Value="False" />
+                    <Condition Property="AutoSuggestBox" Value="{x:Null}" />
+                    <Condition Property="PaneHeader" Value="{x:Null}" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_TopSeparator" Property="Visibility" Value="Collapsed" />
+            </MultiTrigger>
             <Trigger Property="AutoSuggestBox" Value="{x:Null}">
                 <Setter TargetName="PART_AutoSuggestBoxSymbolButton" Property="Visibility" Value="Collapsed" />
+                <Setter TargetName="AutoSuggestBoxContentPresenter" Property="Visibility" Value="Collapsed" />
             </Trigger>
             <Trigger Property="PaneTitle" Value="{x:Null}">
                 <Setter TargetName="PART_ToggleButton" Property="Content" Value="{x:Null}" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Fixes two issues:
- If AutoSuggestBox is null, AutoSuggestBoxContentPresenter should also be hidden to avoid a margin of 6.
- If all content above the menu items (back button, toggler, auto suggest box, pane header) are null/collapsed, the separator should be collapsed to avoid a 9px block.