### PR TITLE
feat(controls): Implement `SpinButtonPlacementMode.Compact` for `NumberBox`

### DIFF
--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/Text/NumberBoxViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/Text/NumberBoxViewModel.cs
@@ -3,6 +3,35 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
+using Wpf.Ui.Controls;
+
 namespace Wpf.Ui.Gallery.ViewModels.Pages.Text;
 
-public partial class NumberBoxViewModel : ViewModel;
+public partial class NumberBoxViewModel : ViewModel
+{
+    private int _numberBoxSpinButtonPlacementModeSelectedIndex = 2;
+
+    public int NumberBoxSpinButtonPlacementModeSelectedIndex
+    {
+        get => _numberBoxSpinButtonPlacementModeSelectedIndex;
+        set
+        {
+            _ = SetProperty(ref _numberBoxSpinButtonPlacementModeSelectedIndex, value);
+
+            UpdateSpinButtonPlacementMode(value);
+        }
+    }
+
+    [ObservableProperty]
+    private NumberBoxSpinButtonPlacementMode _spinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline;
+
+    private void UpdateSpinButtonPlacementMode(int placementModeIndex)
+    {
+        SpinButtonPlacementMode = placementModeIndex switch
+        {
+            0 => NumberBoxSpinButtonPlacementMode.Hidden,
+            1 => NumberBoxSpinButtonPlacementMode.Compact,
+            _ => NumberBoxSpinButtonPlacementMode.Inline,
+        };
+    }
+}

--- a/src/Wpf.Ui.Gallery/Views/Pages/Text/NumberBoxPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Text/NumberBoxPage.xaml
@@ -6,7 +6,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Wpf.Ui.Gallery.Views.Pages.Text"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:system="clr-namespace:System;assembly=System.Runtime"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="NumberBoxPage"
     controls:PageControlDocumentation.DocumentationType="{x:Type ui:NumberBox}"
@@ -25,6 +24,40 @@
             HeaderText="WPF UI NumberBox."
             XamlCode="&lt;ui:NumberBox PlaceholderText=&quot;Enter your age&quot; /&gt;">
             <ui:NumberBox PlaceholderText="Enter your age" />
+        </controls:ControlExample>
+
+        <controls:ControlExample
+            Margin="0,36,0,0"
+            HeaderText="A NumberBox with spin buttons."
+            XamlCode="&lt;ui:NumberBox PlaceholderText=&quot;Enter your age&quot; /&gt;">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <ui:NumberBox
+                    Icon="{ui:SymbolIcon NumberSymbolSquare24}"
+                    LargeChange="2.25"
+                    Maximum="10"
+                    Minimum="-10"
+                    PlaceholderText="Enter your age"
+                    SmallChange="0.25"
+                    SpinButtonPlacementMode="{Binding ViewModel.SpinButtonPlacementMode}"
+                    Value="1.50" />
+
+                <StackPanel
+                    Grid.Column="1"
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Top">
+                    <Label Content="Spin button placement mode" Target="{Binding ElementName=SpinButtonPlacementModeComboBox}" />
+                    <ComboBox x:Name="SpinButtonPlacementModeComboBox" SelectedIndex="{Binding ViewModel.NumberBoxSpinButtonPlacementModeSelectedIndex, Mode=TwoWay}">
+                        <ComboBoxItem Content="Hidden" />
+                        <ComboBoxItem Content="Compact" />
+                        <ComboBoxItem Content="Inline" />
+                    </ComboBox>
+                </StackPanel>
+            </Grid>
         </controls:ControlExample>
 
         <controls:ControlExample

--- a/src/Wpf.Ui.Gallery/Views/Pages/Text/NumberBoxPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Text/NumberBoxPage.xaml
@@ -37,6 +37,7 @@
                 </Grid.ColumnDefinitions>
 
                 <ui:NumberBox
+                    Margin="0,23,0,0"
                     Icon="{ui:SymbolIcon NumberSymbolSquare24}"
                     LargeChange="2.25"
                     Maximum="10"

--- a/src/Wpf.Ui.Gallery/Views/Pages/Text/NumberBoxPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/Text/NumberBoxPage.xaml
@@ -28,7 +28,7 @@
 
         <controls:ControlExample
             Margin="0,36,0,0"
-            HeaderText="A NumberBox with spin buttons."
+            HeaderText="A NumberBox with a spin button."
             XamlCode="&lt;ui:NumberBox PlaceholderText=&quot;Enter your age&quot; /&gt;">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -27,9 +27,13 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
 {
     // Template part names
     private const string PART_ClearButton = nameof(PART_ClearButton);
+    private const string PART_CompactIncrementDecrementButton = nameof(PART_CompactIncrementDecrementButton);
+    private const string PART_CompactIncrementDecrementFlyout = nameof(PART_CompactIncrementDecrementFlyout);
+    private const string PART_CompactIncrementButton = nameof(PART_CompactIncrementButton);
+    private const string PART_CompactDecrementButton = nameof(PART_CompactDecrementButton);
     private const string PART_InlineIncrementButton = nameof(PART_InlineIncrementButton);
     private const string PART_InlineDecrementButton = nameof(PART_InlineDecrementButton);
-
+    
     private bool _valueUpdating;
 
     /// <summary>Identifies the <see cref="Value"/> dependency property.</summary>
@@ -330,6 +334,9 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
             PART_ClearButton,
             () => OnClearButtonClick()
         );
+        SubscribeToButtonClickEvent<System.Windows.Controls.Button>(PART_CompactIncrementDecrementButton, () => OnCompactIncrementDecrementButtonClick());
+        SubscribeToButtonClickEvent<System.Windows.Controls.Button>(PART_CompactIncrementButton, () => StepValue(SmallChange));
+        SubscribeToButtonClickEvent<System.Windows.Controls.Button>(PART_CompactDecrementButton, () => StepValue(-SmallChange));
         SubscribeToButtonClickEvent<RepeatButton>(PART_InlineIncrementButton, () => StepValue(SmallChange));
         SubscribeToButtonClickEvent<RepeatButton>(PART_InlineDecrementButton, () => StepValue(-SmallChange));
 
