### PR TITLE
feat(controls): Make Durations customizable

### DIFF
--- a/src/Wpf.Ui/Animations/AnimationDurationExtension.cs
+++ b/src/Wpf.Ui/Animations/AnimationDurationExtension.cs
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.Windows.Markup;
+
+namespace Wpf.Ui.Animations;
+
+/// <summary>
+/// A XAML markup extension that resolves an <see cref="AnimationDuration"/> key
+/// to a concrete <see cref="Duration"/> value at parse time.
+/// This allows Storyboard animations to reference configurable durations
+/// without requiring <c>DynamicResource</c> (which cannot be frozen).
+/// </summary>
+/// <example>
+/// <code lang="xml">
+/// &lt;!-- Positional syntax --&gt;
+/// Duration="{markup:AnimationDuration Slow}"
+///
+/// &lt;!-- Named property syntax --&gt;
+/// Duration="{markup:AnimationDuration Duration=Slow}"
+/// </code>
+/// </example>
+public class AnimationDurationExtension : MarkupExtension
+{
+    /// <summary>
+    /// Gets or sets the <see cref="AnimationDuration"/> key to resolve.
+    /// </summary>
+    public AnimationDuration Duration { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnimationDurationExtension"/> class.
+    /// </summary>
+    public AnimationDurationExtension() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnimationDurationExtension"/> class.
+    /// </summary>
+    public AnimationDurationExtension(AnimationDuration animationDuration)
+    {
+        Duration = animationDuration;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="System.Windows.Duration"/> associated with the current
+    /// <see cref="Duration"/> key, including any user-defined override.
+    /// </summary>
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        return AnimationDurationsDictionary.Get(Duration);
+    }
+}
+
+/// <summary>
+/// Defines the speed categories available for control animations.
+/// Each key maps to a <see cref="Duration"/> value held in
+/// <see cref="AnimationDurationsDictionary"/>.
+/// </summary>
+public enum AnimationDuration
+{
+    /// <summary>
+    /// A longer duration intended for prominent or decorative transitions.
+    /// </summary>
+    SlowDuration,
+
+    /// <summary>
+    /// The standard duration for most interactive feedback animations.
+    /// </summary>
+    NormalDuration,
+
+    /// <summary>
+    /// A shorter duration for rapid state changes.
+    /// </summary>
+    FastDuration,
+}
+
+/// <summary>
+/// A static registry that maps each <see cref="AnimationDuration"/> key to a
+/// <see cref="Duration"/> value. Defaults are provided out of the box and can be
+/// overridden at application startup via <see cref="Set"/> or through the
+/// corresponding properties on <see cref="ControlsDictionary"/>
+/// (e.g. <c>&lt;ui:ControlsDictionary SlowDuration="0:0:0.9" /&gt;</c>).
+/// Overrides must be applied before the control dictionaries are loaded,
+/// because <see cref="AnimationDurationExtension"/> resolves values at XAML parse time.
+/// </summary>
+public static class AnimationDurationsDictionary
+{
+    private static readonly Dictionary<AnimationDuration, Duration> Defaults = new()
+    {
+        [AnimationDuration.SlowDuration] = new Duration(TimeSpan.FromMilliseconds(333)),
+        [AnimationDuration.NormalDuration] = new Duration(TimeSpan.FromMilliseconds(167)),
+        [AnimationDuration.FastDuration] = new Duration(TimeSpan.FromMilliseconds(80)),
+    };
+
+    private static readonly Dictionary<AnimationDuration, Duration> Overrides = [];
+
+    /// <summary>
+    /// Returns the <see cref="Duration"/> for the specified <paramref name="key"/>,
+    /// using the user-defined override if one exists, otherwise the built-in default.
+    /// </summary>
+    /// <param name="key">The animation speed category to look up.</param>
+    public static Duration Get(AnimationDuration key)
+    {
+        return Overrides.TryGetValue(key, out Duration value)
+            ? value
+            : Defaults[key];
+    }
+
+    /// <summary>
+    /// Overrides the <see cref="Duration"/> for the specified <paramref name="key"/>.
+    /// Must be called before the WPF UI control dictionaries are parsed.
+    /// </summary>
+    /// <param name="key">The animation speed category to override.</param>
+    /// <param name="value">The desired duration.</param>
+    public static void Set(AnimationDuration key, TimeSpan value)
+    {
+        Overrides[key] = new Duration(value);
+    }
+}

--- a/src/Wpf.Ui/Animations/AnimationDurationExtension.cs
+++ b/src/Wpf.Ui/Animations/AnimationDurationExtension.cs
@@ -86,14 +86,12 @@ public enum AnimationDuration
 /// </summary>
 public static class AnimationDurationsDictionary
 {
-    private static readonly Dictionary<AnimationDuration, Duration> Defaults = new()
+    private static readonly Dictionary<AnimationDuration, Duration> Durations = new()
     {
         [AnimationDuration.SlowDuration] = new Duration(TimeSpan.FromMilliseconds(333)),
         [AnimationDuration.NormalDuration] = new Duration(TimeSpan.FromMilliseconds(167)),
         [AnimationDuration.FastDuration] = new Duration(TimeSpan.FromMilliseconds(80)),
     };
-
-    private static readonly Dictionary<AnimationDuration, Duration> Overrides = [];
 
     /// <summary>
     /// Returns the <see cref="Duration"/> for the specified <paramref name="key"/>,
@@ -102,9 +100,7 @@ public static class AnimationDurationsDictionary
     /// <param name="key">The animation speed category to look up.</param>
     public static Duration Get(AnimationDuration key)
     {
-        return Overrides.TryGetValue(key, out Duration value)
-            ? value
-            : Defaults[key];
+        return Durations[key];
     }
 
     /// <summary>
@@ -115,6 +111,6 @@ public static class AnimationDurationsDictionary
     /// <param name="value">The desired duration.</param>
     public static void Set(AnimationDuration key, TimeSpan value)
     {
-        Overrides[key] = new Duration(value);
+        Durations[key] = new Duration(value);
     }
 }

--- a/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
+++ b/src/Wpf.Ui/Controls/AutoSuggestBox/AutoSuggestBox.xaml
@@ -2,6 +2,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <Thickness x:Key="AutoSuggestBoxBorderThemeThickness">1,1,1,0</Thickness>
@@ -68,7 +69,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -80,7 +81,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.ExitActions>

--- a/src/Wpf.Ui/Controls/CardExpander/CardExpander.xaml
+++ b/src/Wpf.Ui/Controls/CardExpander/CardExpander.xaml
@@ -64,7 +64,7 @@
                                 Storyboard.TargetName="ChevronGrid"
                                 Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)"
                                 To="180"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -75,7 +75,7 @@
                                 Storyboard.TargetName="ChevronGrid"
                                 Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)"
                                 To="0"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/CheckBox/CheckBox.xaml
