### PR TITLE
fix(controls): Resolve ContentDialog ShowAsync task hanging issue

### DIFF
--- a/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Wpf.Ui/Controls/ContentDialog/ContentDialog.cs
@@ -693,6 +693,9 @@ public class ContentDialog : ContentControl
         OnUnloaded();
     }
 
+    /// <summary>
+    /// Occurs after Unloaded event
+    /// </summary>
     protected virtual void OnUnloaded()
     {
     }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- Opening a new ContentDialog before the previous one is closed causes task hanging—the `ShowAsync` method never returns.  
  Typical scenario: Navigation between dialogs.

- The `DialogHost` property is publicly writable; if modified while a dialog is displayed, it leads to inconsistent state.

Example of a problem:

https://github.com/user-attachments/assets/312e07e7-9faa-48a7-a590-3f352ec22a52

Issue Number: N/A

## What is the new behavior?

- Handle Unloaded event to complete pending async tasks when dialog is removed

- Add `_capturedDialogHost` field to ensure DialogHost consistency during display

- Update documentation for DialogHost property usage

- Fixed #1618

After the issue was fixed:

https://github.com/user-attachments/assets/b606b6b3-b767-4d4f-942f-0781fb62fd0f

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
