### PR TITLE
Check if UIElement is connected to presentation source

### DIFF
--- a/src/Wpf.Ui/Extensions/UiElementExtensions.cs
+++ b/src/Wpf.Ui/Extensions/UiElementExtensions.cs
@@ -10,7 +10,7 @@ internal static class UiElementExtensions
     /// <summary>
     /// Do not call it outside of NCHITTEST, NCLBUTTONUP, NCLBUTTONDOWN messages!
     /// </summary>
-    /// <returns><see langword="true"/> if mouse is over the element. <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true" /> if mouse is over the element. <see langword="false" /> otherwise.</returns>
     public static bool IsMouseOverElement(this UIElement element, IntPtr lParam)
     {
         // This method will be invoked very often and must be as simple as possible.
@@ -21,24 +21,18 @@ internal static class UiElementExtensions
 
         try
         {
-            var mousePosScreen = new Point(Get_X_LParam(lParam), Get_Y_LParam(lParam));
+            // Ensure the visual is connected to a presentation source (needed for PointFromScreen).
+            if (PresentationSource.FromVisual(element) == null)
+            {
+                return false;
+            }
 
-            return new Rect(default, element.RenderSize).Contains(element.PointFromScreen(mousePosScreen))
-                && element.IsHitTestVisible
-                && (
-                    !(element is System.Windows.Controls.Panel panel)
-                    || // If element is Panel, check if children at mousePosRelative is with IsHitTestVisible false.
-                    (
-                        panel
-                            .Children.OfType<UIElement>()
-                            .FirstOrDefault(child =>
-                                new Rect(default, child.RenderSize).Contains(
-                                    child.PointFromScreen(mousePosScreen)
-                                )
-                            )
-                            ?.IsHitTestVisible ?? false
-                    )
-                );
+            var mousePosition = new Point(Get_X_LParam(lParam), Get_Y_LParam(lParam));
+
+            // If element is Panel, check if children at mousePosRelative is with IsHitTestVisible false.
+            return new Rect(default, element.RenderSize).Contains(element.PointFromScreen(mousePosition)) &&
+                   element.IsHitTestVisible &&
+                   (element is not System.Windows.Controls.Panel panel || IsChildHitTestVisibleAtPointFromScreen(panel, mousePosition));
         }
         catch
         {
@@ -54,5 +48,18 @@ internal static class UiElementExtensions
     private static int Get_Y_LParam(IntPtr lParam)
     {
         return (short)(lParam.ToInt32() >> 16);
+    }
+
+    private static bool IsChildHitTestVisibleAtPointFromScreen(System.Windows.Controls.Panel panel, Point mousePosition)
+    {
+        foreach (UIElement child in panel.Children)
+        {
+            if (new Rect(default, child.RenderSize).Contains(child.PointFromScreen(mousePosition)))
+            {
+                return child.IsHitTestVisible;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

To call PointFromScreen, the visual needs to be connected to a presentation source. Otherwise an `InvalidOperationException` with the message `This Visual is not connected to a PresentationSource` is thrown. This is already catched, but we can avoid this by checking whether it's connected. I also refactored the almost unreadable panel fallback into a separate method.