+++ b/src/Wpf.Ui/Controls/CheckBox/CheckBox.xaml
@@ -13,6 +13,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
     xmlns:converters="clr-namespace:Wpf.Ui.Converters"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <!--
@@ -33,7 +34,6 @@
     <system:Double x:Key="CheckBoxHeight">20</system:Double>
     <system:Double x:Key="CheckBoxWidth">20</system:Double>
     <system:TimeSpan x:Key="CheckBoxAnimationOffset">00:00:00.250</system:TimeSpan>
-    <Duration x:Key="CheckBoxAnimationDuration">00:00:00.250</Duration>
     <converters:ClipConverter x:Key="ClipConverter" />
 
     <Style x:Key="DefaultCheckBoxStyle" TargetType="{x:Type CheckBox}">
@@ -140,7 +140,7 @@
                                             Storyboard.TargetProperty="Tag"
                                             From="0"
                                             To="1"
-                                            Duration="{StaticResource CheckBoxAnimationDuration}">
+                                            Duration="{animations:AnimationDuration NormalDuration}">
                                             <DoubleAnimation.EasingFunction>
                                                 <CubicEase EasingMode="EaseOut" />
                                             </DoubleAnimation.EasingFunction>

--- a/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
+++ b/src/Wpf.Ui/Controls/ComboBox/ComboBox.xaml
@@ -14,6 +14,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animation="clr-namespace:Wpf.Ui.Animations"
     xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <Thickness x:Key="ComboBoxPadding">10,8,10,8</Thickness>
@@ -333,13 +334,13 @@
                                             Storyboard.TargetProperty="(controls:SymbolIcon.RenderTransform).(RotateTransform.Angle)"
                                             From="0"
                                             To="180"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animation:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="DropDownBorder"
                                             Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
                                             From="-90"
                                             To="0"
