### PR TITLE
fix(controls): Add ItemsPanel to ComboBox to enable GroupStyle support

### DIFF
--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/BasicInput/ComboBoxViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/BasicInput/ComboBoxViewModel.cs
@@ -34,4 +34,44 @@ public partial class ComboBoxViewModel : ViewModel
         48,
         72,
     ];
+
+    [ObservableProperty]
+    private ObservableCollection<GroupedComboBoxItem> _groupedItems =
+    [
+        new("Fruits", "Apple"),
+        new("Fruits", "Banana"),
+        new("Fruits", "Orange"),
+        new("Fruits", "Mango"),
+        new("Fruits", "Pineapple"),
+        new("Fruits", "Strawberry"),
+        new("Fruits", "Grapes"),
+        new("Fruits", "Watermelon"),
+        new("Vegetables", "Carrot"),
+        new("Vegetables", "Broccoli"),
+        new("Vegetables", "Spinach"),
+        new("Vegetables", "Tomato"),
+        new("Vegetables", "Cucumber"),
+        new("Vegetables", "Lettuce"),
+        new("Vegetables", "Pepper"),
+        new("Vegetables", "Onion"),
+        new("Dairy", "Milk"),
+        new("Dairy", "Cheese"),
+        new("Dairy", "Yogurt"),
+        new("Dairy", "Butter"),
+        new("Dairy", "Cream"),
+        new("Dairy", "Ice Cream"),
+        new("Meat", "Chicken"),
+        new("Meat", "Beef"),
+        new("Meat", "Pork"),
+        new("Meat", "Fish"),
+        new("Meat", "Turkey"),
+        new("Meat", "Lamb"),
+        new("Grains", "Rice"),
+        new("Grains", "Bread"),
+        new("Grains", "Pasta"),
+        new("Grains", "Oats"),
+        new("Grains", "Quinoa"),
+    ];
 }
+
+public record GroupedComboBoxItem(string Category, string Name);

--- a/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/ComboBoxPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/ComboBoxPage.xaml
@@ -62,5 +62,39 @@
                 ItemsSource="{Binding ViewModel.ComboBoxFontSizes, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:ComboBoxPage}, Mode=OneWay}"
                 SelectedIndex="0" />
         </controls:ControlExample>
+
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            HeaderText="A ComboBox with grouped items using GroupStyle."
+            XamlCode="&lt;ComboBox&gt;&#x0a;  &lt;ComboBox.GroupStyle&gt;&#x0a;    &lt;GroupStyle /&gt;&#x0a;  &lt;/ComboBox.GroupStyle&gt;&#x0a;&lt;/ComboBox&gt;">
+            <controls:ControlExample.Resources>
+                <CollectionViewSource x:Key="GroupedItemsSource" Source="{Binding ViewModel.GroupedItems, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:ComboBoxPage}}">
+                    <CollectionViewSource.GroupDescriptions>
+                        <PropertyGroupDescription PropertyName="Category" />
+                    </CollectionViewSource.GroupDescriptions>
+                </CollectionViewSource>
+            </controls:ControlExample.Resources>
+            <ComboBox
+                MinWidth="200"
+                HorizontalAlignment="Left"
+                DisplayMemberPath="Name"
+                ItemsSource="{Binding Source={StaticResource GroupedItemsSource}}"
+                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                SelectedIndex="0">
+                <ComboBox.GroupStyle>
+                    <GroupStyle>
+                        <GroupStyle.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock
+                                    Margin="8,4,0,4"
+                                    FontWeight="SemiBold"
+                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                    Text="{Binding Name}" />
+                            </DataTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </ComboBox.GroupStyle>
+            </ComboBox>
+        </controls:ControlExample>
     </StackPanel>
 </Page>

--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -173,6 +173,13 @@
         <!--  WPF doesn't like centering, the animation is ugly and the mouse button sometimes clicks right away.  -->
         <Setter Property="Popup.Placement" Value="Bottom" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <StackPanel />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
This PR includes the following:
- Fix ComboBox not rendering grouped items when using GroupStyle (only headers were showing, items were missing)
- Add ItemsPanel property with StackPanel to the ComboBox style to enable proper group rendering
- Add Gallery example demonstrating ComboBox with grouped items
 

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When using GroupStyle with a ComboBox, only the group headers would display:  the actual items within each group were missing. This was because the ComboBox style was missing an ItemsPanel property that ListBox already had.

Issue Number: N/A

## What is the new behavior?

Added the ItemsPanel setter to ComboBox.xaml:
```
<Setter Property="ItemsPanel">
  <Setter.Value>
	  <ItemsPanelTemplate>
		  <StackPanel />
	  </ItemsPanelTemplate>
  </Setter.Value>
</Setter>
```
A simple StackPanel is used instead of VirtualizingStackPanel because virtualization can conflict with GroupStyle rendering, and ComboBox dropdowns typically have fewer items where virtualization isn't needed.

### Test plan
- Open Gallery app → BasicInput → ComboBox page
- Verify the "grouped items" example shows both group headers AND items
- Verify scrolling works with the scrollbar visible
- Test in both light and dark themes


## Other information
<img width="779" height="1255" alt="image" src="https://github.com/user-attachments/assets/41131970-82aa-4d69-8f5b-4a0549eae97d" />


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
