### PR TITLE
fix(controls): Fix close button flickers

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
@@ -73,6 +73,15 @@ public partial class TitleBar
             hit |= 0b1000u; // bottom
 #pragma warning restore
 
+        if (hit == 0b0110u)
+        {
+            const int cornerWidth = 4;
+            if (x < windowRect.right - cornerWidth)
+            {
+                hit = 0b0100u;
+            }
+        }
+
         return hit switch
         {
             0b0101u => (IntPtr)PInvoke.HTTOPLEFT, // top    + left  (0b0100 | 0b0001)

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
@@ -75,7 +75,7 @@ public partial class TitleBar
 
         if (hit == 0b0110u)
         {
-            const int cornerWidth = 4;
+            const int cornerWidth = 1;
             if (x < windowRect.right - cornerWidth)
             {
                 hit = 0b0100u;

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -710,19 +710,20 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
             }
 
             htResult = GetWindowBorderHitTestResult(hwnd, lParam, isMouseOverHeaderContent);
-            if (isMouseOverButtons)
-            {
-                htResult = (IntPtr)PInvoke.HTNOWHERE;
-            }
-            
+
             // Skip button hit testing if top-left or top-right corner resize detection succeeds
             if (
-                !isMouseOverButtons
-                && (htResult == (IntPtr)PInvoke.HTTOPLEFT || htResult == (IntPtr)PInvoke.HTTOPRIGHT)
+                htResult == (IntPtr)PInvoke.HTTOPLEFT
+                || htResult == (IntPtr)PInvoke.HTTOPRIGHT
             )
             {
                 handled = true;
                 return htResult;
+            }
+
+            if (isMouseOverButtons)
+            {
+                htResult = (IntPtr)PInvoke.HTNOWHERE;
             }
         }
         // For WM_NCLBUTTONDOWN, also skip button hit testing if within top-left or top-right corner resize area
@@ -746,13 +747,18 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
             if (!isMouseOverButtons)
             {
                 htResult = GetWindowBorderHitTestResult(hwnd, lParam, false);
-                if (htResult == (IntPtr)PInvoke.HTTOPLEFT || htResult == (IntPtr)PInvoke.HTTOPRIGHT)
-                {
-                    // If within top-left or top-right corner resize area, skip button hit testing
-                    // and let Windows handle the default resize processing
-                    handled = false;
-                    return IntPtr.Zero;
-                }
+            }
+            else
+            {
+                htResult = GetWindowBorderHitTestResult(hwnd, lParam, false);
+            }
+
+            if (htResult == (IntPtr)PInvoke.HTTOPLEFT || htResult == (IntPtr)PInvoke.HTTOPRIGHT)
+            {
+                // If within top-left or top-right corner resize area, skip button hit testing
+                // and let Windows handle the default resize processing
+                handled = false;
+                return IntPtr.Zero;
             }
         }
 

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -690,10 +690,8 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
                 isMouseOverHeaderContent =
                     (headerLeftUIElement is not null
                         && headerLeftUIElement != _titleBlock
-                        && TitleBarButton.IsMouseOverNonClient(headerLeftUIElement, lParam))
-                    || (headerCenterUIElement is not null
-                        && TitleBarButton.IsMouseOverNonClient(headerCenterUIElement, lParam))
-                    || (headerRightUiElement is not null
+                        && TitleBarButton.IsMouseOverNonClient(headerLeftUIElement, lParam)) || (headerCenterUIElement is not null
+                        && TitleBarButton.IsMouseOverNonClient(headerCenterUIElement, lParam)) || (headerRightUiElement is not null
                         && TitleBarButton.IsMouseOverNonClient(headerRightUiElement, lParam));
             }
 
@@ -725,10 +723,10 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
                 htResult = (IntPtr)PInvoke.HTNOWHERE;
             }
         }
