### PR TITLE
Focus management improvements to ContentDialog

### DIFF
--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/DialogsAndFlyouts/ContentDialogViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/DialogsAndFlyouts/ContentDialogViewModel.cs
@@ -43,4 +43,114 @@ public partial class ContentDialogViewModel(IContentDialogService contentDialogS
 
         _ = await termsOfUseContentDialog.ShowAsync();
     }
+
+    [RelayCommand]
+    private async Task OnShowThreeButtonContentDialog()
+    {
+        var dialog = new ContentDialog(contentDialogService.GetDialogHost())
+        {
+            Title = "Confirmation",
+            Content = "Do you want to save your changes before closing?",
+            PrimaryButtonText = "Save",
+            SecondaryButtonText = "Don't Save",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Secondary,
+        };
+
+        var result = await dialog.ShowAsync();
+        DialogResultText = result switch
+        {
+            ContentDialogResult.Primary => "User saved their work",
+            ContentDialogResult.Secondary => "User did not save their work",
+            _ => "User cancelled the dialog",
+        };
+    }
+
+    [RelayCommand]
+    private async Task OnShowContentDialogWithFocusableContent()
+    {
+        var textBox = new System.Windows.Controls.TextBox
+        {
+            Text = "Type something here...",
+            Margin = new System.Windows.Thickness(0, 8, 0, 0),
+        };
+
+        var dialog = new ContentDialog(contentDialogService.GetDialogHost())
+        {
+            Title = "Input Required",
+            Content = new System.Windows.Controls.StackPanel
+            {
+                Children =
+                {
+                    new System.Windows.Controls.TextBlock
+                    {
+                        Text = "Please enter your name:",
+                        TextWrapping = System.Windows.TextWrapping.Wrap,
+                    },
+                    textBox,
+                },
+            },
+            PrimaryButtonText = "OK",
+            SecondaryButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary,
+        };
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            DialogResultText = $"Hello, {textBox.Text}!";
+        }
+        else
+        {
+            DialogResultText = "User cancelled the dialog";
+        }
+    }
+
+    [RelayCommand]
+    private async Task OnShowContentDialogWithIcons()
+    {
+        var dialog = new ContentDialog(contentDialogService.GetDialogHost())
+        {
+            Title = "Warning",
+            Content = "This action cannot be undone. Are you sure you want to continue?",
+            PrimaryButtonText = "Yes, Continue",
+            SecondaryButtonText = "No, Cancel",
+            PrimaryButtonIcon = new SymbolIcon
+            {
+                Symbol = SymbolRegular.Warning24,
+            },
+            DefaultButton = ContentDialogButton.Secondary,
+        };
+
+        var result = await dialog.ShowAsync();
+        DialogResultText = result switch
+        {
+            ContentDialogResult.Primary => "User chose to continue",
+            ContentDialogResult.Secondary => "User chose to cancel",
+            _ => "User closed the dialog",
+        };
+    }
+
+    [RelayCommand]
+    private async Task OnShowContentDialogWithAutoFocus()
+    {
+        // DefaultButton is set to Primary (default), so focus will automatically be set to primaryButton
+        // when no button has focus and no non-button control has focus
+        var dialog = new ContentDialog(contentDialogService.GetDialogHost())
+        {
+            Title = "Auto Focus",
+            Content = "This ContentDialog will automatically set focus to the primary button when no button or non-button control has focus.",
+            PrimaryButtonText = "OK",
+            SecondaryButtonText = "Cancel",
+            // DefaultButton is intentionally set to Primary (default value)
+        };
+
+        var result = await dialog.ShowAsync();
+        DialogResultText = result switch
+        {
+            ContentDialogResult.Primary => "User clicked OK",
+            ContentDialogResult.Secondary => "User clicked Cancel",
+            _ => "User closed the dialog",
+        };
+    }
 }

--- a/src/Wpf.Ui.Gallery/Views/Pages/DialogsAndFlyouts/ContentDialogPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/DialogsAndFlyouts/ContentDialogPage.xaml
@@ -47,5 +47,61 @@
         <controls:ControlExample Margin="0,36,0,0" HeaderText="Terms of Use ContentDialog example">
             <Button Command="{Binding ShowSignInContentDialogCommand}" Content="Show" />
         </controls:ControlExample>
