### PR TITLE
fix(controls): Fixed issues with InfoBar

### DIFF
--- a/src/Wpf.Ui/Controls/InfoBar/InfoBar.xaml
+++ b/src/Wpf.Ui/Controls/InfoBar/InfoBar.xaml
@@ -63,6 +63,7 @@
 
                                 <WrapPanel Grid.Column="1" VerticalAlignment="Top">
                                     <TextBlock
+                                        x:Name="TitleText"
                                         Margin="0,0,14,0"
                                         ScrollViewer.CanContentScroll="False"
                                         Text="{TemplateBinding Title}"
@@ -103,10 +104,18 @@
                         </Trigger>
 
                         <Trigger Property="IsOpen" Value="True">
-                            <Setter TargetName="InfoBarRoot" Property="Visibility" Value="Visible" />
+                            <Setter Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsOpen" Value="False">
-                            <Setter TargetName="InfoBarRoot" Property="Visibility" Value="Collapsed" />
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+
+                        <!-- Collapse TitleText when Title is null or empty to release layout space -->
+                        <Trigger Property="Title" Value="{x:Null}">
+                            <Setter TargetName="TitleText" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="Title" Value="">
+                            <Setter TargetName="TitleText" Property="Visibility" Value="Collapsed" />
                         </Trigger>
 
                         <Trigger Property="Severity" Value="Informational">
@@ -117,21 +126,25 @@
                             </Setter>
                             <Setter TargetName="SymbolIcon" Property="Symbol" Value="Info24" />
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource InfoBarInformationalSeverityBackgroundBrush}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource InfoBarInformationalSeverityBorderBrush}" />
                         </Trigger>
                         <Trigger Property="Severity" Value="Success">
                             <Setter TargetName="SymbolIcon" Property="Foreground" Value="{DynamicResource InfoBarSuccessSeverityIconBackground}" />
                             <Setter TargetName="SymbolIcon" Property="Symbol" Value="CheckmarkCircle24" />
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource InfoBarSuccessSeverityBackgroundBrush}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource InfoBarSuccessSeverityBorderBrush}" />
                         </Trigger>
                         <Trigger Property="Severity" Value="Warning">
                             <Setter TargetName="SymbolIcon" Property="Foreground" Value="{DynamicResource InfoBarWarningSeverityIconBackground}" />
                             <Setter TargetName="SymbolIcon" Property="Symbol" Value="ErrorCircle24" />
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource InfoBarWarningSeverityBackgroundBrush}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource InfoBarWarningSeverityBorderBrush}" />
                         </Trigger>
                         <Trigger Property="Severity" Value="Error">
                             <Setter TargetName="SymbolIcon" Property="Foreground" Value="{DynamicResource InfoBarErrorSeverityIconBackground}" />
                             <Setter TargetName="SymbolIcon" Property="Symbol" Value="DismissCircle24" />
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource InfoBarErrorSeverityBackgroundBrush}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource InfoBarErrorSeverityBorderBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Wpf.Ui/Resources/Theme/Dark.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Dark.xaml
@@ -482,6 +482,11 @@
     <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
     <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource TextFillColorPrimary}" />
 
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    
     <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemFillColorCriticalBackground}" />
     <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemFillColorCautionBackground}" />
     <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemFillColorSuccessBackground}" />

--- a/src/Wpf.Ui/Resources/Theme/HC1.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC1.xaml
@@ -367,6 +367,11 @@
     <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource SystemColorButtonTextColor}" />
 
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    
     <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HC2.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC2.xaml
@@ -366,6 +366,11 @@
     <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource SystemColorButtonTextColor}" />
 
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+
     <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
@@ -366,6 +366,11 @@
     <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource SystemColorButtonTextColor}" />
 
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    
     <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
@@ -366,6 +366,11 @@
     <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource SystemColorButtonTextColor}" />
 
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBorderBrush" Color="{StaticResource SystemColorButtonTextColor}" />
+    
     <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -483,6 +483,11 @@
     <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
     <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource TextFillColorPrimary}" />
 
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    
     <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemFillColorCriticalBackground}" />
     <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemFillColorCautionBackground}" />
     <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemFillColorSuccessBackground}" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- When InfoBar's `IsOpen` property is set to `false`, the internal element “InfoBarRoot” is collapsed, but the InfoBar control itself remains visible in layout. This causes the margin and padding of InfoBar to still occupy space.

  Example usage:
  ```xml
  <Border
      Grid.Column="0"
      VerticalAlignment="Center"
      Background="Aquamarine">
      <ui:InfoBar
          Title="Title"
          Grid.Column="0"
          Margin="0 20"
          IsOpen="{Binding ViewModel.IsShortInfoBarOpened, Mode=TwoWay}"
          Message="Essential app message."
          Severity="{Binding ViewModel.ShortInfoBarSeverity, Mode=OneWay}" />
  </Border>
  ```
  Example:  

  https://github.com/user-attachments/assets/cf9e1c47-a3f2-4cd7-ba2f-695a8a96aff5

- When the Title is empty, the space occupied by its TextBlock is not released, causing the TextBox displaying the Message to be squeezed out.

  <img width="446" height="112" alt="TitleBar-title1" src="https://github.com/user-attachments/assets/1e26c1c0-3585-44de-843f-3b21a8132f9d" />

- Currently, the InfoBar lacks appropriate border colors for different severity levels, and there are no suitable resource keys available even when customizing its style.

---

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- InfoBar will be truly “closed” and will not occupy any layout space.

  Example:  

  https://github.com/user-attachments/assets/8abebacf-81a6-4a18-84d4-3427e7c72d8f

- When the Title is empty, the Message aligns to the position where the Title would be.

  <img width="446" height="112" alt="TitleBar-title2" src="https://github.com/user-attachments/assets/42f7d929-643e-43bd-976a-225b76ff6fc7" />

- Four new brush keys have been added to the existing themes: `InfoBarErrorSeverityBorderBrush`, `InfoBarWarningSeverityBorderBrush`, `InfoBarSuccessSeverityBorderBrush`, and `InfoBarInformationalSeverityBorderBrush`. These allow developers to easily override and customize the styles. Please note that, to maintain consistency with WinUI InfoBar behavior, the corresponding color values remain unchanged.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