-                                            Duration="00:00:00.167">
+                                            Duration="{animation:AnimationDuration NormalDuration}">
                                             <DoubleAnimation.EasingFunction>
                                                 <CircleEase EasingMode="EaseOut" />
                                             </DoubleAnimation.EasingFunction>
@@ -355,7 +356,7 @@
                                             Storyboard.TargetProperty="(controls:SymbolIcon.RenderTransform).(RotateTransform.Angle)"
                                             From="180"
                                             To="0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animation:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/ContextMenu/ContextMenu.xaml
+++ b/src/Wpf.Ui/Controls/ContextMenu/ContextMenu.xaml
@@ -8,7 +8,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
 
     <Style x:Key="UiContextMenu" TargetType="{x:Type ContextMenu}">
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ContextMenuForeground}" />
@@ -62,7 +63,7 @@
                                             Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
                                             From="-90"
                                             To="0"
-                                            Duration="00:00:00.167">
+                                            Duration="{animations:AnimationDuration NormalDuration}">
                                             <DoubleAnimation.EasingFunction>
                                                 <CircleEase EasingMode="EaseOut" />
                                             </DoubleAnimation.EasingFunction>

--- a/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
+++ b/src/Wpf.Ui/Controls/DataGrid/DataGrid.xaml
@@ -19,6 +19,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations"
     xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <ResourceDictionary.MergedDictionaries>
@@ -645,7 +646,7 @@
                                             Storyboard.TargetProperty="(controls:SymbolIcon.RenderTransform).(RotateTransform.Angle)"
                                             From="0"
                                             To="180"
-                                            Duration="00:00:00.333" />
+                                            Duration="{animations:AnimationDuration SlowDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.EnterActions>
@@ -657,7 +658,7 @@
                                             Storyboard.TargetProperty="(controls:SymbolIcon.RenderTransform).(RotateTransform.Angle)"
                                             From="180"
                                             To="0"
-                                            Duration="00:00:00.333" />
+                                            Duration="{animations:AnimationDuration SlowDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/DynamicScrollBar/DynamicScrollBar.xaml
@@ -2,10 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations"
     xmlns:sys="clr-namespace:System;assembly=mscorlib">
-
-    <Duration x:Key="DynamicScrollAnimationDuration">0:0:0.16</Duration>
-    <Duration x:Key="DynamicButtonHoverAnimationDuration">0:0:0.16</Duration>
 
     <sys:Double x:Key="DynamicLineButtonHeight">12</sys:Double>
     <sys:Double x:Key="DynamicLineButtonWidth">12</sys:Double>
@@ -48,7 +46,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="{StaticResource DynamicButtonHoverAnimationDuration}" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.EnterActions>
@@ -60,7 +58,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="{StaticResource DynamicButtonHoverAnimationDuration}" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>
@@ -167,25 +165,25 @@
                                 Storyboard.TargetProperty="Width"
                                 From="6"
                                 To="8"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollUp"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollDown"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -197,25 +195,25 @@
                                 Storyboard.TargetProperty="Width"
                                 From="8"
                                 To="6"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollUp"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollDown"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>
@@ -229,7 +227,7 @@
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -241,7 +239,7 @@
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>
@@ -314,25 +312,25 @@
                                 Storyboard.TargetProperty="Height"
                                 From="6"
                                 To="8"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollLeft"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollRight"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -344,25 +342,25 @@
                                 Storyboard.TargetProperty="Height"
                                 From="8"
                                 To="6"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollLeft"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollRight"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>
@@ -376,7 +374,7 @@
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -388,7 +386,7 @@
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource DynamicScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/Expander/Expander.xaml
+++ b/src/Wpf.Ui/Controls/Expander/Expander.xaml
@@ -59,7 +59,7 @@
                                 Storyboard.TargetName="ChevronGrid"
                                 Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)"
                                 To="180"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -70,7 +70,7 @@
                                 Storyboard.TargetName="ChevronGrid"
                                 Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)"
                                 To="0"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
+++ b/src/Wpf.Ui/Controls/Menu/MenuItem.xaml
@@ -8,7 +8,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/DefaultFocusVisualStyle.xaml" />
@@ -164,7 +165,7 @@
                                 Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
                                 From="-90"
                                 To="0"