@@ -344,6 +351,14 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
         }
 
         base.OnApplyTemplate();
+    }
+
+    private void OnCompactIncrementDecrementButtonClick()
+    {
+        if (GetTemplateChild(PART_CompactIncrementDecrementFlyout) is Flyout flyout)
+        {
+            flyout.IsOpen = true;
+        }
     }
 
     private void SubscribeToButtonClickEvent<TButton>(string elementName, Action action)

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -124,6 +124,7 @@
                                         IsTabStop="False">
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="Dismiss24" />
                                     </Button>
+
                                     <Button
                                         x:Name="PART_CompactIncrementDecrementButton"
                                         Width="{StaticResource NumberBoxButtonHeight}"
@@ -141,6 +142,23 @@
                                         Visibility="Collapsed">
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronUpDown24" />
                                     </Button>
+
+                                    <controls:Flyout x:Name="PART_CompactIncrementDecrementFlyout" Placement="Center">
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="*" />
+                                                <RowDefinition Height="*" />
+                                            </Grid.RowDefinitions>
+
+                                            <Button x:Name="PART_CompactIncrementButton">
+                                                <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronUp24" />
+                                            </Button>
+                                            <Button x:Name="PART_CompactDecrementButton" Grid.Row="1">
+                                                <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronDown24" />
+                                            </Button>
+                                        </Grid>
+                                    </controls:Flyout>
+
                                     <RepeatButton
                                         x:Name="PART_InlineIncrementButton"
                                         Width="{StaticResource NumberBoxButtonHeight}"
@@ -198,6 +216,7 @@
                             BorderThickness="{StaticResource NumberBoxAccentBorderThemeThickness}"
                             CornerRadius="{TemplateBinding Border.CornerRadius}" />
                     </Grid>
+
                     <ControlTemplate.Triggers>
                         <Trigger Property="CurrentPlaceholderEnabled" Value="False">
                             <Setter TargetName="PlaceholderTextBox" Property="Visibility" Value="Collapsed" />

--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -124,6 +124,23 @@
                                         IsTabStop="False">
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="Dismiss24" />
                                     </Button>
+                                    <Button
+                                        x:Name="PART_CompactIncrementDecrementButton"
+                                        Width="{StaticResource NumberBoxButtonHeight}"
+                                        Height="{StaticResource NumberBoxButtonHeight}"
+                                        Margin="{StaticResource NumberBoxButtonMargin}"
+                                        Padding="{StaticResource NumberBoxButtonPadding}"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Top"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Background="Transparent"
+                                        BorderBrush="Transparent"
+                                        Foreground="{DynamicResource TextControlButtonForeground}"
+                                        IsTabStop="False"
+                                        Visibility="Collapsed">
+                                        <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronUpDown24" />
+                                    </Button>
                                     <RepeatButton
                                         x:Name="PART_InlineIncrementButton"
                                         Width="{StaticResource NumberBoxButtonHeight}"
@@ -196,8 +213,15 @@
                         <Trigger Property="SpinButtonPlacementMode" Value="Hidden">
                             <Setter TargetName="PART_InlineIncrementButton" Property="Margin" Value="0" />
                             <Setter TargetName="PART_InlineDecrementButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_CompactIncrementDecrementButton" Property="Margin" Value="0" />
+                        </Trigger>
+                        <Trigger Property="SpinButtonPlacementMode" Value="Compact">
+                            <Setter TargetName="PART_InlineIncrementButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_InlineDecrementButton" Property="Margin" Value="0" />
+                            <Setter TargetName="PART_CompactIncrementDecrementButton" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="SpinButtonPlacementMode" Value="Inline">
+                            <Setter TargetName="PART_CompactIncrementDecrementButton" Property="Margin" Value="0" />
                             <Setter TargetName="PART_InlineIncrementButton" Property="Visibility" Value="Visible" />
                             <Setter TargetName="PART_InlineDecrementButton" Property="Visibility" Value="Visible" />
                         </Trigger>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

`NumberBox` already had a `SpinButtonPlacementMode.Compact`; however, it previously had the same effect as `Hidden`. This adds a style to NumberBox that will:

- add a button with an up/down symbol:

<img width="1133" height="135" alt="image" src="https://github.com/user-attachments/assets/be18a890-f3ac-40a4-bc14-5cd634114962" />

- when clicked, pop out a flyout, with buttons to increment/decrement:

<img width="111" height="124" alt="image" src="https://github.com/user-attachments/assets/2f5c1f8f-7029-4ba9-986a-c0ec35a194cf" />

It also expands Gallery's `NumberBoxPage` to let users try out the three variants.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #1673

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

`SpinButtonPlacementMode.Compact` now has its own look/behavior.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The result roughly matches the look+feel in WinUI 3 Gallery 2.9.0.0:

<img width="243" height="154" alt="image" src="https://github.com/user-attachments/assets/62c80d02-0afc-43a6-8b80-a77177d4ed28" />

<img width="276" height="170" alt="image" src="https://github.com/user-attachments/assets/aceda9cf-b374-4e2a-9f92-9de3e2c5059f" />

Minor differences:

- there's no Flyout drop shadow (see #1708)
- the buttons should probably have the "subtle" style, which I don't believe WPF UI implements; from the WinUI gallery:

<img width="363" height="117" alt="image" src="https://github.com/user-attachments/assets/d20ba213-efce-4406-95ba-d736c6c54f4c" />