### PR TITLE
fix(controls): Fix card automation peers

### DIFF
--- a/src/Wpf.Ui/AutomationPeers/CardControlAutomationPeer.cs
+++ b/src/Wpf.Ui/AutomationPeers/CardControlAutomationPeer.cs
@@ -3,7 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using Wpf.Ui.Controls;
 
@@ -12,8 +11,12 @@ namespace Wpf.Ui.AutomationPeers;
 /// <summary>
 /// Provides UI Automation peer for the CardControl.
 /// </summary>
-internal class CardControlAutomationPeer(CardControl owner) : FrameworkElementAutomationPeer(owner)
+internal class CardControlAutomationPeer : FrameworkElementAutomationPeer
 {
+    public CardControlAutomationPeer(CardControl owner)
+        : base(owner)
+    { }
+
     protected override string GetClassNameCore()
     {
         return "CardControl";
@@ -22,47 +25,5 @@ internal class CardControlAutomationPeer(CardControl owner) : FrameworkElementAu
     protected override AutomationControlType GetAutomationControlTypeCore()
     {
         return AutomationControlType.Pane;
-    }
-
-    public override object GetPattern(PatternInterface patternInterface)
-    {
-        if (patternInterface == PatternInterface.ItemContainer)
-        {
-            return this;
-        }
-
-        return base.GetPattern(patternInterface);
-    }
-
-    protected override AutomationPeer GetLabeledByCore()
-    {
-        if (owner.Header is UIElement element)
-        {
-            return CreatePeerForElement(element);
-        }
-
-        return base.GetLabeledByCore();
-    }
-
-    protected override string GetNameCore()
-    {
-        var result = base.GetNameCore() ?? string.Empty;
-
-        if (result == string.Empty)
-        {
-            result = AutomationProperties.GetName(owner);
-        }
-
-        if (result == string.Empty && owner.Header is DependencyObject d)
-        {
-            result = AutomationProperties.GetName(d);
-        }
-
-        if (result == string.Empty && owner.Header is string s)
-        {
-            result = s;
-        }
-
-        return result;
     }
 }

--- a/src/Wpf.Ui/Controls/CardAction/CardAction.cs
+++ b/src/Wpf.Ui/Controls/CardAction/CardAction.cs
@@ -5,13 +5,14 @@
 
 // ReSharper disable once CheckNamespace
 using System.Windows.Automation.Peers;
+using System.Windows.Controls.Primitives;
 
 namespace Wpf.Ui.Controls;
 
 /// <summary>
 /// Inherited from the <see cref="System.Windows.Controls.Primitives.ButtonBase"/> interactive card styled according to Fluent Design.
 /// </summary>
-public class CardAction : System.Windows.Controls.Primitives.ButtonBase
+public class CardAction : ButtonBase
 {
     /// <summary>Identifies the <see cref="IsChevronVisible"/> dependency property.</summary>
     public static readonly DependencyProperty IsChevronVisibleProperty = DependencyProperty.Register(
@@ -55,4 +56,6 @@ public class CardAction : System.Windows.Controls.Primitives.ButtonBase
     {
         return new CardActionAutomationPeer(this);
     }
+
+    internal void AutomationClick() => this.OnClick();
 }

--- a/src/Wpf.Ui/Controls/CardAction/CardActionAutomationPeer.cs
+++ b/src/Wpf.Ui/Controls/CardAction/CardActionAutomationPeer.cs
@@ -3,25 +3,18 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Threading;
 
 namespace Wpf.Ui.Controls;
 
-internal class CardActionAutomationPeer : FrameworkElementAutomationPeer
+internal class CardActionAutomationPeer : FrameworkElementAutomationPeer, IInvokeProvider
 {
-    private readonly CardAction _owner;
-
     public CardActionAutomationPeer(CardAction owner)
         : base(owner)
-    {
-        _owner = owner;
-    }
+    { }
 
     protected override string GetClassNameCore()
     {
@@ -35,7 +28,7 @@ internal class CardActionAutomationPeer : FrameworkElementAutomationPeer
 
     public override object GetPattern(PatternInterface patternInterface)
     {
-        if (patternInterface == PatternInterface.ItemContainer)
+        if (patternInterface == PatternInterface.Invoke)
         {
             return this;
         }
@@ -43,35 +36,19 @@ internal class CardActionAutomationPeer : FrameworkElementAutomationPeer
         return base.GetPattern(patternInterface);
     }
 
-    protected override AutomationPeer GetLabeledByCore()
+    void IInvokeProvider.Invoke()
     {
-        if (_owner.Content is UIElement element)
+        if (!IsEnabled())
         {
-            return CreatePeerForElement(element);
+            throw new ElementNotEnabledException();
         }
 
-        return base.GetLabeledByCore();
-    }
-
-    protected override string GetNameCore()
-    {
-        var result = base.GetNameCore() ?? string.Empty;
-
-        if (result == string.Empty)
+        // Async call of click event
+        // In ClickHandler opens a dialog and suspend the execution we don't want to block this thread
+        Dispatcher.BeginInvoke(DispatcherPriority.Input, new DispatcherOperationCallback(_ =>
         {
-            result = AutomationProperties.GetName(_owner);
-        }
-
-        if (result == string.Empty && _owner.Content is DependencyObject d)
-        {
-            result = AutomationProperties.GetName(d);
-        }
-
-        if (result == string.Empty && _owner.Content is string s)
-        {
-            result = s;
-        }
-
-        return result;
+            ((CardAction)Owner).AutomationClick();
+            return null;
+        }), null);
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

```
Unable to cast object of type 'Wpf.Ui.Controls.CardActionAutomationPeer' to type 'System.Windows.Automation.Provider.IItemContainerProvider'.
``` 


## What is the new behavior?

Similar to my previous PR (https://github.com/lepoco/wpfui/pull/1646), the existing automation peers are not working correctly. The logic was flawed. For CardActionAutomationPeer, we can base it on [ButtonAutomationPeer](https://github.com/dotnet/wpf/tree/fb0e2171a55f793fe51754041ec597a3c7a7d2b7/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ButtonAutomationPeer.cs). For CardControlAutomationPeer, use [FrameAutomationPeer](https://github.com/dotnet/wpf/blob/fb0e2171a55f793fe51754041ec597a3c7a7d2b7/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/FrameAutomationPeer.cs) as this control doesn't have actions on its own.