### PR TITLE
fix(controls): Center align DynamicScrollBar Grid elements

### DIFF
--- a/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
@@ -106,7 +106,7 @@
     </Style>
 
     <ControlTemplate x:Key="DynamicVerticalScrollBar" TargetType="{x:Type controls:DynamicScrollBar}">
-        <Grid>
+        <Grid HorizontalAlignment="Center">
             <Grid.RowDefinitions>
                 <RowDefinition MaxHeight="14" />
                 <RowDefinition Height="0.00001*" />
@@ -250,7 +250,7 @@
     </ControlTemplate>
 
     <ControlTemplate x:Key="DynamicHorizontalScrollBar" TargetType="{x:Type controls:DynamicScrollBar}">
-        <Grid>
+        <Grid VerticalAlignment="Center">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition MaxWidth="18" />
                 <ColumnDefinition Width="0.00001*" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

See:
https://github.com/lepoco/wpfui/pull/1669


## What is the new behavior?

Simple fix by centering the elements.

Old:
<img width="59" height="100" alt="image" src="https://github.com/user-attachments/assets/c4119e9d-dd04-40b4-858c-bced48e12156" />

New:
<img width="102" height="103" alt="image" src="https://github.com/user-attachments/assets/2a287bf2-3d8d-494f-b8f6-9d7e44bf31ac" />
