### PR TITLE
fix(controls): Fixed scroll buttons on horizontal ScrollBar for RTL FlowDirection

### DIFF
--- a/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
+++ b/src/Wpf.Ui/Controls/ScrollBar/ScrollBar.xaml
@@ -284,6 +284,10 @@
                 Style="{StaticResource UiScrollBarLineButton}" />
         </Grid>
         <ControlTemplate.Triggers>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+                <Setter TargetName="PART_ButtonScrollLeft" Property="Content" Value="{x:Static controls:SymbolRegular.CaretRight24}" />
+                <Setter TargetName="PART_ButtonScrollRight" Property="Content" Value="{x:Static controls:SymbolRegular.CaretLeft24}" />
+            </Trigger>
             <Trigger Property="IsMouseOver" Value="True">
                 <Trigger.EnterActions>
                     <BeginStoryboard>


### PR DESCRIPTION
SymbolRegular.CaretRight24 is defined for the PART_ButtonScrollRight of UiHorizontalScrollBar, and vice versa for the left one. In right-to-left flow direction, since the whole scroll bar is reversed, this causes the CaretRight24 to be displayed visually on the left side.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When using RTL FlowDirection, any controls displaying a HorizontalScrollBar will have "swapped" scroll buttons:

<img width="269" height="163" alt="image" src="https://github.com/user-attachments/assets/9b18489d-ea4f-4fda-b535-41f4f7a906ab" />


## What is the new behavior?

The symbols are switched for the scroll buttons with one another when FlowDirection is RTL.
