### PR TITLE
fix(controls): Remove duplicate right‑click event handling in TitleBar

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -486,7 +486,9 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
             _parentWindow = VisualTreeHelper.GetParent(_parentWindow);
         }
 
-        MouseRightButtonUp += TitleBar_MouseRightButtonUp;
+        // HwndSourceHook handles the system menu, no additional processing needed.
+        // Temporarily commented out, can be restored if WPF-based processing is needed in the future.
+        // MouseRightButtonUp += TitleBar_MouseRightButtonUp;
 
         /*_mainGrid = GetTemplateChild<System.Windows.Controls.Grid>(ElementMainGrid);*/
         _icon = GetTemplateChild<System.Windows.Controls.ContentPresenter>(ElementIcon);


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The current TitleBar already handles right‑click system menus via `HwndSourceHook`. However, the `MouseRightButtonUp` event is also subscribed and unconditionally pops up the system menu, resulting in:

- Duplicate system‑menu handling in TitleBar; a system menu always appears on right‑click.

- Right‑click menus of controls inside `TrailingContent` cannot be shown.

<img width="554" height="251" alt="TitleBar-RightButton-Issue1" src="https://github.com/user-attachments/assets/a9b86826-cdcc-40cb-80e5-1465ed379748" />

<img width="512" height="238" alt="TitleBar-RightButton-Issue2" src="https://github.com/user-attachments/assets/233def72-f6f0-4847-97aa-01dcb8ba1297" />

Issue Number: N/A

## What is the new behavior?

- The handler for the `MouseRightButtonUp` event has been temporarily commented out (code is preserved). It can be restored later if a WPF‑based system‑menu implementation is needed in the future.

- After the change, both the system menu and control‑specific context menus now work correctly:

<img width="564" height="251" alt="TitleBar-RightButton-Fixed1" src="https://github.com/user-attachments/assets/94638aed-df75-4dde-bb01-5a56800dd1ee" />

<img width="492" height="259" alt="TitleBar-RightButton-Fixed2" src="https://github.com/user-attachments/assets/205fba97-3012-42de-a143-cd2a91726814" />

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
