### PR TITLE
fix(controls): Fix flickering issue when hovering over the top-right close button

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
@@ -73,6 +73,15 @@ public partial class TitleBar
             hit |= 0b1000u; // bottom
 #pragma warning restore
 
+        if (hit == 0b0110u)
+        {
+            const int cornerWidth = 1;
+            if (x < windowRect.right - cornerWidth)
+            {
+                hit = 0b0100u;
+            }
+        }
+
         return hit switch
         {
             0b0101u => (IntPtr)PInvoke.HTTOPLEFT, // top    + left  (0b0100 | 0b0001)

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
@@ -35,6 +35,24 @@ namespace Wpf.Ui.Controls;
 /// </remarks>
 public partial class TitleBar
 {
+    /// <summary>
+    /// Bit flags that represent which window border edges the cursor is currently over.
+    /// </summary>
+    [Flags]
+    private enum BorderHitEdges : uint
+    {
+        /// <summary>No border edge is hit.</summary>
+        None = 0,
+        /// <summary>The left border edge is hit.</summary>
+        Left = 1 << 0,
+        /// <summary>The right border edge is hit.</summary>
+        Right = 1 << 1,
+        /// <summary>The top border edge is hit.</summary>
+        Top = 1 << 2,
+        /// <summary>The bottom border edge is hit.</summary>
+        Bottom = 1 << 3,
+    }
+
     private int _borderX;
     private int _borderY;
 
@@ -60,38 +78,36 @@ public partial class TitleBar
         int x = (short)(lp & 0xFFFF);
         int y = (short)((lp >> 16) & 0xFFFF);
 
-        uint hit = 0u;
+        BorderHitEdges hit = BorderHitEdges.None;
 
-#pragma warning disable
         if (x < windowRect.left + _borderX)
-            hit |= 0b0001u; // left
+            hit |= BorderHitEdges.Left;
         if (x >= windowRect.right - _borderX)
-            hit |= 0b0010u; // right
+            hit |= BorderHitEdges.Right;
         if (y < windowRect.top + _borderY)
-            hit |= 0b0100u; // top
+            hit |= BorderHitEdges.Top;
         if (y >= windowRect.bottom - _borderY)
-            hit |= 0b1000u; // bottom
-#pragma warning restore
+            hit |= BorderHitEdges.Bottom;
 
-        if (hit == 0b0110u)
+        if (hit == (BorderHitEdges.Top | BorderHitEdges.Right))
         {
             const int cornerWidth = 1;
             if (x < windowRect.right - cornerWidth)
             {
-                hit = 0b0100u;
+                hit = BorderHitEdges.Top;
             }
         }
 
         return hit switch
         {
-            0b0101u => (IntPtr)PInvoke.HTTOPLEFT, // top    + left  (0b0100 | 0b0001)
-            0b0110u => (IntPtr)PInvoke.HTTOPRIGHT, // top    + right (0b0100 | 0b0010)
-            0b1001u => (IntPtr)PInvoke.HTBOTTOMLEFT, // bottom + left  (0b1000 | 0b0001)
-            0b1010u => (IntPtr)PInvoke.HTBOTTOMRIGHT, // bottom + right (0b1000 | 0b0010)
-            0b0100u => (IntPtr)PInvoke.HTTOP, // top
-            0b0001u => (IntPtr)PInvoke.HTLEFT, // left
-            0b1000u => (IntPtr)PInvoke.HTBOTTOM, // bottom
-            0b0010u => (IntPtr)PInvoke.HTRIGHT, // right
+            BorderHitEdges.Top | BorderHitEdges.Left => (IntPtr)PInvoke.HTTOPLEFT,
+            BorderHitEdges.Top | BorderHitEdges.Right => (IntPtr)PInvoke.HTTOPRIGHT,
+            BorderHitEdges.Bottom | BorderHitEdges.Left => (IntPtr)PInvoke.HTBOTTOMLEFT,
+            BorderHitEdges.Bottom | BorderHitEdges.Right => (IntPtr)PInvoke.HTBOTTOMRIGHT,
+            BorderHitEdges.Top => (IntPtr)PInvoke.HTTOP,
+            BorderHitEdges.Left => (IntPtr)PInvoke.HTLEFT,
+            BorderHitEdges.Bottom => (IntPtr)PInvoke.HTBOTTOM,
+            BorderHitEdges.Right => (IntPtr)PInvoke.HTRIGHT,
 
             // no match = HTNOWHERE (stop processing)
             _ => (IntPtr)PInvoke.HTNOWHERE,

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -685,14 +685,14 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
             {
                 UIElement? headerLeftUIElement = Header as UIElement;
                 UIElement? headerCenterUIElement = CenterContent as UIElement;
-                UIElement? headerRightUiElement = TrailingContent as UIElement;
+                UIElement? headerTrailingUiElement = TrailingContent as UIElement;
 
                 isMouseOverHeaderContent =
                     (headerLeftUIElement is not null
                         && headerLeftUIElement != _titleBlock
                         && TitleBarButton.IsMouseOverNonClient(headerLeftUIElement, lParam)) || (headerCenterUIElement is not null
-                        && TitleBarButton.IsMouseOverNonClient(headerCenterUIElement, lParam)) || (headerRightUiElement is not null
-                        && TitleBarButton.IsMouseOverNonClient(headerRightUiElement, lParam));
+                        && TitleBarButton.IsMouseOverNonClient(headerCenterUIElement, lParam)) || (headerTrailingUiElement is not null
+                        && TitleBarButton.IsMouseOverNonClient(headerTrailingUiElement, lParam));
             }
 
             TitleBarButton? rightmostButton = null;

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -740,7 +740,7 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
             }
 
             if (rightmostButton is not null
-                && Windows.Win32.PInvoke.GetCursorPos(out Windows.Win32.POINT cursorPoint))
+                && Windows.Win32.PInvoke.GetCursorPos(out System.Drawing.Point cursorPoint))
             {
                 Point cursorPosition = new(cursorPoint.X, cursorPoint.Y);
 

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBarButton.cs
@@ -89,7 +89,7 @@ public class TitleBarButton : Wpf.Ui.Controls.Button
     {
         mousePosition = default;
 
-        if (!Windows.Win32.PInvoke.GetCursorPos(out Windows.Win32.POINT point))
+        if (!Windows.Win32.PInvoke.GetCursorPos(out System.Drawing.Point point))
         {
             return false;
         }

--- a/src/Wpf.Ui/Interop/PInvoke.cs
+++ b/src/Wpf.Ui/Interop/PInvoke.cs
@@ -4,7 +4,6 @@
 // All Rights Reserved.
 
 using System.Runtime.InteropServices;
-using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Windows.Win32;
@@ -15,5 +14,18 @@ internal static partial class PInvoke
         DllImport("USER32.dll", ExactSpelling = true, EntryPoint = "SetWindowLongPtrW", SetLastError = true),
         DefaultDllImportSearchPaths(DllImportSearchPath.System32)
     ]
-    internal static extern nint SetWindowLongPtr(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong);
+    internal static extern nint SetWindowLongPtr(Windows.Win32.Foundation.HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong);
+
+    [
+        DllImport("USER32.dll", ExactSpelling = true, EntryPoint = "GetCursorPos", SetLastError = true),
+        DefaultDllImportSearchPaths(DllImportSearchPath.System32)
+    ]
+    internal static extern bool GetCursorPos(out POINT lpPoint);
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct POINT
+{
+    public int X;
+    public int Y;
 }

--- a/src/Wpf.Ui/Interop/PInvoke.cs
+++ b/src/Wpf.Ui/Interop/PInvoke.cs
@@ -15,17 +15,4 @@ internal static partial class PInvoke
         DefaultDllImportSearchPaths(DllImportSearchPath.System32)
     ]
     internal static extern nint SetWindowLongPtr(Windows.Win32.Foundation.HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong);
