### PR TITLE
fix(controls): Fix null binding error in scroll bar buttons when deleting tabs

### DIFF
--- a/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
@@ -36,7 +36,7 @@
                             Filled="True"
                             FontSize="{TemplateBinding FontSize}"
                             Foreground="{TemplateBinding Foreground}"
-                            Symbol="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+                            Symbol="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, TargetNullValue={x:Static controls:SymbolRegular.Empty}}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">

--- a/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
@@ -43,7 +43,7 @@
                             Filled="True"
                             FontSize="{TemplateBinding FontSize}"
                             Foreground="{TemplateBinding Foreground}"
-                            Symbol="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+                            Symbol="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, TargetNullValue={x:Static controls:SymbolRegular.Empty}}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">


### PR DESCRIPTION
Fixes `NotSupportedException` that occurred when deleting tabs. The issue was caused by `RepeatButton.Content` temporarily becoming `null` in scroll bar buttons, which failed to convert to `SymbolRegular` type via `EnumConverter`.
This issue was present in versions **4.0.3 through 4.1.0**.

## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The errors occurred in `SymbolIcon` elements for `PART_ButtonScrollLeft` and `PART_ButtonScrollRight`.

Issue Number: N/A

## What is the new behavior?

- ScrollBar.xaml: Add TargetNullValue to UiScrollBarLineButton
- DynamicScrollBar.xaml: Add TargetNullValue to DynamicScrollBarLineButton

## Other information

The following error occurs when deleting a tab.
```
例外がスローされました: 'System.NotSupportedException' (System.ComponentModel.TypeConverter.dll の中)
System.Windows.Data Error: 23 : Cannot convert '<null>' from type '<null>' to type 'Wpf.Ui.Controls.SymbolRegular' for 'en-US' culture with default conversions; consider using Converter property of Binding. NotSupportedException:'System.NotSupportedException: EnumConverter cannot convert from (null).
   at System.ComponentModel.TypeConverter.GetConvertFromException(Object value)
   at System.ComponentModel.TypeConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at MS.Internal.Data.DefaultValueConverter.ConvertHelper(Object o, Type destinationType, DependencyObject targetElement, CultureInfo culture, Boolean isForward)'
例外がスローされました: 'System.NotSupportedException' (PresentationFramework.dll の中)
System.Windows.Data Error: 6 : 'ObjectSourceConverter' converter failed to convert value '<null>' (type '<null>'); fallback value will be used, if available. BindingExpression:Path=Content; DataItem='RepeatButton' (Name='PART_ButtonScrollLeft'); target element is 'SymbolIcon' (Name=''); target property is 'Symbol' (type 'SymbolRegular') NotSupportedException:'System.NotSupportedException: EnumConverter cannot convert from (null).
   at MS.Internal.Data.DefaultValueConverter.ConvertHelper(Object o, Type destinationType, DependencyObject targetElement, CultureInfo culture, Boolean isForward)
   at MS.Internal.Data.ObjectSourceConverter.Convert(Object o, Type type, Object parameter, CultureInfo culture)
   at System.Windows.Data.BindingExpression.ConvertHelper(IValueConverter converter, Object value, Type targetType, Object parameter, CultureInfo culture)'
例外がスローされました: 'System.NotSupportedException' (System.ComponentModel.TypeConverter.dll の中)
System.Windows.Data Error: 23 : Cannot convert '<null>' from type '<null>' to type 'Wpf.Ui.Controls.SymbolRegular' for 'en-US' culture with default conversions; consider using Converter property of Binding. NotSupportedException:'System.NotSupportedException: EnumConverter cannot convert from (null).
   at System.ComponentModel.TypeConverter.GetConvertFromException(Object value)
   at System.ComponentModel.TypeConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at MS.Internal.Data.DefaultValueConverter.ConvertHelper(Object o, Type destinationType, DependencyObject targetElement, CultureInfo culture, Boolean isForward)'
例外がスローされました: 'System.NotSupportedException' (PresentationFramework.dll の中)
System.Windows.Data Error: 6 : 'ObjectSourceConverter' converter failed to convert value '<null>' (type '<null>'); fallback value will be used, if available. BindingExpression:Path=Content; DataItem='RepeatButton' (Name='PART_ButtonScrollRight'); target element is 'SymbolIcon' (Name=''); target property is 'Symbol' (type 'SymbolRegular') NotSupportedException:'System.NotSupportedException: EnumConverter cannot convert from (null).
   at MS.Internal.Data.DefaultValueConverter.ConvertHelper(Object o, Type destinationType, DependencyObject targetElement, CultureInfo culture, Boolean isForward)
   at MS.Internal.Data.ObjectSourceConverter.Convert(Object o, Type type, Object parameter, CultureInfo culture)
   at System.Windows.Data.BindingExpression.ConvertHelper(IValueConverter converter, Object value, Type targetType, Object parameter, CultureInfo culture)'

```
