### PR TITLE
fix: UpdateAutoSuggestBoxSuggestions When MenuItems_CollectionChanged

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationView.Properties.cs
@@ -553,7 +553,7 @@ public partial class NavigationView
     private void OnFooterMenuItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         UpdateAutoSuggestBoxSuggestions();
-        
+
         if (e.NewItems is null)
         {
             return;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- AutoSuggestBox Suggestions still keep old status when MenuItems/FooterMenuItems changed.
Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Update AutoSuggestBox Suggestions when MenuItems/FooterMenuItems changed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
