### PR TITLE
fix(LeftNavigationViewTemplate): release layout space when AutoSuggestBox is null or invisible

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
@@ -528,7 +528,15 @@
             <Trigger Property="AutoSuggestBox" Value="{x:Null}">
                 <Setter TargetName="PART_AutoSuggestBoxSymbolButton" Property="Visibility" Value="Collapsed" />
                 <Setter TargetName="AutoSuggestBoxContentPresenter" Property="Visibility" Value="Collapsed" />
+                <Setter TargetName="AutoSuggestBoxContentPresenter" Property="Margin" Value="0" />
+                <Setter TargetName="PART_ToggleButton" Property="Margin" Value="0" />
             </Trigger>
+            <DataTrigger Binding="{Binding Content.(UIElement.Visibility), ElementName=AutoSuggestBoxContentPresenter}" Value="Collapsed">
+                <Setter TargetName="PART_AutoSuggestBoxSymbolButton" Property="Visibility" Value="Collapsed" />
+                <Setter TargetName="AutoSuggestBoxContentPresenter" Property="Visibility" Value="Collapsed" />
+                <Setter TargetName="AutoSuggestBoxContentPresenter" Property="Margin" Value="0" />
+                <Setter TargetName="PART_ToggleButton" Property="Margin" Value="0" />
+            </DataTrigger>
             <Trigger Property="PaneTitle" Value="{x:Null}">
                 <Setter TargetName="PART_ToggleButton" Property="Content" Value="{x:Null}" />
                 <Setter TargetName="PART_ToggleButton" Property="HorizontalAlignment" Value="Left" />


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When the `AutoSuggestBox` property is `null` or its `Visibility` is set to `Collapsed`, the related UI elements (`AutoSuggestBoxContentPresenter` and `PART_ToggleButton`) still occupy layout space, resulting in unnecessary blank areas and visual misalignment.

When `Visibility` is set to `Collapsed`:

https://github.com/user-attachments/assets/0935c5be-c7c9-4feb-91a5-bbc5a609a90f

## What is the new behavior?

Enhanced the template triggers to ensure that when `AutoSuggestBox` is invisible or non-existent, the related containers completely release their layout space. Adjacent elements above and below can now connect seamlessly, restoring proper layout alignment.

https://github.com/user-attachments/assets/1aee5dd1-9436-4b14-aad1-8739428a3ffd
