### PR TITLE
fix(control): Making titlebarbutton nullable in TitleBar.cs

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.cs
@@ -415,7 +415,7 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
     /// </summary>
     public Action<TitleBar, System.Windows.Window>? MinimizeActionOverride { get; set; }
 
-    private readonly TitleBarButton[] _buttons = new TitleBarButton[4];
+    private readonly TitleBarButton?[] _buttons = new TitleBarButton[4];
     private readonly TextBlock _titleBlock;
     private System.Windows.Window _currentWindow = null!;
 
@@ -674,17 +674,17 @@ public partial class TitleBar : System.Windows.Controls.Control, IThemeControl
             return IntPtr.Zero;
         }
 
-        foreach (TitleBarButton button in _buttons)
+        foreach (TitleBarButton? button in _buttons)
         {
-            if (!button.ReactToHwndHook(message, lParam, out IntPtr returnIntPtr))
+            if (button is null || !button.ReactToHwndHook(message, lParam, out IntPtr returnIntPtr))
             {
                 continue;
             }
 
             // Fix for when sometimes, button hover backgrounds aren't cleared correctly, causing multiple buttons to appear as if hovered.
-            foreach (TitleBarButton anotherButton in _buttons)
+            foreach (TitleBarButton? anotherButton in _buttons)
             {
-                if (anotherButton == button)
+                if (anotherButton is null || anotherButton == button)
                 {
                     continue;
                 }


### PR DESCRIPTION
Nullable check for titlebarbutton

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

nullref exception when TitleBar.Visibilty = Collapsed

Issue Number: #1670 
fixes #1670 

## What is the new behavior?

early return on null

## Other information

n/a