-                                Duration="00:00:00.167">
+                                Duration="{animations:AnimationDuration NormalDuration}">
                                 <DoubleAnimation.EasingFunction>
                                     <CircleEase EasingMode="EaseOut" />
                                 </DoubleAnimation.EasingFunction>
@@ -478,7 +479,7 @@
                                 Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
                                 From="-90"
                                 To="0"
-                                Duration="00:00:00.167">
+                                Duration="{animations:AnimationDuration NormalDuration}">
                                 <DoubleAnimation.EasingFunction>
                                     <CircleEase EasingMode="EaseOut" />
                                 </DoubleAnimation.EasingFunction>
@@ -649,7 +650,7 @@
                                 Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
                                 From="-90"
                                 To="0"
-                                Duration="00:00:00.167">
+                                Duration="{animations:AnimationDuration NormalDuration}">
                                 <DoubleAnimation.EasingFunction>
                                     <CircleEase EasingMode="EaseOut" />
                                 </DoubleAnimation.EasingFunction>
@@ -976,7 +977,7 @@
                                 Storyboard.TargetProperty="(Border.RenderTransform).(TranslateTransform.Y)"
                                 From="-90"
                                 To="0"
-                                Duration="00:00:00.167">
+                                Duration="{animations:AnimationDuration NormalDuration}">
                                 <DoubleAnimation.EasingFunction>
                                     <CircleEase EasingMode="EaseOut" />
                                 </DoubleAnimation.EasingFunction>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationLeftFluent.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationLeftFluent.xaml
@@ -1,7 +1,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/NavigationView/NavigationViewConstants.xaml" />
     </ResourceDictionary.MergedDictionaries>
@@ -83,19 +84,19 @@
                                 Storyboard.TargetProperty="Height"
                                 From="{StaticResource NavigationViewFluentIconSize}"
                                 To="0"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="ContentGrid"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1"
                                 To="0"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="MainBorder"
                                 Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Opacity)"
                                 From="0"
                                 To="1"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -107,19 +108,19 @@
                                 Storyboard.TargetProperty="Height"
                                 From="0"
                                 To="{StaticResource NavigationViewFluentIconSize}"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="ContentGrid"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0"
                                 To="1"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="MainBorder"
                                 Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Opacity)"
                                 From="1"
                                 To="0"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewBasePaneButtonStyle.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewBasePaneButtonStyle.xaml
@@ -1,7 +1,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/NavigationView/NavigationViewConstants.xaml" />
     </ResourceDictionary.MergedDictionaries>
@@ -87,7 +88,7 @@
                                         Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                                         From="1.0"
                                         To="0.66"
-                                        Duration="0:0:0.08" />
+                                        Duration="{animations:AnimationDuration FastDuration}" />
                                 </Storyboard>
                             </BeginStoryboard>
                         </EventTrigger>
@@ -99,7 +100,7 @@
                                         Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                                         From="0.66"
                                         To="1.0"
-                                        Duration="0:0:0.08" />
+                                        Duration="{animations:AnimationDuration FastDuration}" />
                                 </Storyboard>
                             </BeginStoryboard>
                         </EventTrigger>

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewCompact.xaml
@@ -1,7 +1,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/NavigationView/NavigationViewBasePaneButtonStyle.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/NavigationView/NavigationViewItemDefaultStyle.xaml" />
@@ -229,12 +230,12 @@
                                 Storyboard.TargetProperty="(ItemsControl.Opacity)"
                                 From="0.0"
                                 To="1.0"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="ChevronIcon"
                                 Storyboard.TargetProperty="(Control.RenderTransform).(RotateTransform.Angle)"
                                 To="-180"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -246,12 +247,12 @@
                                 Storyboard.TargetProperty="(ItemsControl.Opacity)"
                                 From="1.0"
                                 To="0.0"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="ChevronIcon"
                                 Storyboard.TargetProperty="(Control.RenderTransform).(RotateTransform.Angle)"
                                 To="0"
-                                Duration="00:00:00.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>
@@ -486,14 +487,14 @@
                                 Storyboard.TargetProperty="Width"
                                 From="40"
                                 To="{TemplateBinding OpenPaneLength}"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 AccelerationRatio="0.4"
                                 Storyboard.TargetName="AutoSuggestBoxContentPresenter"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0"
                                 To="1"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </VisualState>
                     <VisualState Name="PaneCompact">
