### PR TITLE
fix(controls): fix ContentDialog multiline text rendering issue

### DIFF
--- a/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.xaml
+++ b/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.xaml
@@ -46,6 +46,7 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding Border.CornerRadius}"
                             Focusable="False"
+                            VerticalAlignment="Center"
                             Opacity="1">
                             <Border.Effect>
                                 <DropShadowEffect


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, when ContentDialog contains text that exceeds the width and wraps to multiple lines, a container sizing calculation error occurs (it fails to measure the actual space the text should occupy), causing inexplicable extra blank space below wrapped text (as described in #1273).

<img width="612" height="448" alt="ContentDialog-Text-Issue1" src="https://github.com/user-attachments/assets/25b9022c-5f7e-4773-bb02-7d4250c552c4" />

<img width="811" height="746" alt="ContentDialog-Text-Issue2" src="https://github.com/user-attachments/assets/7c3c0086-6a54-4c09-8ae6-e5434dad78c9" />

The root cause is that the level 0 child element of ContentDialog does not have vertical alignment parameters set, defaulting to the Stretch vertical alignment mode.

Issue Number: #1273

## What is the new behavior?

- After modification, ContentDialog text content now renders correctly:

<img width="653" height="405" alt="ContentDialog-Text-Fixed1" src="https://github.com/user-attachments/assets/280ed807-e840-48dd-933c-19a2d24f96ea" />

<img width="860" height="703" alt="ContentDialog-Text-Fixed2" src="https://github.com/user-attachments/assets/e22cb07a-6622-4f17-a068-3c4025239fe8" />

- Fixed #1273

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
