### PR TITLE
fix(controls): Remove MinWidth of TabItem

### DIFF
--- a/src/Wpf.Ui/Controls/TabControl/TabControl.xaml
+++ b/src/Wpf.Ui/Controls/TabControl/TabControl.xaml
@@ -76,7 +76,6 @@
                     <Grid x:Name="Root">
                         <Border
                             x:Name="Border"
-                            MinWidth="180"
                             MinHeight="36"
                             Margin="0"
                             Padding="6"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently when setting the width of TabItem it will be shown truncated.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The width of the TabItem will be calculated automatically.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Fixes #503 
