### PR TITLE
fix  CheckBox animation throwing NullReferenceException on ObservableCollection changes

### DIFF
--- a/src/Wpf.Ui/Controls/CheckBox/CheckBox.xaml
+++ b/src/Wpf.Ui/Controls/CheckBox/CheckBox.xaml
@@ -13,7 +13,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
     xmlns:converters="clr-namespace:Wpf.Ui.Converters"
-    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    xmlns:system="clr-namespace:System;assembly=mscorlib"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
 
     <!--
         I don't see that CheckBox had combined states. Without it,
@@ -95,7 +96,7 @@
                                                 <MultiBinding.Bindings>
                                                     <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}" />
                                                     <Binding Path="ActualHeight" RelativeSource="{RelativeSource Self}" />
-                                                    <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                                                    <Binding Path="(animations:AnimationProperties.AnimationTagValue)" RelativeSource="{RelativeSource Self}" />
                                                 </MultiBinding.Bindings>
                                             </MultiBinding>
                                         </controls:SymbolIcon.Clip>
@@ -137,7 +138,7 @@
                                     <Storyboard>
                                         <DoubleAnimation
                                             Storyboard.TargetName="ControlIcon"
-                                            Storyboard.TargetProperty="Tag"
+                                            Storyboard.TargetProperty="(animations:AnimationProperties.AnimationTagValue)"
                                             From="0"
                                             To="1"
                                             Duration="{StaticResource CheckBoxAnimationDuration}">


### PR DESCRIPTION
Use DependencyProperty for getting/setting the Tag property value to avoid it having the default value of 'null'

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Issue Number: #1140 

## What is the new behavior?

- I didn't try to think about a proper solution/what's causing that issue and just used the code added in #1398, it stopped throwing this exception in my use cases and animations seem to work properly. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
