### PR TITLE
fix(controls): Fix TopSeparator and FooterSeparator rendering in LeftNavigationView

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
@@ -368,7 +368,6 @@
                             Grid.Row="1"
                             Height="1"
                             Margin="0,4,0,4"
-                            BorderThickness=".5"
                             Background="{DynamicResource LeftNavigationViewSeparatorBrush}" />
 
                         <!--  Scrollable Menu Items  -->
@@ -401,7 +400,6 @@
                             Grid.Row="3"
                             Height="1"
                             Margin="0,4,0,4"
-                            BorderThickness=".5"
                             Background="{DynamicResource LeftNavigationViewSeparatorBrush}" />
 
                         <!--  Footer (Fixed)  -->


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- The Separator (Border) did not have a border brush set but had a border thickness > 0, which could make the border occupy space but remain invisible.
- The top and bottom border thickness of the Separator (Border) was 0.5 each, exactly filling the height of a 1-unit Border, preventing the background from showing.

Issue Number: N/A

## What is the new behavior?

- The separators render correctly.

## Other information

The issue seems to have originated from #1541, which attempted to fix #1514 but didn’t address the root cause.  
This PR corrects the rendering logic to align with the intended design.  
Note: #1514 has already been resolved by #1464.