@@ -504,21 +505,21 @@
                                 Storyboard.TargetProperty="Opacity"
                                 From="1"
                                 To="0"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 AccelerationRatio="0.4"
                                 Storyboard.TargetName="PART_AutoSuggestBoxSymbolButton"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0"
                                 To="1"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 AccelerationRatio="0.4"
                                 Storyboard.TargetName="PaneGrid"
                                 Storyboard.TargetProperty="Width"
                                 From="{TemplateBinding OpenPaneLength}"
                                 To="40"
-                                Duration="0:0:.16" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <ObjectAnimationUsingKeyFrames
                                 BeginTime="0:0:0.16"
                                 Storyboard.TargetName="AutoSuggestBoxContentPresenter"

--- a/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
+++ b/src/Wpf.Ui/Controls/NavigationView/NavigationViewTop.xaml
@@ -2,7 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
-    xmlns:converters="clr-namespace:Wpf.Ui.Converters">
+    xmlns:converters="clr-namespace:Wpf.Ui.Converters"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/NavigationView/NavigationViewBasePaneButtonStyle.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Controls/NavigationView/NavigationViewItemDefaultStyle.xaml" />
@@ -323,12 +324,12 @@
                                 Storyboard.TargetProperty="(UIElement.Opacity)"
                                 From="0.0"
                                 To="1.0"
-                                Duration="0:0:0.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <!--<DoubleAnimation
                                 Storyboard.TargetName="ChevronIcon"
                                 Storyboard.TargetProperty="(Control.RenderTransform).(RotateTransform.Angle)"
                                 To="-180"
-                                Duration="00:00:00.167" />-->
+                                Duration="{animations:AnimationDuration NormalDuration}" />-->
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -340,13 +341,13 @@
                                 Storyboard.TargetProperty="(UIElement.Opacity)"
                                 From="1.0"
                                 To="0.0"
-                                Duration="0:0:0.167" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
 
                             <!--<DoubleAnimation
                                 Storyboard.TargetName="ChevronIcon"
                                 Storyboard.TargetProperty="(Control.RenderTransform).(RotateTransform.Angle)"
                                 To="0"
-                                Duration="00:00:00.167" />-->
+                                Duration="{animations:AnimationDuration NormalDuration}" />-->
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/RadioButton/RadioButton.xaml
+++ b/src/Wpf.Ui/Controls/RadioButton/RadioButton.xaml
@@ -11,7 +11,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
 
     <system:Double x:Key="RadioButtonCheckGlyphSize">11</system:Double>
     <system:Double x:Key="RadioButtonOuterEllipseSize">20</system:Double>
@@ -119,12 +120,12 @@
                                             Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleY)"
                                             To="1.2"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleX)"
                                             To="1.2"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -169,13 +170,13 @@
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleY)"
                                             From="0.7"
                                             To="1.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleX)"
                                             From="0.7"
                                             To="1.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -197,13 +198,13 @@
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleY)"
                                             From="1.2"
                                             To=".95"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleX)"
                                             From="1.2"
                                             To=".95"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.EnterActions>
@@ -214,12 +215,12 @@
                                             Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleY)"
                                             To="1.2"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="(Ellipse.LayoutTransform).(ScaleTransform.ScaleX)"
                                             To="1.2"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </MultiTrigger.ExitActions>

--- a/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
@@ -9,10 +9,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations"
     xmlns:sys="clr-namespace:System;assembly=mscorlib">
-
-    <Duration x:Key="ScrollAnimationDuration">0:0:0.16</Duration>
-    <Duration x:Key="ButtonHoverAnimationDuration">0:0:0.16</Duration>
 
     <sys:Double x:Key="LineButtonHeight">12</sys:Double>
     <sys:Double x:Key="LineButtonWidth">12</sys:Double>
@@ -55,7 +53,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="{StaticResource ButtonHoverAnimationDuration}" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.EnterActions>
@@ -67,7 +65,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="{StaticResource ButtonHoverAnimationDuration}" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>
@@ -175,25 +173,25 @@
                                 Storyboard.TargetProperty="Width"
                                 From="6"
                                 To="8"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollUp"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollDown"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -205,25 +203,25 @@
                                 Storyboard.TargetProperty="Width"
                                 From="8"
                                 To="6"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollUp"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollDown"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>
