### PR TITLE
fix(controls): Fix ProgressRing not restarting properly when visibily changes

### DIFF
--- a/src/Wpf.Ui/Controls/ProgressRing/ProgressRing.xaml
+++ b/src/Wpf.Ui/Controls/ProgressRing/ProgressRing.xaml
@@ -65,51 +65,42 @@
                                 </controls:Arc>
                             </Grid>
                             <ControlTemplate.Triggers>
+                                <EventTrigger SourceName="Arc" RoutedEvent="Loaded">
+                                    <BeginStoryboard Name="RotateStoryboard">
+                                        <Storyboard>
+                                            <DoubleAnimation
+                                                RepeatBehavior="Forever"
+                                                Storyboard.TargetName="Arc"
+                                                Storyboard.TargetProperty="(Canvas.RenderTransform).(RotateTransform.Angle)"
+                                                To="360"
+                                                Duration="0:0:2" />
+                                            <DoubleAnimation
+                                                AutoReverse="True"
+                                                RepeatBehavior="Forever"
+                                                Storyboard.TargetName="Arc"
+                                                Storyboard.TargetProperty="EndAngle"
+                                                From="100"
+                                                To="320"
+                                                Duration="0:0:5" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </EventTrigger>
                                 <Trigger Property="IsEnabled" Value="True">
                                     <Trigger.EnterActions>
-                                        <BeginStoryboard>
-                                            <Storyboard>
-                                                <DoubleAnimation
-                                                    RepeatBehavior="Forever"
-                                                    Storyboard.TargetName="Arc"
-                                                    Storyboard.TargetProperty="(Canvas.RenderTransform).(RotateTransform.Angle)"
-                                                    To="360"
-                                                    Duration="0:0:2" />
-
-                                                <DoubleAnimation
-                                                    AutoReverse="True"
-                                                    RepeatBehavior="Forever"
-                                                    Storyboard.TargetName="Arc"
-                                                    Storyboard.TargetProperty="EndAngle"
-                                                    From="100"
-                                                    To="320"
-                                                    Duration="0:0:5" />
-                                            </Storyboard>
-                                        </BeginStoryboard>
+                                        <ResumeStoryboard BeginStoryboardName="RotateStoryboard" />
                                     </Trigger.EnterActions>
+                                    <Trigger.ExitActions>
+                                        <PauseStoryboard BeginStoryboardName="RotateStoryboard" />
+                                    </Trigger.ExitActions>
                                 </Trigger>
                                 <Trigger Property="IsVisible" Value="True">
                                     <Trigger.EnterActions>
-                                        <BeginStoryboard>
-                                            <Storyboard>
-                                                <DoubleAnimation
-                                                    RepeatBehavior="Forever"
-                                                    Storyboard.TargetName="Arc"
-                                                    Storyboard.TargetProperty="(Canvas.RenderTransform).(RotateTransform.Angle)"
-                                                    To="360"
-                                                    Duration="0:0:2" />
-
-                                                <DoubleAnimation
-                                                    AutoReverse="True"
-                                                    RepeatBehavior="Forever"
-                                                    Storyboard.TargetName="Arc"
-                                                    Storyboard.TargetProperty="EndAngle"
-                                                    From="100"
-                                                    To="320"
-                                                    Duration="0:0:5" />
-                                            </Storyboard>
-                                        </BeginStoryboard>
+                                        <ResumeStoryboard BeginStoryboardName="RotateStoryboard" />
                                     </Trigger.EnterActions>
+                                    <Trigger.ExitActions>
+                                        <PauseStoryboard BeginStoryboardName="RotateStoryboard" />
+                                        <SeekStoryboard BeginStoryboardName="RotateStoryboard" Offset="0" />
+                                    </Trigger.ExitActions>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>

--- a/src/Wpf.Ui/Controls/ProgressRing/ProgressRing.xaml
+++ b/src/Wpf.Ui/Controls/ProgressRing/ProgressRing.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     This Source Code Form is subject to the terms of the MIT License.
     If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
@@ -87,11 +87,29 @@
                                             </Storyboard>
                                         </BeginStoryboard>
                                     </Trigger.EnterActions>
-                                    <Trigger.ExitActions>
+                                </Trigger>
+                                <Trigger Property="IsVisible" Value="True">
+                                    <Trigger.EnterActions>
                                         <BeginStoryboard>
-                                            <Storyboard />
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    RepeatBehavior="Forever"
+                                                    Storyboard.TargetName="Arc"
+                                                    Storyboard.TargetProperty="(Canvas.RenderTransform).(RotateTransform.Angle)"
+                                                    To="360"
+                                                    Duration="0:0:2" />
+
+                                                <DoubleAnimation
+                                                    AutoReverse="True"
+                                                    RepeatBehavior="Forever"
+                                                    Storyboard.TargetName="Arc"
+                                                    Storyboard.TargetProperty="EndAngle"
+                                                    From="100"
+                                                    To="320"
+                                                    Duration="0:0:5" />
+                                            </Storyboard>
                                         </BeginStoryboard>
-                                    </Trigger.ExitActions>
+                                    </Trigger.EnterActions>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

If you hide an indeterminate progress ring (e.g., after loading is done), and then show it again, the progress ring doesn't restart the animation properly, rendering a partial progress ring (+ looks like broken animation) due to the angle not getting reset.

## What is the new behavior?

Restart the animation after visibily changed (reuses the IsEnabled path).