### PR TITLE
fix(controls): `NavigationViewItemAutomationPeer` GetPattern logic

### DIFF
--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemAutomationPeer.cs
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewItemAutomationPeer.cs
@@ -30,7 +30,8 @@ internal class NavigationViewItemAutomationPeer : FrameworkElementAutomationPeer
 
     public override object GetPattern(PatternInterface patternInterface)
     {
-        if (patternInterface == PatternInterface.ItemContainer)
+        // Only provide expand collapse pattern if we have children! https://github.com/microsoft/microsoft-ui-xaml/blob/50177b54e88e923e24440df679bdf984b0048ab4/src/controls/dev/NavigationView/NavigationViewItemAutomationPeer.cpp#L52
+        if (patternInterface == PatternInterface.SelectionItem || (patternInterface == PatternInterface.ExpandCollapse && _owner is { HasMenuItems: true }))
         {
             return this;
         }


### PR DESCRIPTION
This used to check ItemContainer, this is wrong, it needs to check SelectionItem and ExpandCollapse as you'll get Unable to cast object of type 'Wpf.Ui.Controls.NavigationViewItemAutomationPeer' to type 'System.Windows.Automation.Provider.IItemContainerProvider'. otherwise.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Unable to cast object of type 'Wpf.Ui.Controls.NavigationViewItemAutomationPeer' to type 'System.Windows.Automation.Provider.IItemContainerProvider'.


## What is the new behavior?

Working AutomationPeer.