@@ -293,25 +291,25 @@
                                 Storyboard.TargetProperty="Height"
                                 From="6"
                                 To="8"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollLeft"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollRight"
                                 Storyboard.TargetProperty="Opacity"
                                 From="0.0"
                                 To="1.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -323,25 +321,25 @@
                                 Storyboard.TargetProperty="Height"
                                 From="8"
                                 To="6"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollLeft"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_ButtonScrollRight"
                                 Storyboard.TargetProperty="Opacity"
                                 From="1.0"
                                 To="0.0"
-                                Duration="{StaticResource ScrollAnimationDuration}" />
+                                Duration="{animations:AnimationDuration NormalDuration}" />
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/TabControl/TabControl.xaml
+++ b/src/Wpf.Ui/Controls/TabControl/TabControl.xaml
@@ -5,7 +5,9 @@
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
 
     <Style TargetType="{x:Type TabControl}">
         <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
@@ -108,7 +110,7 @@
                                             Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="0.5"
-                                            Duration="0:0:.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>

--- a/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
+++ b/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
@@ -12,7 +12,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
-    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
 
     <system:Double x:Key="RadioButtonBorderThemeThickness">1</system:Double>
     <system:Double x:Key="ToggleButtonWidth">40</system:Double>
@@ -153,37 +154,37 @@
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ActiveToggleRectangle"
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ActiveToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.RenderTransform).(TranslateTransform.X)"
                                             From="-9"
                                             To="9"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ActiveToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.RenderTransform).(TranslateTransform.X)"
                                             From="-9"
                                             To="9"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.EnterActions>
@@ -195,37 +196,37 @@
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ActiveToggleRectangle"
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ActiveToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.RenderTransform).(TranslateTransform.X)"
                                             From="9"
                                             To="-9"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                         <DoubleAnimation
                                             Storyboard.TargetName="ActiveToggleEllipse"
                                             Storyboard.TargetProperty="(Rectangle.RenderTransform).(TranslateTransform.X)"
                                             From="9"
                                             To="-9"
-                                            Duration="00:00:00.167" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/ToolBar/ToolBar.xaml
+++ b/src/Wpf.Ui/Controls/ToolBar/ToolBar.xaml
@@ -8,7 +8,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Wpf.Ui.Controls">
+    xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations">
 
     <Style x:Key="ToolBarButtonBaseStyle" TargetType="{x:Type ButtonBase}">
         <Setter Property="Background">
@@ -46,7 +47,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="0:0:0.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.EnterActions>
@@ -58,7 +59,7 @@
                                             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Opacity)"
                                             From="1.0"
                                             To="0.0"
-                                            Duration="0:0:0.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>

--- a/src/Wpf.Ui/Controls/TreeView/TreeViewItem.xaml
+++ b/src/Wpf.Ui/Controls/TreeView/TreeViewItem.xaml
@@ -9,6 +9,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Wpf.Ui.Controls"
+    xmlns:animations="clr-namespace:Wpf.Ui.Animations"
     xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <system:Double x:Key="TreeViewItemChevronSize">10</system:Double>
@@ -48,7 +49,7 @@
                                             Storyboard.TargetName="ChevronContainer"
                                             Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)"
                                             To="90"
-                                            Duration="0:0:0.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.EnterActions>
@@ -59,7 +60,7 @@
                                             Storyboard.TargetName="ChevronContainer"
                                             Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)"
                                             To="0"
-                                            Duration="0:0:0.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>
@@ -250,7 +251,7 @@
                             <!--
                             <VisualStateGroup Name="CommonStates">
                                 <VisualStateGroup.Transitions>
-                                    <VisualTransition GeneratedDuration="0:0:0.16" />
+                                    <VisualTransition GeneratedDuration="{animations:AnimationDuration NormalDuration}" />
                                 </VisualStateGroup.Transitions>
                                 <VisualState Name="Normal" />
                                 <VisualState Name="MouseOver">
@@ -259,7 +260,7 @@
                                             Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="0.5"
-                                            Duration="0:0:.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState Name="Pressed" />
@@ -273,7 +274,7 @@
                                             Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="0:0:.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Unselected" />
@@ -283,7 +284,7 @@
                                             Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Opacity)"
                                             From="0.0"
                                             To="1.0"
