### PR TITLE
fix(controls): Change order of triggers for Button

### DIFF
--- a/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/ButtonPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/BasicInput/ButtonPage.xaml
@@ -125,5 +125,31 @@
                 </Canvas>
             </ui:Button>
         </controls:ControlExample>
+
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            HeaderText="WPF UI button disabled/enabled"
+            XamlCode="&lt;ui:Button Appearance=&quot;Primary&quot; IsEnabled=&quot;False&quot; /&gt;">
+            <StackPanel>
+                <TextBlock Text="Enabled" />
+                <WrapPanel>
+                    <ui:Button Appearance="Primary"   Content="Primary"   Margin="4" />
+                    <ui:Button Appearance="Secondary" Content="Secondary" Margin="4" />
+                    <ui:Button Appearance="Success"   Content="Success"   Margin="4" />
+                    <ui:Button Appearance="Caution"   Content="Caution"   Margin="4" />
+                    <ui:Button Appearance="Danger"    Content="Danger"    Margin="4" />
+                </WrapPanel>
+
+                <TextBlock Text="Disabled" />
+                <WrapPanel>
+                    <ui:Button Appearance="Primary"   Content="Primary"   IsEnabled="False" Margin="4" />
+                    <ui:Button Appearance="Secondary" Content="Secondary" IsEnabled="False" Margin="4" />
+                    <ui:Button Appearance="Success"   Content="Success"   IsEnabled="False" Margin="4" />
+                    <ui:Button Appearance="Caution"   Content="Caution"   IsEnabled="False" Margin="4" />
+                    <ui:Button Appearance="Danger"    Content="Danger"    IsEnabled="False" Margin="4" />
+                </WrapPanel>
+            </StackPanel>
+        </controls:ControlExample>
+
     </StackPanel>
 </Page>

--- a/src/Wpf.Ui/Controls/Button/Button.xaml
+++ b/src/Wpf.Ui/Controls/Button/Button.xaml
@@ -287,6 +287,164 @@
                         </Border>
                     </Border>
                     <ControlTemplate.Triggers>