-
-    [
-        DllImport("USER32.dll", ExactSpelling = true, EntryPoint = "GetCursorPos", SetLastError = true),
-        DefaultDllImportSearchPaths(DllImportSearchPath.System32)
-    ]
-    internal static extern bool GetCursorPos(out POINT lpPoint);
-}
-
-[StructLayout(LayoutKind.Sequential)]
-internal struct POINT
-{
-    public int X;
-    public int Y;
 }

--- a/src/Wpf.Ui/NativeMethods.txt
+++ b/src/Wpf.Ui/NativeMethods.txt
@@ -3,6 +3,7 @@ DwmIsCompositionEnabled
 DwmExtendFrameIntoClientArea
 SetWindowThemeAttribute
 GetDpiForWindow
+GetCursorPos
 GetForegroundWindow
 IsWindowVisible
 SetWindowLong


### PR DESCRIPTION
## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

This pull request revisits and consolidates the changes from previous pull requests (#1647 and #1604).

It fixes an issue where the close button in the upper-right corner could flicker and become unresponsive when the mouse cursor was nearby, and restores the ability to resize the window from that corner.

Issue Number: #1647

## What is the new behavior?

- Improved non-client-side hit testing for title bar buttons, reducing flickering during hover at pixel/DPI boundaries.
- Adjusted hit testing logic for TitleBar to prevent treating window button areas as resize/drag regions.
- Resolved merge conflict in src/Wpf.Ui/Controls/TitleBar/TitleBar.cs.  ( my pull request #1604 )

## Other information

N/A