### PR TITLE
fix(interop): Correct LPRECT parameter type for AdjustWindowRectEx in User32

### DIFF
--- a/src/Wpf.Ui/Interop/User32.cs
+++ b/src/Wpf.Ui/Interop/User32.cs
@@ -882,7 +882,7 @@ internal static class User32
     [DllImport(Libraries.User32, CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool AdjustWindowRectEx(
-        [In] ref Rect lpRect,
+        [In] ref WinDef.RECT lpRect,
         [In] WS dwStyle,
         [In] [MarshalAs(UnmanagedType.Bool)] bool bMenu,
         [In] WS_EX dwExStyle


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- Description: According to the Win32 SDK, the first parameter `LPRECT lpRect` of `AdjustWindowRectEx` should use a structure of four 32-bit integers.
- Issue: Currently `System.Windows.Rect` is used, which stores double-precision floating point values, causing memory layout mismatch.

Issue Number: N/A

## What is the new behavior?

- The `AdjustWindowRectEx` parameter now uses the library-defined `WinDef.RECT` struct, ensuring correct memory layout compatibility with the Win32 `LPRECT` parameter.


## Other information

*No additional information.*
