### PR TITLE
fix(tray): support Unicode for NotifyIcon.TooltipText

### DIFF
--- a/src/Wpf.Ui.Tray/Interop/Shell32.cs
+++ b/src/Wpf.Ui.Tray/Interop/Shell32.cs
@@ -69,7 +69,7 @@ internal static class Shell32
         VISTA_MASK = XP_MASK | REALTIME | SHOWTIP,
     }
 
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public class NOTIFYICONDATA
     {
         /// <summary>
@@ -153,7 +153,7 @@ internal static class Shell32
         [Out, MarshalAs(UnmanagedType.Interface)] out object ppv
     );
 
-    [DllImport(Libraries.Shell32)]
+    [DllImport(Libraries.Shell32, CharSet = CharSet.Unicode)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool Shell_NotifyIcon([In] NIM dwMessage, [In] NOTIFYICONDATA lpdata);
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Explicitly use the Unicode (wide) variant of `Shell_NotifyIcon`.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #1705

## Other information

I tried to migrate this to `[LibraryImport]` and `CsWin32`, but both of those seemed to be too much of a rabbit hole.