### PR TITLE
feat(controls): Check if system accent matches colorization color

### DIFF
--- a/src/Wpf.Ui/Appearance/ApplicationAccentColorManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationAccentColorManager.cs
@@ -170,6 +170,7 @@ public static class ApplicationAccentColorManager
             systemAccent = systemAccent.UpdateBrightness(6f);
         }
 
+        bool isSystemAccent = systemAccent == GetColorizationColor();
         Color primaryAccent;
         Color secondaryAccent;
         Color tertiaryAccent;
@@ -191,7 +192,7 @@ public static class ApplicationAccentColorManager
 
         Color GetColor(UIColorType colorType, float brightnessFactor, float saturationFactor = 0.0f)
         {
-            if (GetUiColor(colorType) is { } color)
+            if (isSystemAccent && GetUiColor(colorType) is { } color)
             {
                 return color;
             }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Fixes: https://github.com/lepoco/wpfui/issues/1580

## What is the new behavior?

If a custom accent is passed in, this is now used again.
From the issue:

<img width="516" height="285" alt="image" src="https://github.com/user-attachments/assets/731c56c3-6c98-4d4c-89e7-eee2ee24e4e7" />