### PR TITLE
fix(ListView): use themed disabled background instead of SystemColors.ControlBrush

### DIFF
--- a/src/Wpf.Ui/Controls/ListView/ListView.xaml
+++ b/src/Wpf.Ui/Controls/ListView/ListView.xaml
@@ -132,7 +132,7 @@
         </Border>
         <ControlTemplate.Triggers>
             <Trigger Property="IsEnabled" Value="False">
-                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
Problem The ListView with GridView template (GridViewTemplate) sets the disabled state background to SystemColors.ControlBrush, bypassing Wpf.Ui’s theme resource keys. In dark themes this produces a jarring white block while adjacent controls use dark palette values, breaking visual consistency.

Screenshot (Dark Theme):
<img width="500" height="360" alt="屏幕截图 2025-10-28 004151" src="https://github.com/user-attachments/assets/82f2d1d4-9367-484c-9d5c-c03dc4e90d60" />

Screenshot (Light Theme):
<img width="500" height="350" alt="屏幕截图 2025-10-28 004205" src="https://github.com/user-attachments/assets/00b8b9bb-8506-4897-af5c-6805a3a80d8e" />

## Changes made:
Updated the disabled state background in ListView's GridViewTemplate from `SystemColors.ControlBrushKey` to `ControlFillColorDisabledBrush`.

## What is the new behavior?
Effects Disabled ListView with GridView now blends into the themed surface (light: subtle muted fill; dark: appropriate subdued dark tone) instead of defaulting to pure white.

Screenshot (Dark Theme):
<img width="500" height="330" alt="屏幕截图 2025-10-28 004754" src="https://github.com/user-attachments/assets/2b49ff6d-d26b-4c4f-8975-5d64b4733ff1" />

Screenshot (Light Theme):
<img width="500" height="334" alt="屏幕截图 2025-10-28 004809" src="https://github.com/user-attachments/assets/12580bfb-ef69-4379-8926-dca9ecd179a1" />

## Other information
I believe a better approach would be to remove this trigger and not alter the background color for the disabled state at all. However, for now, this fix is scoped only to replacing the brush.
