### PR TITLE
fix(controls): Fix Separator layout and add Orientation attached property

### DIFF
--- a/src/Wpf.Ui/Controls/Separator/Separator.xaml
+++ b/src/Wpf.Ui/Controls/Separator/Separator.xaml
@@ -5,28 +5,47 @@
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
-    <Style TargetType="{x:Type Separator}">
-        <Setter Property="BorderBrush" Value="{DynamicResource SeparatorBorderBrush}" />
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Margin" Value="0" />
-        <Setter Property="BorderThickness" Value="1,1,0,0" />
-        <Setter Property="Focusable" Value="False" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Thickness x:Key="SeparatorHorizontalMargin">0,2,0,2</Thickness>
+    <Thickness x:Key="SeparatorVerticalMargin">2,0,2,0</Thickness>
+
+    <Style x:Key="DefaultSeparatorStyle" TargetType="{x:Type Separator}">
+        <!--
+            Note: Any existing code referencing the "SeparatorBorderBrush" resource key will
+            need to be updated to "SeparatorBackgroundBrush".
+        -->
+        <Setter Property="Background" Value="{DynamicResource SeparatorBackgroundBrush}" />
+        <Setter Property="Margin" Value="{DynamicResource SeparatorHorizontalMargin}" />
+        <Setter Property="Focusable" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Separator}">
                     <Border
-                        Width="{TemplateBinding Width}"
-                        Margin="{TemplateBinding Margin}"
+                        x:Name="SeparatorBorder"
+                        Height="1"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Center"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}" />
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true" />
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="controls:SeparatorAttached.Orientation" Value="Vertical">
+                            <Setter TargetName="SeparatorBorder" Property="Width" Value="1" />
+                            <Setter TargetName="SeparatorBorder" Property="Height" Value="Auto" />
+                            <Setter TargetName="SeparatorBorder" Property="HorizontalAlignment" Value="Center" />
+                            <Setter TargetName="SeparatorBorder" Property="VerticalAlignment" Value="Stretch" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style BasedOn="{StaticResource DefaultSeparatorStyle}" TargetType="{x:Type Separator}" />
 
 </ResourceDictionary>

--- a/src/Wpf.Ui/Controls/Separator/SeparatorAttached.cs
+++ b/src/Wpf.Ui/Controls/Separator/SeparatorAttached.cs
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.Windows.Controls;
+
+// ReSharper disable once CheckNamespace
+namespace Wpf.Ui.Controls;
+
+/// <summary>
+/// Provides <c>Orientation</c> property for Separator
+/// </summary>
+/// <example>
+/// <code lang="xml">
+/// &lt;Separator controls:SeparatorAttached.Orientation="Vertical" /&gt;
+/// </code>
+/// </example>
+public static class SeparatorAttached
+{
+    /// <summary>
+    /// Resource key for <see cref="Separator"/> horizontal margin.
+    /// </summary>
+    public const string HorizontalMarginKey = "SeparatorHorizontalMargin";
+
+    /// <summary>
+    /// Resource key for <see cref="Separator"/> vertical margin.
+    /// </summary>
+    public const string VerticalMarginKey = "SeparatorVerticalMargin";
+
+    public static readonly DependencyProperty OrientationProperty =
+        DependencyProperty.RegisterAttached(
+            "Orientation",
+            typeof(Orientation),
+            typeof(SeparatorAttached),
+            new FrameworkPropertyMetadata(Orientation.Horizontal, OnOrientationChanged)
+        );
+
+    /// <summary>Helper for getting <see cref="OrientationProperty"/> from <paramref name="obj"/>.</summary>
+    /// <param name="obj"><see cref="DependencyObject"/> to read <see cref="OrientationProperty"/> from.</param>
+    /// <returns>Orientation property value.</returns>
+    [AttachedPropertyBrowsableForType(typeof(Separator))]
+    public static Orientation GetOrientation(DependencyObject obj)
+    {
+        return (Orientation)obj.GetValue(OrientationProperty);
+    }
+
+    /// <summary>Helper for setting <see cref="OrientationProperty"/> on <paramref name="obj"/>.</summary>
+    /// <param name="obj"><see cref="DependencyObject"/> to set <see cref="OrientationProperty"/> on.</param>
+    /// <param name="value">Orientation property value.</param>
+    public static void SetOrientation(DependencyObject obj, Orientation value)
+    {
+        obj.SetValue(OrientationProperty, value);
+    }
+
+    private static void OnOrientationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not FrameworkElement element)
+        {
+            return;
+        }
+
+        Thickness currentMargin = element.Margin;
+        Thickness? horizontalMargin = element.TryFindResource(HorizontalMarginKey) as Thickness?;
+        Thickness? verticalMargin = element.TryFindResource(VerticalMarginKey) as Thickness?;
+        Orientation newOrientation = (Orientation)e.NewValue;
+
+        // Only swap margin if it matches one of our default values
+        if (newOrientation == Orientation.Vertical && currentMargin == horizontalMargin)
+        {
+            element.SetResourceReference(FrameworkElement.MarginProperty, VerticalMarginKey);
+        }
+        else if (newOrientation == Orientation.Horizontal && currentMargin == verticalMargin)
+        {
+            element.SetResourceReference(FrameworkElement.MarginProperty, HorizontalMarginKey);
+        }
+    }
+}