+                        <!--  TRANSPARENT  -->
+                        <Trigger Property="Appearance" Value="Transparent">
+                            <Setter Property="Background" Value="Transparent" />
+                        </Trigger>
+
+                        <!--  PRIMARY  -->
+                        <Trigger Property="Appearance" Value="Primary">
+                            <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
+                            <Setter Property="MouseOverBackground" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
+                            <Setter Property="PressedBackground" Value="{DynamicResource AccentButtonBackgroundPressed}" />
+                            <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
+                            <Setter Property="PressedForeground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                            <Setter Property="PressedBorderBrush" Value="{DynamicResource ControlFillColorTransparentBrush}" />
+                        </Trigger>
+
+                        <!--  SECONDARY  -->
+                        <Trigger Property="Appearance" Value="Secondary">
+                            <Setter TargetName="InsetBorder" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}}" />
+                        </Trigger>
+
+                        <!--  DARK  -->
+                        <Trigger Property="Appearance" Value="Dark">
+                            <Setter Property="Background">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="{DynamicResource ControlStrongFillColorDark}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="MouseOverBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="#62000000" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="#52000000" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBorderBrush" Value="Transparent" />
+                            <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
+                            <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorLightSecondaryBrush}" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                        </Trigger>
+
+                        <!--  LIGHT  -->
+                        <Trigger Property="Appearance" Value="Light">
+                            <Setter Property="Background">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="{DynamicResource ControlStrongFillColorLight}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="MouseOverBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="#D3FFFFFF" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="#F3FFFFFF" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Foreground" Value="{DynamicResource TextFillColorDarkPrimaryBrush}" />
+                            <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorDarkSecondaryBrush}" />
+                        </Trigger>
+
+                        <!--  INFO  -->
+                        <Trigger Property="Appearance" Value="Info">
+                            <Setter Property="Background">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="{DynamicResource PaletteLightBlueColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="MouseOverBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteLightBlueColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteLightBlueColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
+                            <Setter Property="PressedBorderBrush" Value="Transparent" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                        </Trigger>
+
+                        <!--  DANGER  -->
+                        <Trigger Property="Appearance" Value="Danger">
+                            <Setter Property="Background">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="{DynamicResource PaletteRedColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="MouseOverBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteRedColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteRedColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBorderBrush" Value="Transparent" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                        </Trigger>
+
+                        <!--  SUCCESS  -->
+                        <Trigger Property="Appearance" Value="Success">
+                            <Setter Property="Background">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="{DynamicResource PaletteGreenColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="MouseOverBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteGreenColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteGreenColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBorderBrush" Value="Transparent" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                        </Trigger>
+
+                        <!--  CAUTION  -->
+                        <Trigger Property="Appearance" Value="Caution">
+                            <Setter Property="Background">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="{DynamicResource PaletteOrangeColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="MouseOverBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteOrangeColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBackground">
+                                <Setter.Value>
+                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteOrangeColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="PressedBorderBrush" Value="Transparent" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                        </Trigger>
+
+                        <!--  SHARED TRIGGERS  -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsMouseOver" Value="True" />
@@ -304,11 +462,7 @@
                             <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{Binding PressedBorderBrush, RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter Property="Foreground" Value="{Binding PressedForeground, RelativeSource={RelativeSource TemplatedParent}}" />
                         </MultiTrigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
-                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
-                            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
-                        </Trigger>
+
                         <Trigger Property="Content" Value="{x:Null}">
                             <Setter TargetName="ControlIcon" Property="Margin" Value="0" />
                         </Trigger>
@@ -319,166 +473,16 @@
                             <Setter TargetName="ControlIcon" Property="Margin" Value="0" />
                             <Setter TargetName="ControlIcon" Property="Visibility" Value="Collapsed" />
                         </Trigger>
-                        <Trigger Property="Appearance" Value="Secondary">
-                            <Setter TargetName="InsetBorder" Property="BorderThickness" Value="0" />
-                            <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}}" />
+
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
+                            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Style.Triggers>
-            <!--  TRANSPARENT  -->
-            <Trigger Property="Appearance" Value="Transparent">
-                <Setter Property="Background" Value="Transparent" />
-            </Trigger>
-
-            <!--  PRIMARY  -->
-            <Trigger Property="Appearance" Value="Primary">
-                <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
-                <Setter Property="MouseOverBackground" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
-                <Setter Property="PressedBackground" Value="{DynamicResource AccentButtonBackgroundPressed}" />
-                <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
-                <Setter Property="PressedForeground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                <Setter Property="PressedBorderBrush" Value="{DynamicResource ControlFillColorTransparentBrush}" />
-            </Trigger>
-
-            <!--  DARK  -->
-            <Trigger Property="Appearance" Value="Dark">
-                <Setter Property="Background">
-                    <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource ControlStrongFillColorDark}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="MouseOverBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Color="#62000000" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Color="#52000000" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBorderBrush" Value="Transparent" />
-                <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
-                <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorLightSecondaryBrush}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-            </Trigger>
-
-            <!--  LIGHT  -->
-            <Trigger Property="Appearance" Value="Light">
-                <Setter Property="Background">
-                    <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource ControlStrongFillColorLight}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="MouseOverBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Color="#D3FFFFFF" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Color="#F3FFFFFF" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="Foreground" Value="{DynamicResource TextFillColorDarkPrimaryBrush}" />
-                <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorDarkSecondaryBrush}" />
-            </Trigger>
-
-            <!--  INFO  -->
-            <Trigger Property="Appearance" Value="Info">
-                <Setter Property="Background">
-                    <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource PaletteLightBlueColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="MouseOverBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteLightBlueColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteLightBlueColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
-                <Setter Property="PressedBorderBrush" Value="Transparent" />
-                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-            </Trigger>
-
-            <!--  DANGER  -->
-            <Trigger Property="Appearance" Value="Danger">
-                <Setter Property="Background">
-                    <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource PaletteRedColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="MouseOverBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteRedColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteRedColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBorderBrush" Value="Transparent" />
-                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-            </Trigger>
-
-            <!--  SUCCESS  -->
-            <Trigger Property="Appearance" Value="Success">
-                <Setter Property="Background">
-                    <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource PaletteGreenColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="MouseOverBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteGreenColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteGreenColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBorderBrush" Value="Transparent" />
-                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-            </Trigger>
-
-            <!--  CAUTION  -->
-            <Trigger Property="Appearance" Value="Caution">
-                <Setter Property="Background">
-                    <Setter.Value>
-                        <SolidColorBrush Color="{DynamicResource PaletteOrangeColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="MouseOverBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteOrangeColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBackground">
-                    <Setter.Value>
-                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteOrangeColor}" />
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="PressedBorderBrush" Value="Transparent" />
-                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-            </Trigger>
-        </Style.Triggers>
     </Style>
 
     <Style BasedOn="{StaticResource DefaultRepeatButtonStyle}" TargetType="{x:Type RepeatButton}" />


### PR DESCRIPTION
Since 4.2.1, a ui:Button with Appearance="Primary" IsEnabled="False" renders white text on the grey disabled background — invisible in light theme.

## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

WPF Style triggers have higher precedence than ControlTemplate triggers for the same dependency property. The Appearance="Primary" Style trigger sets Foreground = AccentButtonForeground (white). When the button is also disabled, the ControlTemplate's IsEnabled=False trigger attempts to set Foreground = ButtonForegroundDisabled, but is overridden by the Style-level Appearance trigger — leaving white text on a grey disabled background.

Issue Number: #1699 
fixes #1699

## What is the new behavior?

moved Appearance-specific settings to inside the ControlTemplate.Triggers and positioned them first in the trigger list

## Other information

Added section in gallery as per example in issue #1699 
