### PR TITLE
fix(controls): DataGrid editing behavior for ComboBox and CheckBox columns

### DIFF
--- a/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
+++ b/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
@@ -121,6 +121,7 @@
                         Padding="{TemplateBinding Padding}"
                         HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                         VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                        Background="Transparent"
                         BorderBrush="Transparent"
                         BorderThickness="0"
                         SnapsToDevicePixels="True">
@@ -156,6 +157,7 @@
     <Style x:Key="DefaultDataGridRowStyle" TargetType="{x:Type DataGridRow}">
         <Setter Property="Margin" Value="0,2" />
         <Setter Property="Padding" Value="4" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -180,6 +182,7 @@
                 <ControlTemplate TargetType="{x:Type DataGridRow}">
                     <Border
                         x:Name="DGR_Border"
+                        Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="{DynamicResource ControlCornerRadius}"
@@ -882,6 +885,8 @@
         BasedOn="{StaticResource DefaultCheckBoxStyle}"
         TargetType="{x:Type CheckBox}">
         <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="Focusable" Value="False" />
     </Style>
 
     <Style
@@ -895,11 +900,10 @@
         x:Key="DefaultDataGridComboBoxElementStyle"
         BasedOn="{StaticResource DefaultComboBoxStyle}"
         TargetType="{x:Type ComboBox}">
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="BorderBrush" Value="Transparent" />
-        <Setter Property="Margin" Value="0,0,10,0" />
-        <Setter Property="Padding" Value="12,8,0,8" />
-        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="Background" Value="{x:Null}" />
+        <Setter Property="BorderBrush" Value="{x:Null}" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="IsSynchronizedWithCurrentItem" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBox}">
@@ -925,7 +929,8 @@
                                 Content="{TemplateBinding SelectionBoxItem}"
                                 ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                 ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                TextElement.Foreground="{TemplateBinding Foreground}" />
+                                TextElement.Foreground="{TemplateBinding Foreground}"
+                                IsHitTestVisible="False" />
                             <controls:SymbolIcon
                                 Grid.Column="1"
                                 Visibility="Hidden"
@@ -943,8 +948,8 @@
         x:Key="DefaultDataGridComboBoxEditingElementStyle"
         BasedOn="{StaticResource DefaultComboBoxStyle}"
         TargetType="{x:Type ComboBox}">
+        <Setter Property="IsSynchronizedWithCurrentItem" Value="False" />
         <Setter Property="IsDropDownOpen" Value="True" />
-        <Setter Property="Margin" Value="2,0,0,0" />
     </Style>
 
     <Style


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
Several DataGrid element styles do not respect column editing rules:

- `DataGridComboBoxColumn` cannot be edited in some cases due to the applied element/editing styles.
- `DataGridCheckBoxColumn` remains editable even when `IsReadOnly="True"` is set on the column.
- This behavior is caused by the current `DataGridCell`, `DataGridRow`, `DataGridCheckBoxElementStyle`, `DataGridComboBoxElementStyle`, and `DataGridComboBoxEditingElementStyle` definitions.

Related issues:
- #709
- #1388
- #1395

## What is the new behavior?

- `DataGridComboBoxColumn` can now be edited correctly when the column is editable.
- `DataGridCheckBoxColumn` correctly respects `IsReadOnly="True"` and is no longer editable when read-only.
- DataGrid element and editing styles now align with standard WPF DataGrid behavior.
- No API changes were introduced; only style fixes were applied.