### PR TITLE
fix: CardExpander is difficult to expand

### DIFF
--- a/src/Wpf.Ui/Controls/CardExpander/CardExpander.xaml
+++ b/src/Wpf.Ui/Controls/CardExpander/CardExpander.xaml
@@ -26,7 +26,7 @@
 
     <ControlTemplate x:Key="DefaultUiCardExpanderToggleButtonStyle" TargetType="{x:Type ToggleButton}">
         <Border Padding="{TemplateBinding Padding}" Background="Transparent">
-            <Grid Background="Transparent">
+            <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

CardExpander cannot be expanded if the margin is clicked

Issue Number: #1551

## What is the new behavior?

Making CardExpander easier to extend
