### PR TITLE
fix(app): Add null check for Application.Current

### DIFF
--- a/src/Wpf.Ui/Appearance/ApplicationAccentColorManager.cs
+++ b/src/Wpf.Ui/Appearance/ApplicationAccentColorManager.cs
@@ -258,6 +258,13 @@ public static class ApplicationAccentColorManager
         Color tertiaryAccent
     )
     {
+        // If the application is shut down (Application.Current becomes null), we cannot change resources, so return immediately.
+        var app = Application.Current;
+        if (app == null)
+        {
+            return;
+        }
+
         System.Diagnostics.Debug.WriteLine("INFO | SystemAccentColor: " + systemAccent, "Wpf.Ui.Accent");
         System.Diagnostics.Debug.WriteLine(
             "INFO | SystemAccentColorPrimary: " + primaryAccent,


### PR DESCRIPTION
Add null check for Application.Current before changing resources.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current/new behavior?

ResourceDictionary can throw NullReferenceException when setting resources on shutdown. Guard against this.