### PR TITLE
fix(controls): Resolve LeftFluentNavigationViewItem text truncation issue

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationLeftFluent.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationLeftFluent.xaml
@@ -9,7 +9,7 @@
     <ControlTemplate x:Key="LeftFluentNavigationViewItemTemplate" TargetType="{x:Type controls:NavigationViewItem}">
         <Border
             x:Name="MainBorder"
-            Width="{StaticResource PaneFluentButtonWidth}"
+            MinWidth="{StaticResource PaneFluentButtonWidth}"
             Height="{StaticResource PaneFluentButtonHeight}"
             Padding="4"
             HorizontalAlignment="Stretch"


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Text truncation occurs in LeftFluentNavigationViewItem due to fixed width constraints, preventing complete display of longer strings such as "Settings".

Example:
<img width="130" height="130" alt="Settings" src="https://github.com/user-attachments/assets/f65d4173-1979-4bb0-99d3-9dfde0c37998" />

Issue Number: #1057 , #17 

## What is the new behavior?

Example:
<img width="176" height="130" alt="Settings" src="https://github.com/user-attachments/assets/67bf1655-1d51-4de0-b95b-aecbbfc390da" />

- Changed Width to MinWidth to allow NavigationViewItem to expand automatically and display full text content

- Fixed #1057

- Fixed #17 

## Other information

- Navigation pane does not update when switching from Left compact view to Fluent view; root cause investigation pending, will be fixed accordingly.