+
+        <controls:ControlExample Margin="0,36,0,0" HeaderText="Three Button ContentDialog. (Default Focus: Secondary Button)">
+            <StackPanel Orientation="Horizontal">
+                <Button
+                    Command="{Binding ShowThreeButtonContentDialogCommand}"
+                    Content="Show" />
+
+                <TextBlock
+                    Margin="15,0,0,0"
+                    VerticalAlignment="Center"
+                    FontSize="14"
+                    Text="{Binding DialogResultText}" />
+            </StackPanel>
+        </controls:ControlExample>
+
+        <controls:ControlExample Margin="0,36,0,0" HeaderText="ContentDialog with Focusable Content. (Default Focus: Primary Button)">
+            <StackPanel Orientation="Horizontal">
+                <Button
+                    Command="{Binding ShowContentDialogWithFocusableContentCommand}"
+                    Content="Show" />
+
+                <TextBlock
+                    Margin="15,0,0,0"
+                    VerticalAlignment="Center"
+                    FontSize="14"
+                    Text="{Binding DialogResultText}" />
+            </StackPanel>
+        </controls:ControlExample>
+
+        <controls:ControlExample Margin="0,36,0,0" HeaderText="ContentDialog with Icons. (Default Focus: Secondary Button)">
+            <StackPanel Orientation="Horizontal">
+                <Button
+                    Command="{Binding ShowContentDialogWithIconsCommand}"
+                    Content="Show" />
+
+                <TextBlock
+                    Margin="15,0,0,0"
+                    VerticalAlignment="Center"
+                    FontSize="14"
+                    Text="{Binding DialogResultText}" />
+            </StackPanel>
+        </controls:ControlExample>
+
+        <controls:ControlExample Margin="0,36,0,0" HeaderText="ContentDialog with Auto Focus. (Default Focus: Primary Button - automatically set when no button or non-button control has focus)">
+            <StackPanel Orientation="Horizontal">
+                <Button
+                    Command="{Binding ShowContentDialogWithAutoFocusCommand}"
+                    Content="Show" />
+
+                <TextBlock
+                    Margin="15,0,0,0"
+                    VerticalAlignment="Center"
+                    FontSize="14"
+                    Text="{Binding DialogResultText}" />
+            </StackPanel>
+        </controls:ControlExample>
     </StackPanel>
 </Page>

--- a/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.xaml
+++ b/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.xaml
@@ -134,6 +134,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <controls:Button
+                                            x:Name="PART_ContentDialogPrimaryButton"
                                             Grid.Column="0"
                                             HorizontalAlignment="Stretch"
                                             Appearance="{TemplateBinding PrimaryButtonAppearance}"
@@ -145,10 +146,13 @@
                                                                         Converter={StaticResource EnumToBoolConverter},
                                                                         ConverterParameter={x:Static controls:ContentDialogButton.Primary}}"
                                             IsEnabled="{TemplateBinding IsPrimaryButtonEnabled}"
+                                            Focusable="True"
+                                            IsTabStop="True"
                                             Visibility="{TemplateBinding IsPrimaryButtonEnabled,
                                                                          Converter={StaticResource BoolToVisibilityConverter}}" />
 
                                         <controls:Button
+                                            x:Name="PART_ContentDialogSecondaryButton"
                                             Grid.Column="2"
                                             HorizontalAlignment="Stretch"
                                             Appearance="{TemplateBinding SecondaryButtonAppearance}"
@@ -160,10 +164,13 @@
                                                                         Converter={StaticResource EnumToBoolConverter},
                                                                         ConverterParameter={x:Static controls:ContentDialogButton.Secondary}}"
                                             IsEnabled="{TemplateBinding IsSecondaryButtonEnabled}"
+                                            Focusable="True"
+                                            IsTabStop="True"
                                             Visibility="{TemplateBinding IsSecondaryButtonEnabled,
                                                                          Converter={StaticResource BoolToVisibilityConverter}}" />
 
                                         <controls:Button
+                                            x:Name="PART_ContentDialogCloseButton"
                                             Grid.Column="4"
                                             HorizontalAlignment="Stretch"
                                             Appearance="{TemplateBinding CloseButtonAppearance}"
@@ -174,7 +181,9 @@
                                             IsCancel="True"
                                             IsDefault="{TemplateBinding DefaultButton,
                                                                         Converter={StaticResource EnumToBoolConverter},
-                                                                        ConverterParameter={x:Static controls:ContentDialogButton.Close}}" />
+                                                                        ConverterParameter={x:Static controls:ContentDialogButton.Close}}"
+                                            Focusable="True"
+                                            IsTabStop="True" />
                                     </Grid>
                                 </Border>
                             </Grid>


### PR DESCRIPTION
## Pull request type

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- Even when displaying the ContentDialog, focus does not shift to the ContentDialog buttons.
- Cannot close with the Esc key (though it closes if focus shifts...)
<img width="1450" height="802" alt="2025-12-18_23h42_12" src="https://github.com/user-attachments/assets/3929bd0c-42c0-4f6a-a323-b5a4cb64e86a" />

Issue Number: #1585

## What is the new behavior?

- Add button names (PART_ContentDialogPrimaryButton, PART_ContentDialogSecondaryButton, PART_ContentDialogCloseButton) to XAML template
- Add Focusable and IsTabStop properties to buttons in XAML template
- Implement SetFocusToFirstAvailableButton method with checkIsFocused parameter
- Set focus early in OnLoaded/OnApplyTemplate without validation
- Validate focus state using Dispatcher.BeginInvoke in OnLoaded to respect developer logic
- Skip focus setting if already on button or non-button control
- Auto-focus primaryButton when focus is on ContentDialog or nowhere
- Add helper methods IsButtonAvailableForFocus and TrySetFocusToButton
- Add Gallery samples demonstrating focus management behavior:
  - Three Button ContentDialog (Default Focus: Secondary Button)
  - ContentDialog with Focusable Content (Default Focus: Primary Button)
  - ContentDialog with Icons (Default Focus: Secondary Button)
  - ContentDialog with Auto Focus (Default Focus: Primary Button)

## Other information

<img width="1450" height="802" alt="2025-12-18_23h47_56" src="https://github.com/user-attachments/assets/72d43a36-842d-4b35-a0fb-21c9042a2c7f" />
