### PR TITLE
fix(controls): enable access key support for multiple WPFUI controls

### DIFF
--- a/src/Wpf.Ui/Controls/Button/Button.xaml
+++ b/src/Wpf.Ui/Controls/Button/Button.xaml
@@ -58,6 +58,7 @@
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
+                            RecognizesAccessKey="True"
                             TextElement.Foreground="{TemplateBinding Foreground}" />
                     </Border>
                     <ControlTemplate.Triggers>
@@ -129,6 +130,7 @@
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
+                            RecognizesAccessKey="True"
                             TextElement.Foreground="{TemplateBinding Foreground}" />
 
                         <!--
@@ -279,6 +281,7 @@
                                     VerticalAlignment="Center"
                                     Content="{TemplateBinding Content}"
                                     ContentTemplate="{TemplateBinding ContentTemplate}"
+                                    RecognizesAccessKey="True"
                                     TextElement.Foreground="{TemplateBinding Foreground}" />
                             </Grid>
                         </Border>

--- a/src/Wpf.Ui/Controls/DropDownButton/DropDownButton.xaml
+++ b/src/Wpf.Ui/Controls/DropDownButton/DropDownButton.xaml
@@ -67,6 +67,7 @@
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
                                     Content="{TemplateBinding Content}"
+                                    RecognizesAccessKey="True"
                                     TextElement.Foreground="{TemplateBinding Foreground}" />
 
                                 <Grid Grid.Column="2" Margin="{StaticResource ButtonChevronIconMargin}">

--- a/src/Wpf.Ui/Controls/HyperlinkButton/HyperlinkButton.xaml
+++ b/src/Wpf.Ui/Controls/HyperlinkButton/HyperlinkButton.xaml
@@ -72,6 +72,7 @@
                                 x:Name="ContentPresenter"
                                 Grid.Column="1"
                                 Content="{TemplateBinding Content}"
+                                RecognizesAccessKey="True"
                                 TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Grid>
                     </Border>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationLeftFluent.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationLeftFluent.xaml
@@ -54,6 +54,7 @@
                             HorizontalAlignment="Center"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
+                            RecognizesAccessKey="True"
                             TextElement.FontSize="{TemplateBinding FontSize}"
                             TextElement.Foreground="{DynamicResource NavigationViewItemForegroundLeftFluent}" />
                     </Grid>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewBottom.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewBottom.xaml
@@ -149,6 +149,7 @@
                         VerticalAlignment="Center"
                         Content="{TemplateBinding Content}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
+                        RecognizesAccessKey="True"
                         TextElement.FontSize="14"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
@@ -74,6 +74,7 @@
                         VerticalAlignment="Center"
                         Content="{TemplateBinding Content}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
+                        RecognizesAccessKey="True"
                         TextElement.FontSize="14"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
 
@@ -173,6 +174,7 @@
                                                 VerticalAlignment="Center"
                                                 Content="{TemplateBinding Content}"
                                                 ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                RecognizesAccessKey="True"
                                                 TextElement.FontSize="14"
                                                 TextElement.Foreground="{TemplateBinding Foreground}" />
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewLeftMinimalCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewLeftMinimalCompact.xaml
@@ -61,6 +61,7 @@
                         VerticalAlignment="Center"
                         Content="{TemplateBinding Content}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
+                        RecognizesAccessKey="True"
                         TextElement.FontSize="14"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
 
@@ -142,6 +143,7 @@
                                                 VerticalAlignment="Center"
                                                 Content="{TemplateBinding Content}"
                                                 ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                RecognizesAccessKey="True"
                                                 TextElement.FontSize="14"
                                                 TextElement.Foreground="{TemplateBinding Foreground}" />
 

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
@@ -153,6 +153,7 @@
                             VerticalAlignment="Center"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
+                            RecognizesAccessKey="True"
                             TextElement.FontSize="14"
                             TextElement.Foreground="{TemplateBinding Foreground}" />
                         <Grid
@@ -280,6 +281,7 @@
                                                         VerticalAlignment="Center"
                                                         Content="{TemplateBinding Content}"
                                                         ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                        RecognizesAccessKey="True"
                                                         TextElement.FontSize="14"
                                                         TextElement.Foreground="{DynamicResource NavigationViewItemForeground}" />
                                                 </Grid>

--- a/src/Wpf.Ui/Controls/RadioButton/RadioButton.xaml
+++ b/src/Wpf.Ui/Controls/RadioButton/RadioButton.xaml
@@ -99,6 +99,7 @@
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
+                            RecognizesAccessKey="True"
                             TextElement.Foreground="{TemplateBinding Foreground}" />
                     </Grid>
                     <ControlTemplate.Triggers>

--- a/src/Wpf.Ui/Controls/ToggleButton/ToggleButton.xaml
+++ b/src/Wpf.Ui/Controls/ToggleButton/ToggleButton.xaml
@@ -55,6 +55,7 @@
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Content="{TemplateBinding Content}"
+                                RecognizesAccessKey="True"
                                 TextElement.FontSize="{TemplateBinding FontSize}"
                                 TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Border>

--- a/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
+++ b/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
@@ -110,6 +110,7 @@
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
+                            RecognizesAccessKey="True"
                             TextElement.Foreground="{TemplateBinding Foreground}" />
                     </Grid>
                     <ControlTemplate.Triggers>


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

I observed that buttons in the WPFUI library lack access key functionality because the `ContentPresenter` in their templates is missing the `RecognizesAccessKey` property. For example, the "S" in "_Save" cannot be recognized as an access key.

Upon investigation, I found that the following controls also have similar issues:

- RepeatButton
- RadioButton  
- ToggleButton
- ToggleSwitch (although it has ON/OFF content, it prioritizes the `Content` property when specified)
- DropDownButton
- HyperlinkButton
- NavigationViewItem (all five variants)

Issue Number: N/A

## What is the new behavior?

I have added `RecognizesAccessKey="True"` to the `ContentPresenter` in these control templates. These controls can now correctly recognize access key prefixes in their `Content` and set the associated characters as quick access keys. When the Alt key is pressed, the underline marking the access key becomes visible:

*(When Alt is pressed)*
<img width="600" height="640" alt="AccessKey" src="https://github.com/user-attachments/assets/196cdacf-76b8-4988-8499-59ce550fe444" />

## Other information

While Windows native access key functionality supports a broader range of controls (such as `ListItem`), I believe the current fixes are sufficient for most use cases. If specific requirements arise in the future, further improvements can be made.

**Note:** The `AutoSuggestBox` within `NavigationView` currently treats access key prefixes as literal text when recognizing content. This PR does not include targeted improvements for this behavior.