--- a/src/Wpf.Ui/Resources/Theme/Dark.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Dark.xaml
@@ -569,7 +569,7 @@
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{DynamicResource SystemAccentColorPrimary}" />
 
     <!--  Separator  -->
-    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource DividerStrokeColorDefault}" />
+    <SolidColorBrush x:Key="SeparatorBackgroundBrush" Color="{StaticResource DividerStrokeColorDefault}" />
 
     <!--  Slider  -->
     <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource ControlStrongFillColorDefault}" />

--- a/src/Wpf.Ui/Resources/Theme/HC1.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC1.xaml
@@ -454,7 +454,7 @@
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
 
     <!--  Separator  -->
-    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SeparatorBackgroundBrush" Color="{StaticResource SystemColorWindowTextColor}" />
 
     <!--  Slider  -->
     <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource SystemColorWindowTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HC2.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HC2.xaml
@@ -453,7 +453,7 @@
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
 
     <!--  Separator  -->
-    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SeparatorBackgroundBrush" Color="{StaticResource SystemColorWindowTextColor}" />
 
     <!--  Slider  -->
     <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource SystemColorWindowTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCBlack.xaml
@@ -453,7 +453,7 @@
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
 
     <!--  Separator  -->
-    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SeparatorBackgroundBrush" Color="{StaticResource SystemColorWindowTextColor}" />
 
     <!--  Slider  -->
     <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource SystemColorWindowTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
+++ b/src/Wpf.Ui/Resources/Theme/HCWhite.xaml
@@ -453,7 +453,7 @@
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
 
     <!--  Separator  -->
-    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="SeparatorBackgroundBrush" Color="{StaticResource SystemColorWindowTextColor}" />
 
     <!--  Slider  -->
     <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource SystemColorWindowTextColor}" />

--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -570,7 +570,7 @@
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{DynamicResource SystemAccentColorPrimary}" />
 
     <!--  Separator  -->
-    <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource DividerStrokeColorDefault}" />
+    <SolidColorBrush x:Key="SeparatorBackgroundBrush" Color="{StaticResource DividerStrokeColorDefault}" />
 
     <!--  Slider  -->
     <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource ControlStrongFillColorDefault}" />


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, the Separator control uses a global implicit style to apply WPFUI’s theme colors and attempts to support vertical orientation. However, several issues cause incorrect layout behavior:

- **"Double Margin" Effect**: The implicit style overrides the default template and incorrectly makes the internal Border's Margin property inherit the Separator control's Margin property via TemplateBinding.

  As shown below:
  ```xml
  <Style TargetType="{x:Type Separator}">
      ...
      <Setter Property="Template">
          <Setter.Value>
              <ControlTemplate TargetType="{x:Type Separator}">
                  <!-- Incorrectly inherits the Margin property -->
                  <Border
                      Margin="{TemplateBinding Margin}"
                      ... />
              </ControlTemplate>
          </Setter.Value>
      </Setter>
  </Style>
  ```
  This causes the Separator's own Margin property to take effect, and the internal Border also inherits the same Margin value. The Border then creates spacing inside the control, expanding it and ultimately manifesting as a "double margin" effect.

  Example:
  <img width="894" height="460" alt="Separator-Bug" src="https://github.com/user-attachments/assets/e035453e-43c2-4176-9225-1ed5934ab946" />

- **Directional Support**: It uses the Top and Left borders of a Border to simulate horizontal and vertical separator lines. When width or height is set larger than 1, two lines become visible. Moreover, these lines are not centered—unlike the native WPF Separator, whose line always stays in the middle.

  Example: `<Separator Width="100" Height="100" />`
  <img width="348" height="335" alt="Separator-Border" src="https://github.com/user-attachments/assets/ab52f0ad-3073-4476-88fd-6e9120a13d3f" />

- **Property and Resource Key Naming**: Due to the above design (using Border to draw the line), the style uses `BorderBrush` for theming, and the resource key is named “SeparatorBorderBrush.” However, the native WPF Separator uses the `Background` property for its visual color. This discrepancy can confuse developers and lead to unexpected behavior.

Issue Number: N/A

## What is the new behavior?

- The style has been redefined to align with the behavior of the native WPF Separator control, eliminating the “double margin” issue.

- Introduced the `SeparatorAttached` helper class, which adds an `Orientation` attached property to Separator. Together with the updated style, this enables seamless direction switching.

- Renamed the theme resource key from **SeparatorBorderBrush** to **SeparatorBackgroundBrush**, matching WPF’s native naming pattern and unifying developer expectations.

Examples:
```xaml
<Separator Margin="0 10 0 2" />
```
<img width="281" height="236" alt="Separator-Fixed" src="https://github.com/user-attachments/assets/5a7575c2-000b-4291-bcc9-47658d9f5781" />

and:

```xaml
<Separator ui:SeparatorAttached.Orientation="Vertical" Margin="10" />
```
<img width="322" height="313" alt="Separator-Ver" src="https://github.com/user-attachments/assets/0933483b-3633-499d-a214-5699c075b142" />

## Other information