-                                            Duration="0:0:.16" />
+                                            Duration="{animations:AnimationDuration NormalDuration}" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>

--- a/src/Wpf.Ui/Markup/ControlsDictionary.cs
+++ b/src/Wpf.Ui/Markup/ControlsDictionary.cs
@@ -4,6 +4,7 @@
 // All Rights Reserved.
 
 using System.Windows.Markup;
+using Wpf.Ui.Animations;
 using Wpf.Ui.Controls;
 
 namespace Wpf.Ui.Markup;
@@ -32,13 +33,54 @@ public class ControlsDictionary : ResourceDictionary
 {
     private const string DictionaryUri = "pack://application:,,,/Wpf.Ui;component/Resources/Wpf.Ui.xaml";
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ControlsDictionary"/> class.
-    /// Default constructor defining <see cref="ResourceDictionary.Source"/> of the <c>WPF UI</c> controls dictionary.
-    /// </summary>
     public ControlsDictionary()
     {
         Source = new Uri(DictionaryUri, UriKind.Absolute);
         TextBlockMetadata.Initialize();
+    }
+
+    /// <summary>
+    /// Gets or sets the duration used by animations marked as <see cref="AnimationDuration.SlowDuration"/>.
+    /// The default value is 333 ms. Set this before the dictionary is loaded to override the default.
+    /// </summary>
+    /// <example>
+    /// <code lang="xml">
+    /// &lt;ui:ControlsDictionary SlowDuration="0:0:0.9" /&gt;
+    /// </code>
+    /// </example>
+    public TimeSpan SlowDuration
+    {
+        get => AnimationDurationsDictionary.Get(AnimationDuration.SlowDuration).TimeSpan;
+        set => AnimationDurationsDictionary.Set(AnimationDuration.SlowDuration, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the duration used by animations marked as <see cref="AnimationDuration.NormalDuration"/>.
+    /// The default value is 167 ms. Set this before the dictionary is loaded to override the default.
+    /// </summary>
+    /// <example>
+    /// <code lang="xml">
+    /// &lt;ui:ControlsDictionary SlowDuration="0:0:0.9" /&gt;
+    /// </code>
+    /// </example>
+    public TimeSpan NormalDuration
+    {
+        get => AnimationDurationsDictionary.Get(AnimationDuration.NormalDuration).TimeSpan;
+        set => AnimationDurationsDictionary.Set(AnimationDuration.NormalDuration, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the duration used by animations marked as <see cref="AnimationDuration.FastDuration"/>.
+    /// The default value is 80 ms. Set this before the dictionary is loaded to override the default.
+    /// </summary>
+    /// <example>
+    /// <code lang="xml">
+    /// &lt;ui:ControlsDictionary SlowDuration="0:0:0.9" /&gt;
+    /// </code>
+    /// </example>
+    public TimeSpan FastDuration
+    {
+        get => AnimationDurationsDictionary.Get(AnimationDuration.FastDuration).TimeSpan;
+        set => AnimationDurationsDictionary.Set(AnimationDuration.FastDuration, value);
     }
 }

--- a/src/Wpf.Ui/Markup/ControlsDictionary.cs
+++ b/src/Wpf.Ui/Markup/ControlsDictionary.cs
@@ -33,6 +33,10 @@ public class ControlsDictionary : ResourceDictionary
 {
     private const string DictionaryUri = "pack://application:,,,/Wpf.Ui;component/Resources/Wpf.Ui.xaml";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ControlsDictionary"/> class.
+    /// Default constructor defining <see cref="ResourceDictionary.Source"/> of the <c>WPF UI</c> controls dictionary.
+    /// </summary>
     public ControlsDictionary()
     {
         Source = new Uri(DictionaryUri, UriKind.Absolute);


### PR DESCRIPTION
Durations on Animations are freezable, this pull request provides a way to make Durations customizable.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Durations on Animation has hard coded values for all controls

Issue Number: #1586 
fixes #1586 

## What is the new behavior?

Durations can be of three types: SlowDuration, NormalDuration and FastDuration. These can all be set when merging ControlsDictionary. Defaults to previous hardcoded values (no breaking change)

`<ui:ControlsDictionary SlowDuration="0:0:0.0" NormalDuration="0:0:0.0" FastDuration="0:0:0.0"  />`

## Other information
