### PR TITLE
fix: Update SystemThemeWatcher WndProc to listen to Windows theme changes

### DIFF
--- a/src/Wpf.Ui/Appearance/SystemThemeWatcher.cs
+++ b/src/Wpf.Ui/Appearance/SystemThemeWatcher.cs
@@ -3,6 +3,7 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
+using System.Runtime.InteropServices;
 using Windows.Win32;
 using Wpf.Ui.Controls;
 using Wpf.Ui.Interop;
@@ -155,6 +156,9 @@ public static class SystemThemeWatcher
             msg == (int)PInvoke.WM_DWMCOLORIZATIONCOLORCHANGED
             || msg == (int)PInvoke.WM_THEMECHANGED
             || msg == (int)PInvoke.WM_SYSCOLORCHANGE
+            || (msg == (int)PInvoke.WM_SETTINGCHANGE &&
+                lParam != IntPtr.Zero &&
+                string.Equals(Marshal.PtrToStringUni(lParam), "ImmersiveColorSet", StringComparison.Ordinal))
         )
         {
             UpdateObservedWindow(hWnd);


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, WndProc in SystemThemeWatcher only listens to `WM_DWMCOLORIZATIONCOLORCHANGED`, `WM_THEMECHANGED` and `WM_SYSCOLORCHANGE` messages. These don't fire when theme changes happen through Windows Settings > Personalization > Colors > Choose your mode (Light/Dark). 

The [docs](https://wpfui.lepo.co/documentation/themes.html#theme-changed-event) imply that `ApplicationThemeManager.Changed` triggers from "automatic updates", which I believe should include Windows theme changes as well.

Issue Number: #1656

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

1. Listens to WM_SETTINGCHANGE (Windows settings option changed) on top of currently established Windows Message conditions
2. Conditional check to ensure that the "ImmersiveColorSet" lParam was provided (specifically theming that was changed)
