### PR TITLE
fix: Make `NotifyIcon` contextmenu display properly

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Windows/MainWindow.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Windows/MainWindow.xaml
@@ -92,7 +92,7 @@
             MenuOnRightClick="True"
             TooltipText="WPF UI Gallery">
             <tray:NotifyIcon.Menu>
-                <ContextMenu ItemsSource="{Binding ViewModel.TrayMenuItems, Mode=OneWay}" />
+                <ContextMenu DataContext="{Binding DataContext, Source={x:Reference NavigationView}}" ItemsSource="{Binding ViewModel.TrayMenuItems, Mode=OneWay}" />
             </tray:NotifyIcon.Menu>
         </tray:NotifyIcon>
     </Grid>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

NotifyIcon's ContextMenu not display

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- now we can see the NotifyIcon's ContextMenu
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
The context menu isn't part of the same visual tree and therefore doesn't have the same DataContext. 
I have provided a tip here to solve this problem.