### PR TITLE
feat(controls): Add LabelPosition property to ToggleSwitch control

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/ToggleSwitchPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/ToggleSwitchPage.xaml
@@ -19,7 +19,7 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid Margin="0,0,0,24">
+    <StackPanel Margin="0,0,0,24">
         <controls:ControlExample
             Margin="0"
             HeaderText="WPF UI toggle switch."
@@ -42,5 +42,17 @@
             </Grid>
         </controls:ControlExample>
 
-    </Grid>
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            HeaderText="ToggleSwitch with LabelPosition property."
+            XamlCode="&lt;ui:ToggleSwitch Content=&quot;Label on Right&quot; LabelPosition=&quot;Right&quot; /&gt;&#10; &lt;ui:ToggleSwitch Content=&quot;Label on Left&quot; LabelPosition=&quot;Left&quot; /&gt;">
+            <StackPanel>
+                <ui:ToggleSwitch
+                    Margin="0,0,0,8"
+                    Content="Label on Right"
+                    LabelPosition="Right" />
+                <ui:ToggleSwitch Content="Label on Left" LabelPosition="Left" />
+            </StackPanel>
+        </controls:ControlExample>
+    </StackPanel>
 </Page>

--- a/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.cs
+++ b/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.cs
@@ -3,6 +3,8 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
+using System.Windows;
+
 namespace Wpf.Ui.Controls;
 
 /// <summary>
@@ -26,6 +28,17 @@ public class ToggleSwitch : System.Windows.Controls.Primitives.ToggleButton
         new PropertyMetadata(null)
     );
 
+    /// <summary>Identifies the <see cref="LabelPosition"/> dependency property.</summary>
+    public static readonly DependencyProperty LabelPositionProperty = DependencyProperty.Register(
+        nameof(LabelPosition),
+        typeof(ElementPlacement),
+        typeof(ToggleSwitch),
+        new FrameworkPropertyMetadata(
+            ElementPlacement.Right,
+            FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure
+        )
+    );
+
     /// <summary>
     /// Gets or sets the content that should be displayed when the <see cref="ToggleSwitch"/> is in the "Off" state.
     /// </summary>
@@ -44,5 +57,16 @@ public class ToggleSwitch : System.Windows.Controls.Primitives.ToggleButton
     {
         get => GetValue(OnContentProperty);
         set => SetValue(OnContentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the position of the label content relative to the toggle switch.
+    /// </summary>
+    [System.ComponentModel.Bindable(true)]
+    [System.ComponentModel.Category("Layout")]
+    public ElementPlacement LabelPosition
+    {
+        get => (ElementPlacement)GetValue(LabelPositionProperty);
+        set => SetValue(LabelPositionProperty, value);
     }
 }

--- a/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
+++ b/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
@@ -32,6 +32,7 @@
         <Setter Property="Padding" Value="{StaticResource ToggleSwitchPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="LabelPosition" Value="Right" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
@@ -43,10 +44,11 @@
                 <ControlTemplate TargetType="{x:Type controls:ToggleSwitch}">
                     <Grid Margin="{TemplateBinding Padding}" Background="Transparent">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition x:Name="ToggleColumn" Width="Auto" />
+                            <ColumnDefinition x:Name="ContentColumn" Width="*" />
                         </Grid.ColumnDefinitions>
                         <Grid
+                            x:Name="ToggleGrid"
                             Grid.Column="0"
                             Width="{StaticResource ToggleButtonWidth}"
                             Height="{StaticResource ToggleButtonHeight}">
@@ -113,6 +115,16 @@
                             TextElement.Foreground="{TemplateBinding Foreground}" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="LabelPosition" Value="Left">
+                            <Setter TargetName="ToggleGrid" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="ContentPresenter" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="ContentPresenter" Property="Margin" Value="0,0,8,0" />
+                        </Trigger>
+                        <Trigger Property="LabelPosition" Value="Right">
+                            <Setter TargetName="ToggleGrid" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="ContentPresenter" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="ContentPresenter" Property="Margin" Value="8,0,0,0" />
+                        </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="Content" Value="{x:Null}" />


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Labels can only be displayed on the right.

Issue Number: #1536

## What is the new behavior?

- Add LabelPosition dependency property to ToggleSwitch class
- Support ElementPlacement.Left and ElementPlacement.Right values
- Default behavior remains unchanged (label on right, toggle on left)
- When LabelPosition is set to Left, label appears on the left side
- Update ToggleSwitch template to dynamically adjust layout based on LabelPosition
- Add sample demonstration in Wpf.Ui.Gallery ToggleSwitchPage

## Other information

<img width="1450" height="802" alt="2025-12-07_21h27_37" src="https://github.com/user-attachments/assets/df38ced0-2fb8-4ea7-b752-5b669b166891" />