### PR TITLE
fix(controls): LoadingScreen template: bind Foreground to ProgressRing and use A…

### DIFF
--- a/src/Wpf.Ui/Controls/LoadingScreen/LoadingScreen.xaml
+++ b/src/Wpf.Ui/Controls/LoadingScreen/LoadingScreen.xaml
@@ -11,10 +11,15 @@
     xmlns:controls="clr-namespace:Wpf.Ui.Controls">
 
     <Style TargetType="{x:Type controls:LoadingScreen}">
-        <Setter Property="Background" Value="{DynamicResource LoadingScreenForeground}" />
+        
         <Setter Property="Background" Value="{DynamicResource LoadingScreenBackground}" />
+
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+
         <Setter Property="SnapsToDevicePixels" Value="True" />
+
         <Setter Property="OverridesDefaultStyle" Value="True" />
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:LoadingScreen}">
@@ -22,13 +27,16 @@
                         Width="{TemplateBinding Width}"
                         Height="{TemplateBinding Height}"
                         Background="{TemplateBinding Background}">
+
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
                         <Grid Grid.Column="0" VerticalAlignment="Center">
-                            <controls:ProgressRing IsIndeterminate="True" />
+                            <controls:ProgressRing 
+                                IsIndeterminate="True"
+                                Foreground="{TemplateBinding Foreground}" />
                         </Grid>
 
                         <Grid Grid.Column="1" VerticalAlignment="Center">
@@ -39,5 +47,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-
 </ResourceDictionary>


### PR DESCRIPTION
### Fix LoadingScreen Foreground not applied to ProgressRing

## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The `LoadingScreen` control exposes a `Foreground` property, but it is not applied to the inner `ProgressRing` inside the control template. As a result, setting `Foreground` on `LoadingScreen` has no effect on the loading indicator color.

Additionally, the style contains duplicate `Background` setters, where the first one is overridden and has no effect.

Issue Number: N/A

## What is the new behavior?

- The `Foreground` property is now bound to the inner `ProgressRing` via `TemplateBinding`
- A default `Foreground` value is introduced using `AccentBrush` to align with Wpf.Ui theme behavior
- The redundant `Background` setter is removed

As a result:
- `Foreground` correctly controls the loading indicator color
- Default behavior follows the current theme accent color
- Style definition is cleaned up and more consistent

## Other information

This change improves consistency with expected WPF behavior, where control-level `Foreground` should cascade into visual elements within the control template.

### Example usage:

```xml
<ui:LoadingScreen Foreground="Red" />