-        // For WM_NCLBUTTONDOWN, also skip button hit testing if within top-left or top-right corner resize area
-        // This ensures resize handling works correctly
         else if (message == PInvoke.WM_NCLBUTTONDOWN)
         {
+            // For WM_NCLBUTTONDOWN, also skip button hit testing if within top-left or top-right corner resize area
+            // This ensures resize handling works correctly
             foreach (TitleBarButton button in _buttons)
             {
                 if (button is null)

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -710,9 +710,14 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
                 UIElement? headerCenterUIElement = CenterContent as UIElement;
                 UIElement? headerRightUiElement = TrailingContent as UIElement;
 
-                isMouseOverHeaderContent = (headerLeftUIElement is not null && headerLeftUIElement != _titleBlock && headerLeftUIElement.IsMouseOverElement(lParam))
-                    || (headerCenterUIElement?.IsMouseOverElement(lParam) ?? false)
-                    || (headerRightUiElement?.IsMouseOverElement(lParam) ?? false);
+                isMouseOverHeaderContent =
+                    (headerLeftUIElement is not null
+                        && headerLeftUIElement != _titleBlock
+                        && TitleBarButton.IsMouseOverNonClient(headerLeftUIElement, lParam))
+                    || (headerCenterUIElement is not null
+                        && TitleBarButton.IsMouseOverNonClient(headerCenterUIElement, lParam))
+                    || (headerRightUiElement is not null
+                        && TitleBarButton.IsMouseOverNonClient(headerRightUiElement, lParam));
             }
 
             htResult = GetWindowBorderHitTestResult(hwnd, lParam);
@@ -729,14 +734,14 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
 
         switch (message)
         {
-            case PInvoke.WM_NCHITTEST when CloseWindowByDoubleClickOnIcon && _icon.IsMouseOverElement(lParam):
+            case PInvoke.WM_NCHITTEST when CloseWindowByDoubleClickOnIcon && TitleBarButton.IsMouseOverNonClient(_icon, lParam):
                 // Ideally, clicking on the icon should open the system menu, but when the system menu is opened manually, double-clicking on the icon does not close the window
                 handled = true;
                 return (IntPtr)PInvoke.HTSYSMENU;
             case PInvoke.WM_NCHITTEST when htResult != (IntPtr)PInvoke.HTNOWHERE:
                 handled = true;
                 return htResult;
-            case PInvoke.WM_NCHITTEST when this.IsMouseOverElement(lParam) && !isMouseOverHeaderContent:
+            case PInvoke.WM_NCHITTEST when TitleBarButton.IsMouseOverNonClient(this, lParam) && !isMouseOverHeaderContent:
                 handled = true;
                 return (IntPtr)PInvoke.HTCAPTION;
             default:

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -12,6 +12,72 @@ namespace Wpf.Ui.Controls;
 
 public class TitleBarButton : Wpf.Ui.Controls.Button
 {
+    // We intentionally keep this logic local to TitleBar components to avoid changing
+    // global hit-testing behavior for other controls.
+    internal static bool IsMouseOverNonClient(UIElement element, IntPtr lParam, double tolerance = 1.0)
+    {
+        // This will be invoked very often and must be as simple as possible.
+        if (lParam == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        try
+        {
+            // Ensure the visual is connected to a presentation source (needed for PointFromScreen).
+            if (PresentationSource.FromVisual(element) == null)
+            {
+                return false;
+            }
+
+            long lp = lParam.ToInt64();
+            int x = (short)(lp & 0xFFFF);
+            int y = (short)(lp >> 16);
+
+            var mousePosition = new Point(x, y);
+
+            // Add a small tolerance to reduce hover flicker at pixel boundaries (rounding/DPI edge cases).
+            var hitRect = new Rect(
+                -tolerance,
+                -tolerance,
+                element.RenderSize.Width + (2 * tolerance),
+                element.RenderSize.Height + (2 * tolerance)
+            );
+
+            if (!hitRect.Contains(element.PointFromScreen(mousePosition)) || !element.IsHitTestVisible)
+            {
+                return false;
+            }
+
+            // If element is Panel, check if children at mousePosition is with IsHitTestVisible false.
+            if (element is System.Windows.Controls.Panel panel)
+            {
+                foreach (UIElement child in panel.Children)
+                {
+                    var childHitRect = new Rect(
+                        -tolerance,
+                        -tolerance,
+                        child.RenderSize.Width + (2 * tolerance),
+                        child.RenderSize.Height + (2 * tolerance)
+                    );
+
+                    if (childHitRect.Contains(child.PointFromScreen(mousePosition)))
+                    {
+                        return child.IsHitTestVisible;
+                    }
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     /// <summary>Identifies the <see cref="ButtonType"/> dependency property.</summary>
     public static readonly DependencyProperty ButtonTypeProperty = DependencyProperty.Register(
         nameof(ButtonType),
@@ -179,7 +245,7 @@ public class TitleBarButton : Wpf.Ui.Controls.Button
         switch (msg)
         {
             case PInvoke.WM_NCHITTEST:
-                if (this.IsMouseOverElement(lParam))
+                if (IsMouseOverNonClient(this, lParam))
                 {
                     /*Debug.WriteLine($"Hitting {ButtonType} | return code {_returnValue}");*/
                     Hover();
@@ -192,10 +258,10 @@ public class TitleBarButton : Wpf.Ui.Controls.Button
             case PInvoke.WM_NCMOUSELEAVE: // Mouse leaves the window
                 RemoveHover();
                 return false;
-            case PInvoke.WM_NCLBUTTONDOWN when this.IsMouseOverElement(lParam): // Left button clicked down
+            case PInvoke.WM_NCLBUTTONDOWN when IsMouseOverNonClient(this, lParam): // Left button clicked down
                 _isClickedDown = true;
                 return true;
-            case PInvoke.WM_NCLBUTTONUP when _isClickedDown && this.IsMouseOverElement(lParam): // Left button clicked up
+            case PInvoke.WM_NCLBUTTONUP when _isClickedDown && IsMouseOverNonClient(this, lParam): // Left button clicked up
                 InvokeClick();
                 return true;
             default:

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -30,11 +30,9 @@ public class TitleBarButton : Wpf.Ui.Controls.Button
                 return false;
             }
 
-            long lp = lParam.ToInt64();
-            int x = (short)(lp & 0xFFFF);
-            int y = (short)(lp >> 16);
-
-            var mousePosition = new Point(x, y);
+            var mousePosition = TryGetCursorPos(out Point cursorPosition)
+                ? cursorPosition
+                : GetLParamPoint(lParam);
 
             // Add a small tolerance to reduce hover flicker at pixel boundaries (rounding/DPI edge cases).
             var hitRect = new Rect(
@@ -76,6 +74,28 @@ public class TitleBarButton : Wpf.Ui.Controls.Button
         {
             return false;
         }
+    }
+
+    private static Point GetLParamPoint(IntPtr lParam)
+    {
+        long lp = lParam.ToInt64();
+        int x = (short)(lp & 0xFFFF);
+        int y = (short)(lp >> 16);
+
+        return new Point(x, y);
+    }
+
+    private static bool TryGetCursorPos(out Point mousePosition)
+    {
+        mousePosition = default;
+
+        if (!Windows.Win32.PInvoke.GetCursorPos(out Windows.Win32.POINT point))
+        {
+            return false;
+        }
+
+        mousePosition = new Point(point.X, point.Y);
+        return true;
     }
 
     /// <summary>Identifies the <see cref="ButtonType"/> dependency property.</summary>

--- a/src/Wpf.Ui/Extensions/UiElementExtensions.cs
+++ b/src/Wpf.Ui/Extensions/UiElementExtensions.cs
@@ -30,16 +30,7 @@ internal static class UiElementExtensions
             var mousePosition = new Point(Get_X_LParam(lParam), Get_Y_LParam(lParam));
 
             // If element is Panel, check if children at mousePosition is with IsHitTestVisible false.
-            // Add a small tolerance to reduce hover flicker at pixel boundaries (rounding/DPI edge cases).
-            const double tolerance = 1.0;
-            var hitRect = new Rect(
-                -tolerance,
-                -tolerance,
-                element.RenderSize.Width + (2 * tolerance),
-                element.RenderSize.Height + (2 * tolerance)
-            );
-
-            return hitRect.Contains(element.PointFromScreen(mousePosition))
+            return new Rect(default, element.RenderSize).Contains(element.PointFromScreen(mousePosition))
                 && element.IsHitTestVisible
                 && (
                     element is not System.Windows.Controls.Panel panel
@@ -54,14 +45,12 @@ internal static class UiElementExtensions
 
     private static int Get_X_LParam(IntPtr lParam)
     {
-        long lp = lParam.ToInt64();
-        return (short)(lp & 0xFFFF);
+        return (short)(lParam.ToInt32() & 0xFFFF);
     }
 
     private static int Get_Y_LParam(IntPtr lParam)
     {
-        long lp = lParam.ToInt64();
-        return (short)(lp >> 16);
+        return (short)(lParam.ToInt32() >> 16);
     }
 
     private static bool IsChildHitTestVisibleAtPointFromScreen(
@@ -71,15 +60,7 @@ internal static class UiElementExtensions
     {
         foreach (UIElement child in panel.Children)
         {
-            const double tolerance = 1.0;
-            var hitRect = new Rect(
-                -tolerance,
-                -tolerance,
-                child.RenderSize.Width + (2 * tolerance),
-                child.RenderSize.Height + (2 * tolerance)
-            );
-
-            if (hitRect.Contains(child.PointFromScreen(mousePosition)))
+            if (new Rect(default, child.RenderSize).Contains(child.PointFromScreen(mousePosition)))
             {
                 return child.IsHitTestVisible;
             }

--- a/src/Wpf.Ui/Interop/PInvoke.cs
+++ b/src/Wpf.Ui/Interop/PInvoke.cs
@@ -4,7 +4,6 @@
 // All Rights Reserved.
 
 using System.Runtime.InteropServices;
-using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Windows.Win32;
@@ -15,5 +14,18 @@ internal static partial class PInvoke
         DllImport("USER32.dll", ExactSpelling = true, EntryPoint = "SetWindowLongPtrW", SetLastError = true),
         DefaultDllImportSearchPaths(DllImportSearchPath.System32)
     ]
-    internal static extern nint SetWindowLongPtr(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong);
+    internal static extern nint SetWindowLongPtr(Windows.Win32.Foundation.HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong);
+
+    [
+        DllImport("USER32.dll", ExactSpelling = true, EntryPoint = "GetCursorPos", SetLastError = true),
+        DefaultDllImportSearchPaths(DllImportSearchPath.System32)
+    ]
+    internal static extern bool GetCursorPos(out POINT lpPoint);
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct POINT
+{
+    public int X;
+    public int Y;
 }


### PR DESCRIPTION
## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When you place the mouse cursor near the window's close button (upper-right corner), the button may flicker and become unclickable.

Issue Number: fixed #1647

## What is the new behavior?

- Improved non-client-side hit testing for title bar buttons, reducing flickering during hover at pixel/DPI boundaries.
- Adjusted hit testing logic for `TitleBar` to prevent treating window button areas as resize/drag regions.
- Resolved merge conflict in `src/Wpf.Ui/Controls/TitleBar/TitleBar.cs`. (my pull request #1604)

## Other information

N/A
