### PR TITLE
fix: make `UiApplication` instance thread-static instead of static

### DIFF
--- a/src/Wpf.Ui/UiApplication.cs
+++ b/src/Wpf.Ui/UiApplication.cs
@@ -10,6 +10,7 @@ namespace Wpf.Ui;
 /// </summary>
 public class UiApplication
 {
+    [ThreadStatic]
     private static UiApplication? _uiApplication;
 
     private readonly Application? _application;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Various controls don't safely handle a multi-threaded UI. See also #594.

An example stack trace would be:

<details>
<pre>
System.Windows.Markup.XamlParseException : Initialization of 'Wpf.Ui.Controls.Button' threw an exception.
---- System.InvalidOperationException : Cannot access Freezable 'System.Windows.Media.SolidColorBrush' across threads because it cannot be frozen.

  Stack Trace: 
XamlReader.RewrapException(Exception e, IXamlLineInfo lineInfo, Uri baseUri)
FrameworkTemplate.LoadTemplateXaml(XamlReader templateReader, XamlObjectWriter currentWriter)
FrameworkTemplate.LoadTemplateXaml(XamlObjectWriter objectWriter)
FrameworkTemplate.LoadOptimizedTemplateContent(DependencyObject container, IComponentConnector componentConnector, IStyleConnector styleConnector, List`1 affectedChildren, UncommonField`1 templatedNonFeChildrenField)
FrameworkTemplate.LoadContent(DependencyObject container, List`1 affectedChildren)
StyleHelper.ApplyTemplateContent(UncommonField`1 dataField, DependencyObject container, FrameworkElementFactory templateRoot, Int32 lastChildIndex, HybridDictionary childIndexFromChildID, FrameworkTemplate frameworkTemplate)
FrameworkTemplate.ApplyTemplateContent(UncommonField`1 templateDataField, FrameworkElement container)
FrameworkElement.ApplyTemplate()
FrameworkElement.MeasureCore(Size availableSize)
UIElement.Measure(Size availableSize)
<48 more frames...>
FrameworkElement.OnStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
DependencyObject.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
DependencyObject.InvalidateProperty(DependencyProperty dp, Boolean preserveCurrentValue)
FrameworkElement.UpdateStyleProperty()
FrameworkElement.OnInitialized(EventArgs e)
FrameworkElement.TryFireInitialized()
ClrObjectRuntime.InitializationGuard(XamlType xamlType, Object obj, Boolean begin)
</pre>
</details>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The root cause appears to be the static `UiApplication` instance. By marking it with `[ThreadStatic]`, we instead make the runtime create one instance per thread.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
