### PR TITLE
fix(controls): Fix theme and accent color reset after Windows session unlock

### DIFF
--- a/src/Wpf.Ui/Appearance/SystemThemeWatcher.cs
+++ b/src/Wpf.Ui/Appearance/SystemThemeWatcher.cs
@@ -151,7 +151,9 @@ public static class SystemThemeWatcher
     /// </summary>
     private static IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
     {
-        if (msg == (int)PInvoke.WM_WININICHANGE)
+        if (msg == (int)PInvoke.WM_DWMCOLORIZATIONCOLORCHANGED ||
+            msg == (int)PInvoke.WM_THEMECHANGED ||
+            msg == (int)PInvoke.WM_SYSCOLORCHANGE)
         {
             UpdateObservedWindow(hWnd);
         }


### PR DESCRIPTION
## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

1. Have a program with changed theme and/or accent color running
2. Lock Windows via Win + L
3. Wait a minute (or until the screen turns black)
4. Log in again
5. Theme and Accent color gets reset to default values

Issue Number: #1467 #1267

## What is the new behavior?

The code from the initial pull request is no longer needed, so I reverted it.

- Updated WndProc to listen for specific theme change messages instead of WM_WININICHANGE
- WM_DWMCOLORIZATIONCOLORCHANGED,WM_THEMECHANGED,and WM_SYSCOLORCHANGE will trigger a call to UpdateObservedWindow.
- Fixed #1467
- Fixed #1267

WM_DWMCOLORIZATIONCOLORCHANGED
Meaning: Sent when the DWM (Desktop Window Manager) color settings change
Timing: When Windows accent colors or DWM color settings change
Purpose: Detect accent color changes

WM_THEMECHANGED
Meaning: Sent when the theme changes
Timing: When switching between light/dark mode or changing the Windows theme
Purpose: Detect theme changes

WM_SYSCOLORCHANGE
Meaning: Sent when system colors change
Timing: When system colors (window background, text, etc.) change
Purpose: Detect system color changes

## Other information

Before locking
<img width="1450" height="802" alt="image" src="https://github.com/user-attachments/assets/34e48832-8ced-4598-9aee-5e84650391b5" />

After unlocking
<img width="1450" height="802" alt="2025-12-14_17h01_22" src="https://github.com/user-attachments/assets/0d25a16c-dfa8-4528-acad-16f7027c766a" />