### PR TITLE
fix(controls): Fix UiScrollBarThumb not centered (ScrollBar.xaml)

### DIFF
--- a/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
@@ -95,7 +95,7 @@
     <Style x:Key="UiScrollBarThumb" TargetType="{x:Type Thumb}">
         <Setter Property="Background" Value="{DynamicResource ScrollBarThumbFill}" />
         <Setter Property="Border.CornerRadius" Value="4" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="SnapsToDevicePixels" Value="False" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Focusable" Value="False" />


### PR DESCRIPTION
`SnapsToDevicePixels="True"` on `UiScrollBarThumb` style of the Scrollbar thumb causes the thumb to not be centered in the scrollbar on some DPI settings / resolutions

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?
<img width="460" height="739" alt="image" src="https://github.com/user-attachments/assets/4cd9dca0-1888-4d22-b2d4-4055a9cad7c3" />


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
<img width="461" height="599" alt="image" src="https://github.com/user-attachments/assets/097009b2-c698-46dd-912f-38673a025004" />
