### PR TITLE
fix(controls): Add ViewportSize bindings to ListView ScrollBars

### DIFF
--- a/src/Wpf.Ui/Controls/ListView/ListView.xaml
+++ b/src/Wpf.Ui/Controls/ListView/ListView.xaml
@@ -84,6 +84,7 @@
                 Maximum="{TemplateBinding ScrollViewer.ScrollableWidth}"
                 Minimum="0"
                 Orientation="Horizontal"
+                ViewportSize="{TemplateBinding ViewportWidth}"
                 Visibility="{TemplateBinding ScrollViewer.ComputedHorizontalScrollBarVisibility}"
                 Value="{Binding Path=HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
             <ScrollBar
@@ -93,6 +94,7 @@
                 Maximum="{TemplateBinding ScrollViewer.ScrollableHeight}"
                 Minimum="0"
                 Orientation="Vertical"
+                ViewportSize="{TemplateBinding ViewportHeight}"
                 Visibility="{TemplateBinding ScrollViewer.ComputedVerticalScrollBarVisibility}"
                 Value="{Binding Path=VerticalOffset, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
             <DockPanel


### PR DESCRIPTION
Bind the horizontal and vertical ScrollBar `ViewportSize` to the control template's `ViewportWidth` and `ViewportHeight` so the scrollbar thumb size correctly reflects the visible viewport. Changes applied to `src/Wpf.Ui/Controls/ListView/ListView.xaml` by adding `TemplateBinding` for `ViewportSize` on both ScrollBar elements.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, the scrollbar thumbs on a `ListView` with a `GridView` are always minimum size, even when the list isn't very long. This is because the `ViewportSize` template binding isn't set on the scrollbar elements in the control template.

Issue Number: N/A

## What is the new behavior?

This PR sets the ViewportHeight and ViewportWidth template bindings on the vertical and horizontal scrollbars in the `GridViewScrollViewerTemplate` control template.

## Other information

Before:
<img width="1168" height="743" alt="Screenshot 2026-04-17 162358" src="https://github.com/user-attachments/assets/bcebefcc-b0d9-4ded-bcaa-dc9b049baa5b" />

After:
<img width="1163" height="743" alt="Screenshot 2026-04-17 162150" src="https://github.com/user-attachments/assets/ede9ef25-0fa9-40f8-815c-110ea70d668e" />
