### PR TITLE
fix(controls): Wrapped header and increased right margin to prevent overlapped by buttons in `MessageBox`

### DIFF
--- a/src/Wpf.Ui/Controls/MessageBox/MessageBox.xaml
+++ b/src/Wpf.Ui/Controls/MessageBox/MessageBox.xaml
@@ -57,10 +57,11 @@
                                 <TextBlock
                                     x:Name="Title"
                                     Grid.Row="0"
-                                    Margin="12,12,12,0"
+                                    Margin="12,12,35,0"
                                     FontWeight="SemiBold"
                                     Foreground="{TemplateBinding Foreground}"
-                                    Text="{TemplateBinding Title}" />
+                                    Text="{TemplateBinding Title}"
+                                    TextWrapping="Wrap" />
 
                                 <controls:TitleBar
                                     Grid.Row="0"


### PR DESCRIPTION
**Issue**
Having a long title texts leads the buttons to overlap the title:
<img width="447" height="181" alt="image" src="https://github.com/user-attachments/assets/a74e4e87-2dd2-4a83-9ae1-91a04d23a694" />

**Fix**
Added text wrapping and increased right margin of title:
<img width="454" height="189" alt="image" src="https://github.com/user-attachments/assets/c32118c2-ffc5-4260-ae64-5c6b8e30d8fa" />
