### PR TITLE
feat(tray): Add balloon tip support to NotifyIcon

### DIFF
--- a/src/Wpf.Ui.Gallery/App.xaml.cs
+++ b/src/Wpf.Ui.Gallery/App.xaml.cs
@@ -13,6 +13,7 @@ using Wpf.Ui.Gallery.ViewModels.Pages;
 using Wpf.Ui.Gallery.ViewModels.Windows;
 using Wpf.Ui.Gallery.Views.Pages;
 using Wpf.Ui.Gallery.Views.Windows;
+using Wpf.Ui.Tray;
 
 namespace Wpf.Ui.Gallery;
 
@@ -51,6 +52,7 @@ public partial class App
                 _ = services.AddSingleton<AllControlsViewModel>();
                 _ = services.AddSingleton<SettingsPage>();
                 _ = services.AddSingleton<SettingsViewModel>();
+                _ = services.AddSingleton<INotifyIconService, NotifyIconService>();
 
                 // All other pages and view models
                 _ = services.AddTransientFromNamespace("Wpf.Ui.Gallery.Views", GalleryAssembly.Asssembly);

--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System.Drawing;
+using Wpf.Ui.Tray;
+using Wpf.Ui.Tray.Controls;
+
+namespace Wpf.Ui.Gallery.ViewModels.Pages.OpSystem;
+
+public partial class NotifyIconViewModel : ViewModel
+{
+    private readonly INotifyIconService _notifyIconService;
+
+    public NotifyIconViewModel(INotifyIconService notifyIconService)
+    {
+        _notifyIconService = notifyIconService;
+        TooltipText = _notifyIconService.TooltipText;
+
+        NotifyIcon notifyIcon = _notifyIconService.GetNotifyIcon()
+            ?? throw new InvalidOperationException("NotifyIcon was never set.");
+
+        notifyIcon.BalloonTipShown += NotifyIcon_BalloonTipShown;
+        notifyIcon.BalloonTipClose += NotifyIcon_BalloonTipClose;
+        notifyIcon.BalloonTipClick += NotifyIcon_BalloonTipClick;
+    }
+
+    private void NotifyIcon_BalloonTipShown([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
+    {
+        BalloonTipStatus = "Shown";
+    }
+
+    private void NotifyIcon_BalloonTipClose([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
+    {
+        BalloonTipStatus = "Closed";
+    }
+
+    private void NotifyIcon_BalloonTipClick([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
+    {
+        BalloonTipStatus = "Clicked";
+    }
+
+    [ObservableProperty]
+    private string _balloonTipTitle = "Hello!";
+
+    [ObservableProperty]
+    private string _balloonTipMessage = "This is a balloon tip notification.";
+
+    [ObservableProperty]
+    private string _tooltipText = string.Empty;
+
+    [ObservableProperty]
+    private string _balloonTipStatus = "No notification sent yet.";
+
+    [RelayCommand]
+    private void OnShowBalloonTip()
+    {
+        NotifyIcon icon = _notifyIconService.GetNotifyIcon()
+            ?? throw new InvalidOperationException("NotifyIcon was never set.");
+
+        icon.ShowBalloonTip(
+            TimeSpan.FromSeconds(3),
+            BalloonTipTitle,
+            BalloonTipMessage,
+            ToolTipIcon.Info
+        );
+    }
+
+    [RelayCommand]
+    private void OnUpdateTooltip()
+    {
+        NotifyIcon icon = _notifyIconService.GetNotifyIcon()
+            ?? throw new InvalidOperationException("NotifyIcon was never set.");
+
+        icon.TooltipText = TooltipText;
+    }
+}

--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
@@ -53,6 +53,12 @@ public partial class NotifyIconViewModel : ViewModel
     [ObservableProperty]
     private string _balloonTipStatus = "No notification sent yet.";
 
+    [ObservableProperty]
+    private ToolTipIcon _selectedBalloonTipIcon = ToolTipIcon.Info;
+
+    [ObservableProperty]
+    private IEnumerable<ToolTipIcon> _balloonTipIcons = Enum.GetValues<ToolTipIcon>();
+
     [RelayCommand]
     private void OnShowBalloonTip()
     {
@@ -63,7 +69,7 @@ public partial class NotifyIconViewModel : ViewModel
             TimeSpan.FromSeconds(3),
             BalloonTipTitle,
             BalloonTipMessage,
-            ToolTipIcon.Info
+            SelectedBalloonTipIcon
         );
     }
 

--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
@@ -20,8 +20,8 @@ public partial class NotifyIconViewModel : ViewModel
         TooltipText = _notifyIcon.TooltipText;
 
         _notifyIcon.BalloonTipShown += NotifyIcon_BalloonTipShown;
-        _notifyIcon.BalloonTipClose += NotifyIcon_BalloonTipClose;
-        _notifyIcon.BalloonTipClick += NotifyIcon_BalloonTipClick;
+        _notifyIcon.BalloonTipClosed += NotifyIcon_BalloonTipClosed;
+        _notifyIcon.BalloonTipClicked += NotifyIcon_BalloonTipClicked;
     }
 
     private void NotifyIcon_BalloonTipShown([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
@@ -29,12 +29,12 @@ public partial class NotifyIconViewModel : ViewModel
         BalloonTipStatus = "Shown";
     }
 
-    private void NotifyIcon_BalloonTipClose([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
+    private void NotifyIcon_BalloonTipClosed([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
     {
         BalloonTipStatus = "Closed";
     }
 
-    private void NotifyIcon_BalloonTipClick([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
+    private void NotifyIcon_BalloonTipClicked([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
     {
         BalloonTipStatus = "Clicked";
     }

--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
@@ -11,19 +11,17 @@ namespace Wpf.Ui.Gallery.ViewModels.Pages.OpSystem;
 
 public partial class NotifyIconViewModel : ViewModel
 {
-    private readonly INotifyIconService _notifyIconService;
+    private readonly NotifyIcon _notifyIcon;
 
     public NotifyIconViewModel(INotifyIconService notifyIconService)
     {
-        _notifyIconService = notifyIconService;
-        TooltipText = _notifyIconService.TooltipText;
+        _notifyIcon = notifyIconService.GetNotifyIcon() ?? throw new InvalidOperationException("NotifyIcon was never set.");
 
-        NotifyIcon notifyIcon = _notifyIconService.GetNotifyIcon()
-            ?? throw new InvalidOperationException("NotifyIcon was never set.");
+        TooltipText = _notifyIcon.TooltipText;
 
-        notifyIcon.BalloonTipShown += NotifyIcon_BalloonTipShown;
-        notifyIcon.BalloonTipClose += NotifyIcon_BalloonTipClose;
-        notifyIcon.BalloonTipClick += NotifyIcon_BalloonTipClick;
+        _notifyIcon.BalloonTipShown += NotifyIcon_BalloonTipShown;
+        _notifyIcon.BalloonTipClose += NotifyIcon_BalloonTipClose;
+        _notifyIcon.BalloonTipClick += NotifyIcon_BalloonTipClick;
     }
 
     private void NotifyIcon_BalloonTipShown([System.Diagnostics.CodeAnalysis.NotNull] NotifyIcon sender, RoutedEventArgs e)
@@ -62,10 +60,11 @@ public partial class NotifyIconViewModel : ViewModel
     [RelayCommand]
     private void OnShowBalloonTip()
     {
-        NotifyIcon icon = _notifyIconService.GetNotifyIcon()
-            ?? throw new InvalidOperationException("NotifyIcon was never set.");
-
-        icon.ShowBalloonTip(
+        // _notifyIcon.SetCurrentValue(NotifyIcon.BalloonTipTitleProperty, BalloonTipTitle);
+        // _notifyIcon.SetCurrentValue(NotifyIcon.BalloonTipTextProperty, BalloonTipMessage);
+        // _notifyIcon.SetCurrentValue(NotifyIcon.BalloonTipIconProperty, SelectedBalloonTipIcon);
+        // _notifyIcon.ShowBalloonTip(TimeSpan.FromSeconds(3));
+        _notifyIcon.ShowBalloonTip(
             TimeSpan.FromSeconds(3),
             BalloonTipTitle,
             BalloonTipMessage,
@@ -76,9 +75,6 @@ public partial class NotifyIconViewModel : ViewModel
     [RelayCommand]
     private void OnUpdateTooltip()
     {
-        NotifyIcon icon = _notifyIconService.GetNotifyIcon()
-            ?? throw new InvalidOperationException("NotifyIcon was never set.");
-
-        icon.TooltipText = TooltipText;
+        _notifyIcon.SetCurrentValue(NotifyIcon.TooltipTextProperty, TooltipText);
     }
 }

--- a/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Pages/OpSystem/NotifyIconViewModel.cs
@@ -3,7 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using System.Drawing;
 using Wpf.Ui.Tray;
 using Wpf.Ui.Tray.Controls;
 
@@ -60,10 +59,6 @@ public partial class NotifyIconViewModel : ViewModel
     [RelayCommand]
     private void OnShowBalloonTip()
     {
-        // _notifyIcon.SetCurrentValue(NotifyIcon.BalloonTipTitleProperty, BalloonTipTitle);
-        // _notifyIcon.SetCurrentValue(NotifyIcon.BalloonTipTextProperty, BalloonTipMessage);
-        // _notifyIcon.SetCurrentValue(NotifyIcon.BalloonTipIconProperty, SelectedBalloonTipIcon);
-        // _notifyIcon.ShowBalloonTip(TimeSpan.FromSeconds(3));
         _notifyIcon.ShowBalloonTip(
             TimeSpan.FromSeconds(3),
             BalloonTipTitle,

--- a/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/Wpf.Ui.Gallery/ViewModels/Windows/MainWindowViewModel.cs
@@ -170,6 +170,7 @@ public partial class MainWindowViewModel(IStringLocalizer<Translations> localize
             {
                 new NavigationViewItem("Clipboard", typeof(ClipboardPage)),
                 new NavigationViewItem("FilePicker", typeof(FilePickerPage)),
+                new NavigationViewItem("NotifyIcon", typeof(NotifyIconPage)),
             },
         },
         new NavigationViewItem("Windows", SymbolRegular.WindowApps24, typeof(WindowsPage)),

--- a/src/Wpf.Ui.Gallery/Views/Pages/OpSystem/NotifyIconPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/OpSystem/NotifyIconPage.xaml
@@ -1,0 +1,92 @@
+<Page
+    x:Class="Wpf.Ui.Gallery.Views.Pages.OpSystem.NotifyIconPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Wpf.Ui.Gallery.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Wpf.Ui.Gallery.Views.Pages.OpSystem"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    controls:PageControlDocumentation.Show="False"
+    d:DataContext="{d:DesignInstance local:NotifyIconPage,
+                                     IsDesignTimeCreatable=False}"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    mc:Ignorable="d">
+
+    <StackPanel Margin="0,0,0,24">
+        <controls:ControlExample
+            Margin="0"
+            CsharpCode="notifyIconService.GetNotifyIcon()?.ShowBalloonTip(TimeSpan.FromSeconds(3), title, message, ToolTipIcon.Info);"
+            HeaderText="Show a balloon tip notification">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <ui:TextBox
+                    Grid.Row="0"
+                    Margin="0,0,0,8"
+                    PlaceholderText="Balloon tip title"
+                    Text="{Binding ViewModel.BalloonTipTitle}" />
+                <ui:TextBox
+                    Grid.Row="1"
+                    Margin="0,0,0,16"
+                    MinLines="3"
+                    PlaceholderText="Balloon tip message"
+                    Text="{Binding ViewModel.BalloonTipMessage}" />
+                <ui:Button
+                    Grid.Row="2"
+                    Command="{Binding ViewModel.ShowBalloonTipCommand}"
+                    Content="Show Balloon Tip"
+                    Icon="{ui:SymbolIcon Alert24}" />
+            </Grid>
+        </controls:ControlExample>
+
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            CsharpCode="notifyIconService.GetNotifyIcon()?.TooltipText = tooltipText;"
+            HeaderText="Update tray icon tooltip">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <ui:TextBox
+                    Grid.Row="0"
+                    Margin="0,0,0,16"
+                    PlaceholderText="New tooltip text"
+                    Text="{Binding ViewModel.TooltipText}" />
+                <ui:Button
+                    Grid.Row="1"
+                    Command="{Binding ViewModel.UpdateTooltipCommand}"
+                    Content="Update Tooltip"
+                    Icon="{ui:SymbolIcon Edit24}" />
+            </Grid>
+        </controls:ControlExample>
+        
+        <controls:ControlExample
+            Margin="0,32,0,0"
+            CsharpCode="icon.BalloonTipShown += ...;\nicon.BalloonTipClose += ...;\nicon.BalloonTipClick += ...;"
+            HeaderText="Balloon tip status">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <ui:TextBlock
+                    Grid.Row="0"
+                    Text="Current status:"
+                    TextDecorations="Underline" />
+                <ui:TextBlock
+                    Grid.Row="1"
+                    Margin="0,4,0,0"
+                    Text="{Binding ViewModel.BalloonTipStatus}" />
+            </Grid>
+        </controls:ControlExample>
+    </StackPanel>
+</Page>

--- a/src/Wpf.Ui.Gallery/Views/Pages/OpSystem/NotifyIconPage.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Pages/OpSystem/NotifyIconPage.xaml
@@ -27,21 +27,27 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <ui:TextBox
                     Grid.Row="0"
                     Margin="0,0,0,8"
                     PlaceholderText="Balloon tip title"
-                    Text="{Binding ViewModel.BalloonTipTitle}" />
+                    Text="{Binding ViewModel.BalloonTipTitle, Mode=TwoWay}" />
                 <ui:TextBox
                     Grid.Row="1"
-                    Margin="0,0,0,16"
+                    Margin="0,0,0,8"
                     MinLines="3"
                     PlaceholderText="Balloon tip message"
-                    Text="{Binding ViewModel.BalloonTipMessage}" />
-                <ui:Button
+                    Text="{Binding ViewModel.BalloonTipMessage, Mode=TwoWay}" />
+                <ComboBox
                     Grid.Row="2"
-                    Command="{Binding ViewModel.ShowBalloonTipCommand}"
+                    Margin="0,0,0,16"
+                    ItemsSource="{Binding ViewModel.BalloonTipIcons, Mode=OneWay}"
+                    SelectedItem="{Binding ViewModel.SelectedBalloonTipIcon, Mode=TwoWay}" />
+                <ui:Button
+                    Grid.Row="3"
+                    Command="{Binding ViewModel.ShowBalloonTipCommand, Mode=OneWay}"
                     Content="Show Balloon Tip"
                     Icon="{ui:SymbolIcon Alert24}" />
             </Grid>
@@ -60,10 +66,10 @@
                     Grid.Row="0"
                     Margin="0,0,0,16"
                     PlaceholderText="New tooltip text"
-                    Text="{Binding ViewModel.TooltipText}" />
+                    Text="{Binding ViewModel.TooltipText, Mode=TwoWay}" />
                 <ui:Button
                     Grid.Row="1"
-                    Command="{Binding ViewModel.UpdateTooltipCommand}"
+                    Command="{Binding ViewModel.UpdateTooltipCommand, Mode=OneWay}"
                     Content="Update Tooltip"
                     Icon="{ui:SymbolIcon Edit24}" />
             </Grid>
@@ -85,7 +91,7 @@
                 <ui:TextBlock
                     Grid.Row="1"
                     Margin="0,4,0,0"
-                    Text="{Binding ViewModel.BalloonTipStatus}" />
+                    Text="{Binding ViewModel.BalloonTipStatus, Mode=OneWay}" />
             </Grid>
         </controls:ControlExample>
     </StackPanel>

--- a/src/Wpf.Ui.Gallery/Views/Pages/OpSystem/NotifyIconPage.xaml.cs
+++ b/src/Wpf.Ui.Gallery/Views/Pages/OpSystem/NotifyIconPage.xaml.cs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using Wpf.Ui.Controls;
+using Wpf.Ui.Gallery.ControlsLookup;
+using Wpf.Ui.Gallery.ViewModels.Pages.OpSystem;
+
+namespace Wpf.Ui.Gallery.Views.Pages.OpSystem;
+
+[GalleryPage("System tray.", SymbolRegular.TrayItemAdd24)]
+public partial class NotifyIconPage : INavigableView<NotifyIconViewModel>
+{
+    public NotifyIconViewModel ViewModel { get; }
+
+    public NotifyIconPage(NotifyIconViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        DataContext = this;
+
+        InitializeComponent();
+    }
+}

--- a/src/Wpf.Ui.Gallery/Views/Windows/MainWindow.xaml
+++ b/src/Wpf.Ui.Gallery/Views/Windows/MainWindow.xaml
@@ -89,6 +89,7 @@
         </ui:TitleBar>
 
         <tray:NotifyIcon
+            x:Name="TrayNotifyIcon"
             Grid.Row="0"
             FocusOnLeftClick="True"
             Icon="pack://application:,,,/Assets/wpfui.png"

--- a/src/Wpf.Ui.Gallery/Views/Windows/MainWindow.xaml.cs
+++ b/src/Wpf.Ui.Gallery/Views/Windows/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using Wpf.Ui.Controls;
 using Wpf.Ui.Gallery.Services.Contracts;
 using Wpf.Ui.Gallery.ViewModels.Windows;
 using Wpf.Ui.Gallery.Views.Pages;
+using Wpf.Ui.Tray;
 
 namespace Wpf.Ui.Gallery.Views.Windows;
 
@@ -17,7 +18,8 @@ public partial class MainWindow : IWindow
         INavigationService navigationService,
         IServiceProvider serviceProvider,
         ISnackbarService snackbarService,
-        IContentDialogService contentDialogService
+        IContentDialogService contentDialogService,
+        INotifyIconService notifyIconService
     )
     {
         Appearance.SystemThemeWatcher.Watch(this);
@@ -30,6 +32,7 @@ public partial class MainWindow : IWindow
         snackbarService.SetSnackbarPresenter(SnackbarPresenter);
         navigationService.SetNavigationControl(NavigationView);
         contentDialogService.SetDialogHost(RootContentDialog);
+        notifyIconService.SetNotifyIcon(TrayNotifyIcon);
         SetupTrayMenuEvents();
     }
 

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -6,7 +6,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using Wpf.Ui.Tray.Internal;
 
 namespace Wpf.Ui.Tray.Controls;
 
@@ -55,7 +54,7 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         new PropertyMetadata(string.Empty, OnTooltipTextChanged)
     );
 
-    /// <summary>Identifies the <see cref="BalloonTipTitle"/> dependency property.</summary>
+    /// <summary>Identifies the <see cref="BalloonTipTitle"/> dependency property. Title text exceeding 63 characters will be truncated by the shell.</summary>
     public static readonly DependencyProperty BalloonTipTitleProperty = DependencyProperty.Register(
         nameof(BalloonTipTitle),
         typeof(string),
@@ -63,7 +62,7 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         new PropertyMetadata(string.Empty, OnBalloonTipTitleChanged)
     );
 
-    /// <summary>Identifies the <see cref="BalloonTipText"/> dependency property.</summary>
+    /// <summary>Identifies the <see cref="BalloonTipText"/> dependency property. Message text exceeding 255 characters will be truncated by the shell.</summary>
     public static readonly DependencyProperty BalloonTipTextProperty = DependencyProperty.Register(
         nameof(BalloonTipText),
         typeof(string),

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -383,9 +383,11 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// </param>
     /// <param name="title">
     /// The title text displayed in the balloon notification.
+    /// Text exceeding 63 characters will be truncated by the shell.
     /// </param>
     /// <param name="message">
     /// The main content text displayed in the balloon notification.
+    /// Text exceeding 255 characters will be truncated by the shell.
     /// </param>
     /// <param name="icon">
     /// The icon type displayed in the balloon notification.

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -6,6 +6,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Wpf.Ui.Tray.Internal;
 
 namespace Wpf.Ui.Tray.Controls;
 
@@ -54,6 +55,30 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         new PropertyMetadata(string.Empty, OnTooltipTextChanged)
     );
 
+    /// <summary>Identifies the <see cref="BalloonTipTitle"/> dependency property.</summary>
+    public static readonly DependencyProperty BalloonTipTitleProperty = DependencyProperty.Register(
+        nameof(BalloonTipTitle),
+        typeof(string),
+        typeof(NotifyIcon),
+        new PropertyMetadata(string.Empty, OnBalloonTipTitleChanged)
+    );
+
+    /// <summary>Identifies the <see cref="BalloonTipText"/> dependency property.</summary>
+    public static readonly DependencyProperty BalloonTipTextProperty = DependencyProperty.Register(
+        nameof(BalloonTipText),
+        typeof(string),
+        typeof(NotifyIcon),
+        new PropertyMetadata(string.Empty, OnBalloonTipTextChanged)
+    );
+
+    /// <summary>Identifies the <see cref="BalloonTipIcon"/> dependency property.</summary>
+    public static readonly DependencyProperty BalloonTipIconProperty = DependencyProperty.Register(
+        nameof(BalloonTipIcon),
+        typeof(ToolTipIcon),
+        typeof(NotifyIcon),
+        new PropertyMetadata(ToolTipIcon.None, OnBalloonTipIconChanged)
+    );
+
     /// <summary>Identifies the <see cref="FocusOnLeftClick"/> dependency property.</summary>
     public static readonly DependencyProperty FocusOnLeftClickProperty = DependencyProperty.Register(
         nameof(FocusOnLeftClick),
@@ -98,6 +123,24 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     {
         get => (string)GetValue(TooltipTextProperty);
         set => SetValue(TooltipTextProperty, value);
+    }
+
+    public string BalloonTipTitle
+    {
+        get => (string)GetValue(BalloonTipTitleProperty);
+        set => SetValue(BalloonTipTitleProperty, value);
+    }
+
+    public string BalloonTipText
+    {
+        get => (string)GetValue(BalloonTipTextProperty);
+        set => SetValue(BalloonTipTextProperty, value);
+    }
+
+    public ToolTipIcon BalloonTipIcon
+    {
+        get => (ToolTipIcon)GetValue(BalloonTipIconProperty);
+        set => SetValue(BalloonTipIconProperty, value);
     }
 
     /// <summary>
@@ -187,6 +230,30 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         typeof(NotifyIcon)
     );
 
+    /// <summary>Identifies the <see cref="BalloonTipClick"/> routed event.</summary>
+    public static readonly RoutedEvent BalloonTipClickEvent = EventManager.RegisterRoutedEvent(
+        nameof(BalloonTipClick),
+        RoutingStrategy.Bubble,
+        typeof(RoutedNotifyIconEvent),
+        typeof(NotifyIcon)
+    );
+
+    /// <summary>Identifies the <see cref="BalloonTipShown"/> routed event.</summary>
+    public static readonly RoutedEvent BalloonTipShownEvent = EventManager.RegisterRoutedEvent(
+        nameof(BalloonTipShown),
+        RoutingStrategy.Bubble,
+        typeof(RoutedNotifyIconEvent),
+        typeof(NotifyIcon)
+    );
+
+    /// <summary>Identifies the <see cref="BalloonTipClose"/> routed event.</summary>
+    public static readonly RoutedEvent BalloonTipCloseEvent = EventManager.RegisterRoutedEvent(
+        nameof(BalloonTipClose),
+        RoutingStrategy.Bubble,
+        typeof(RoutedNotifyIconEvent),
+        typeof(NotifyIcon)
+    );
+
     /// <summary>
     /// Triggered when the user left-clicks on the <see cref="INotifyIcon"/>.
     /// </summary>
@@ -241,6 +308,33 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         remove => RemoveHandler(MiddleDoubleClickEvent, value);
     }
 
+    /// <summary>
+    /// Triggered when the user clicks the balloon tip notification associated with the <see cref="INotifyIcon"/>.
+    /// </summary>
+    public event RoutedNotifyIconEvent BalloonTipClick
+    {
+        add => AddHandler(BalloonTipClickEvent, value);
+        remove => RemoveHandler(BalloonTipClickEvent, value);
+    }
+
+    /// <summary>
+    /// Triggered when the balloon tip notification associated with the <see cref="INotifyIcon"/> is displayed.
+    /// </summary>
+    public event RoutedNotifyIconEvent BalloonTipShown
+    {
+        add => AddHandler(BalloonTipShownEvent, value);
+        remove => RemoveHandler(BalloonTipShownEvent, value);
+    }
+
+    /// <summary>
+    /// Triggered when the balloon tip notification associated with the <see cref="INotifyIcon"/> is closed or dismissed.
+    /// </summary>
+    public event RoutedNotifyIconEvent BalloonTipClose
+    {
+        add => AddHandler(BalloonTipCloseEvent, value);
+        remove => RemoveHandler(BalloonTipCloseEvent, value);
+    }
+
     public NotifyIcon()
     {
         internalNotifyIconManager = new Wpf.Ui.Tray.Internal.InternalNotifyIconManager();
@@ -265,6 +359,49 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// Tries to unregister the <see cref="NotifyIcon"/> from the shell.
     /// </summary>
     public void Unregister() => internalNotifyIconManager.Unregister();
+
+    /// <summary>
+    /// Displays a balloon tip notification from the system tray icon.
+    /// </summary>
+    /// <param name="timeout">
+    /// The duration, in milliseconds, that the balloon tip should be displayed.
+    /// Actual display time may be controlled by the operating system.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the balloon tip was successfully shown; otherwise, <see langword="false"/>.
+    /// </returns>
+    public bool ShowBalloonTip(int timeout)
+    {
+        return internalNotifyIconManager.ShowBalloonTip(timeout);
+    }
+
+    /// <summary>
+    /// Displays a balloon tip notification from the system tray icon with a custom title, message, and icon.
+    /// </summary>
+    /// <param name="timeout">
+    /// The duration, in milliseconds, that the balloon tip should be displayed.
+    /// Actual display time may be controlled by the operating system.
+    /// </param>
+    /// <param name="title">
+    /// The title text displayed in the balloon notification.
+    /// </param>
+    /// <param name="message">
+    /// The main content text displayed in the balloon notification.
+    /// </param>
+    /// <param name="icon">
+    /// The icon type displayed in the balloon notification.
+    /// Defaults to <see cref="ToolTipIcon.Info"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the balloon tip was successfully shown; otherwise, <see langword="false"/>.
+    /// </returns>
+    public bool ShowBalloonTip(int timeout, string title, string message, ToolTipIcon icon = ToolTipIcon.Info)
+    {
+        internalNotifyIconManager.BalloonTipTitle = title;
+        internalNotifyIconManager.BalloonTipText = message;
+        internalNotifyIconManager.BalloonTipIcon = icon;
+        return internalNotifyIconManager.ShowBalloonTip(timeout);
+    }
 
     public void Dispose()
     {
@@ -343,6 +480,33 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     }
 
     /// <summary>
+    /// This virtual method is called when the user clicks the balloon tip associated with the <see cref="NotifyIcon"/> and it raises the <see cref="BalloonTipClick"/> <see langword="event"/>.
+    /// </summary>
+    protected virtual void OnBalloonTipClick()
+    {
+        var newEvent = new RoutedEventArgs(BalloonTipClickEvent, this);
+        RaiseEvent(newEvent);
+    }
+
+    /// <summary>
+    /// This virtual method is called when the balloon tip associated with the <see cref="NotifyIcon"/> is displayed and it raises the <see cref="BalloonTipShown"/> <see langword="event"/>.
+    /// </summary>
+    protected virtual void OnBalloonTipShown()
+        {
+            var newEvent = new RoutedEventArgs(BalloonTipShownEvent, this);
+            RaiseEvent(newEvent);
+    }
+
+    /// <summary>
+    /// This virtual method is called when the balloon tip associated with the <see cref="NotifyIcon"/> is closed or dismissed and it raises the <see cref="BalloonTipClose"/> <see langword="event"/>.
+    /// </summary>
+    protected virtual void OnBalloonTipClose()
+    {
+        var newEvent = new RoutedEventArgs(BalloonTipCloseEvent, this);
+        RaiseEvent(newEvent);
+    }
+
+    /// <summary>
     /// If disposing equals <see langword="true"/>, the method has been called directly or indirectly
     /// by a user's code. Managed and unmanaged resources can be disposed. If disposing equals <see langword="false"/>,
     /// the method has been called by the runtime from inside the finalizer and you should not
@@ -400,6 +564,36 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
 
         notifyIcon.internalNotifyIconManager.TooltipText = notifyIcon.TooltipText;
         _ = notifyIcon.internalNotifyIconManager.ModifyToolTip();
+    }
+
+    private static void OnBalloonTipTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not NotifyIcon notifyIcon)
+        {
+            return;
+        }
+
+        notifyIcon.internalNotifyIconManager.BalloonTipTitle = notifyIcon.BalloonTipTitle;
+    }
+
+    private static void OnBalloonTipTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not NotifyIcon notifyIcon)
+        {
+            return;
+        }
+
+        notifyIcon.internalNotifyIconManager.BalloonTipText = notifyIcon.BalloonTipText;
+    }
+
+    private static void OnBalloonTipIconChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not NotifyIcon notifyIcon)
+        {
+            return;
+        }
+
+        notifyIcon.internalNotifyIconManager.BalloonTipIcon = notifyIcon.BalloonTipIcon;
     }
 
     private static void OnIconChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -482,6 +676,9 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         internalNotifyIconManager.RightDoubleClick += OnRightDoubleClick;
         internalNotifyIconManager.MiddleClick += OnMiddleClick;
         internalNotifyIconManager.MiddleDoubleClick += OnMiddleDoubleClick;
+        internalNotifyIconManager.BalloonTipClick += OnBalloonTipClick;
+        internalNotifyIconManager.BalloonTipShown += OnBalloonTipShown;
+        internalNotifyIconManager.BalloonTipClose += OnBalloonTipClose;
     }
 
     private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -356,6 +356,15 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     }
 
     /// <summary>
+    /// Gets the <see cref="Internal.InternalNotifyIconManager"/> used by this <see cref="NotifyIcon"/> instance.
+    /// </summary>
+    /// <returns>The internal notify icon manager.</returns>
+    internal Wpf.Ui.Tray.Internal.InternalNotifyIconManager GetInternalManager()
+    {
+        return internalNotifyIconManager;
+    }
+
+    /// <summary>
     /// Finalizes an instance of the <see cref="NotifyIcon"/> class.
     /// </summary>
     ~NotifyIcon() => Dispose(false);

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -76,7 +76,7 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         nameof(BalloonTipIcon),
         typeof(ToolTipIcon),
         typeof(NotifyIcon),
-        new PropertyMetadata(ToolTipIcon.None, OnBalloonTipIconChanged)
+        new PropertyMetadata(ToolTipIcon.Info, OnBalloonTipIconChanged)
     );
 
     /// <summary>Identifies the <see cref="FocusOnLeftClick"/> dependency property.</summary>

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -398,9 +398,9 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// </returns>
     public bool ShowBalloonTip(int timeout, string title, string message, ToolTipIcon icon = ToolTipIcon.Info)
     {
-        internalNotifyIconManager.BalloonTipTitle = title;
-        internalNotifyIconManager.BalloonTipText = message;
-        internalNotifyIconManager.BalloonTipIcon = icon;
+        SetCurrentValue(BalloonTipTitleProperty, title);
+        SetCurrentValue(BalloonTipTextProperty, message);
+        SetCurrentValue(BalloonTipIconProperty, icon);
         return internalNotifyIconManager.ShowBalloonTip(timeout);
     }
 

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -240,9 +240,9 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         typeof(NotifyIcon)
     );
 
-    /// <summary>Identifies the <see cref="BalloonTipClick"/> routed event.</summary>
-    public static readonly RoutedEvent BalloonTipClickEvent = EventManager.RegisterRoutedEvent(
-        nameof(BalloonTipClick),
+    /// <summary>Identifies the <see cref="BalloonTipClicked"/> routed event.</summary>
+    public static readonly RoutedEvent BalloonTipClickedEvent = EventManager.RegisterRoutedEvent(
+        nameof(BalloonTipClicked),
         RoutingStrategy.Bubble,
         typeof(RoutedNotifyIconEvent),
         typeof(NotifyIcon)
@@ -256,9 +256,9 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         typeof(NotifyIcon)
     );
 
-    /// <summary>Identifies the <see cref="BalloonTipClose"/> routed event.</summary>
-    public static readonly RoutedEvent BalloonTipCloseEvent = EventManager.RegisterRoutedEvent(
-        nameof(BalloonTipClose),
+    /// <summary>Identifies the <see cref="BalloonTipClosed"/> routed event.</summary>
+    public static readonly RoutedEvent BalloonTipClosedEvent = EventManager.RegisterRoutedEvent(
+        nameof(BalloonTipClosed),
         RoutingStrategy.Bubble,
         typeof(RoutedNotifyIconEvent),
         typeof(NotifyIcon)
@@ -321,10 +321,10 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// <summary>
     /// Triggered when the user clicks the balloon tip notification associated with the <see cref="INotifyIcon"/>.
     /// </summary>
-    public event RoutedNotifyIconEvent BalloonTipClick
+    public event RoutedNotifyIconEvent BalloonTipClicked
     {
-        add => AddHandler(BalloonTipClickEvent, value);
-        remove => RemoveHandler(BalloonTipClickEvent, value);
+        add => AddHandler(BalloonTipClickedEvent, value);
+        remove => RemoveHandler(BalloonTipClickedEvent, value);
     }
 
     /// <summary>
@@ -339,10 +339,10 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// <summary>
     /// Triggered when the balloon tip notification associated with the <see cref="INotifyIcon"/> is closed or dismissed.
     /// </summary>
-    public event RoutedNotifyIconEvent BalloonTipClose
+    public event RoutedNotifyIconEvent BalloonTipClosed
     {
-        add => AddHandler(BalloonTipCloseEvent, value);
-        remove => RemoveHandler(BalloonTipCloseEvent, value);
+        add => AddHandler(BalloonTipClosedEvent, value);
+        remove => RemoveHandler(BalloonTipClosedEvent, value);
     }
 
     public NotifyIcon()
@@ -501,11 +501,11 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     }
 
     /// <summary>
-    /// This virtual method is called when the user clicks the balloon tip associated with the <see cref="NotifyIcon"/> and it raises the <see cref="BalloonTipClick"/> <see langword="event"/>.
+    /// This virtual method is called when the user clicks the balloon tip associated with the <see cref="NotifyIcon"/> and it raises the <see cref="BalloonTipClicked"/> <see langword="event"/>.
     /// </summary>
-    protected virtual void OnBalloonTipClick()
+    protected virtual void OnBalloonTipClicked()
     {
-        var newEvent = new RoutedEventArgs(BalloonTipClickEvent, this);
+        var newEvent = new RoutedEventArgs(BalloonTipClickedEvent, this);
         RaiseEvent(newEvent);
     }
 
@@ -519,11 +519,11 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     }
 
     /// <summary>
-    /// This virtual method is called when the balloon tip associated with the <see cref="NotifyIcon"/> is closed or dismissed and it raises the <see cref="BalloonTipClose"/> <see langword="event"/>.
+    /// This virtual method is called when the balloon tip associated with the <see cref="NotifyIcon"/> is closed or dismissed and it raises the <see cref="BalloonTipClosed"/> <see langword="event"/>.
     /// </summary>
-    protected virtual void OnBalloonTipClose()
+    protected virtual void OnBalloonTipClosed()
     {
-        var newEvent = new RoutedEventArgs(BalloonTipCloseEvent, this);
+        var newEvent = new RoutedEventArgs(BalloonTipClosedEvent, this);
         RaiseEvent(newEvent);
     }
 
@@ -697,9 +697,9 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         internalNotifyIconManager.RightDoubleClick += OnRightDoubleClick;
         internalNotifyIconManager.MiddleClick += OnMiddleClick;
         internalNotifyIconManager.MiddleDoubleClick += OnMiddleDoubleClick;
-        internalNotifyIconManager.BalloonTipClick += OnBalloonTipClick;
+        internalNotifyIconManager.BalloonTipClicked += OnBalloonTipClicked;
         internalNotifyIconManager.BalloonTipShown += OnBalloonTipShown;
-        internalNotifyIconManager.BalloonTipClose += OnBalloonTipClose;
+        internalNotifyIconManager.BalloonTipClosed += OnBalloonTipClosed;
     }
 
     private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/NotifyIcon.cs
@@ -54,7 +54,7 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         new PropertyMetadata(string.Empty, OnTooltipTextChanged)
     );
 
-    /// <summary>Identifies the <see cref="BalloonTipTitle"/> dependency property. Title text exceeding 63 characters will be truncated by the shell.</summary>
+    /// <summary>Identifies the <see cref="BalloonTipTitle"/> dependency property.</summary>
     public static readonly DependencyProperty BalloonTipTitleProperty = DependencyProperty.Register(
         nameof(BalloonTipTitle),
         typeof(string),
@@ -62,7 +62,7 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         new PropertyMetadata(string.Empty, OnBalloonTipTitleChanged)
     );
 
-    /// <summary>Identifies the <see cref="BalloonTipText"/> dependency property. Message text exceeding 255 characters will be truncated by the shell.</summary>
+    /// <summary>Identifies the <see cref="BalloonTipText"/> dependency property.</summary>
     public static readonly DependencyProperty BalloonTipTextProperty = DependencyProperty.Register(
         nameof(BalloonTipText),
         typeof(string),
@@ -124,18 +124,29 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
         set => SetValue(TooltipTextProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the title displayed in the notification balloon tip.
+    /// Text exceeding 63 characters will be truncated by the shell.
+    /// </summary>
     public string BalloonTipTitle
     {
         get => (string)GetValue(BalloonTipTitleProperty);
         set => SetValue(BalloonTipTitleProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the message text displayed in the notification balloon tip.
+    /// Text exceeding 255 characters will be truncated by the shell.
+    /// </summary>
     public string BalloonTipText
     {
         get => (string)GetValue(BalloonTipTextProperty);
         set => SetValue(BalloonTipTextProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the icon displayed in the notification balloon tip.
+    /// </summary>
     public ToolTipIcon BalloonTipIcon
     {
         get => (ToolTipIcon)GetValue(BalloonTipIconProperty);
@@ -363,13 +374,13 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// Displays a balloon tip notification from the system tray icon.
     /// </summary>
     /// <param name="timeout">
-    /// The duration, in milliseconds, that the balloon tip should be displayed.
+    /// The duration that the balloon tip should be displayed.
     /// Actual display time may be controlled by the operating system.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the balloon tip was successfully shown; otherwise, <see langword="false"/>.
     /// </returns>
-    public bool ShowBalloonTip(int timeout)
+    public bool ShowBalloonTip(TimeSpan timeout)
     {
         return internalNotifyIconManager.ShowBalloonTip(timeout);
     }
@@ -378,7 +389,7 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// Displays a balloon tip notification from the system tray icon with a custom title, message, and icon.
     /// </summary>
     /// <param name="timeout">
-    /// The duration, in milliseconds, that the balloon tip should be displayed.
+    /// The duration that the balloon tip should be displayed.
     /// Actual display time may be controlled by the operating system.
     /// </param>
     /// <param name="title">
@@ -390,13 +401,13 @@ public class NotifyIcon : System.Windows.FrameworkElement, IDisposable
     /// Text exceeding 255 characters will be truncated by the shell.
     /// </param>
     /// <param name="icon">
-    /// The icon type displayed in the balloon notification.
+    /// The icon displayed in the balloon notification.
     /// Defaults to <see cref="ToolTipIcon.Info"/>.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the balloon tip was successfully shown; otherwise, <see langword="false"/>.
     /// </returns>
-    public bool ShowBalloonTip(int timeout, string title, string message, ToolTipIcon icon = ToolTipIcon.Info)
+    public bool ShowBalloonTip(TimeSpan timeout, string title, string message, ToolTipIcon icon = ToolTipIcon.Info)
     {
         SetCurrentValue(BalloonTipTitleProperty, title);
         SetCurrentValue(BalloonTipTextProperty, message);

--- a/src/Wpf.Ui.Tray/Controls/ToolTipIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/ToolTipIcon.cs
@@ -3,10 +3,6 @@
 // Copyright (C) Leszek Pomianowski and WPF UI Contributors.
 // All Rights Reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Wpf.Ui.Tray.Controls;
 
 /// <summary>

--- a/src/Wpf.Ui.Tray/Controls/ToolTipIcon.cs
+++ b/src/Wpf.Ui.Tray/Controls/ToolTipIcon.cs
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Wpf.Ui.Tray.Controls;
+
+/// <summary>
+/// Specifies the icon displayed in a tray balloon tip notification.
+/// </summary>
+public enum ToolTipIcon
+{
+    /// <summary>
+    /// No icon is displayed in the balloon tip notification.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Displays an informational icon in the balloon tip notification.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Displays a warning icon in the balloon tip notification.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Displays an error icon in the balloon tip notification.
+    /// </summary>
+    Error
+}

--- a/src/Wpf.Ui.Tray/INotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/INotifyIcon.cs
@@ -37,11 +37,13 @@ internal interface INotifyIcon
 
     /// <summary>
     /// Gets or sets the title displayed in the notification balloon tip.
+    /// Text exceeding 63 characters will be truncated by the shell.
     /// </summary>
     string BalloonTipTitle { get; set; }
 
     /// <summary>
     /// Gets or sets the message text displayed in the notification balloon tip.
+    /// Text exceeding 255 characters will be truncated by the shell.
     /// </summary>
     string BalloonTipText { get; set; }
 

--- a/src/Wpf.Ui.Tray/INotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/INotifyIcon.cs
@@ -6,6 +6,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Wpf.Ui.Tray.Controls;
 
 namespace Wpf.Ui.Tray;
 
@@ -33,6 +34,21 @@ internal interface INotifyIcon
     /// Gets or sets the ToolTip text displayed when the mouse pointer rests on a notification area icon.
     /// </summary>
     string TooltipText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the title displayed in the notification balloon tip.
+    /// </summary>
+    string BalloonTipTitle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message text displayed in the notification balloon tip.
+    /// </summary>
+    string BalloonTipText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon type displayed in the notification balloon tip.
+    /// </summary>
+    ToolTipIcon BalloonTipIcon { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="System.Windows.Media.Imaging.BitmapSource"/> of the tray icon.

--- a/src/Wpf.Ui.Tray/INotifyIcon.cs
+++ b/src/Wpf.Ui.Tray/INotifyIcon.cs
@@ -37,13 +37,11 @@ internal interface INotifyIcon
 
     /// <summary>
     /// Gets or sets the title displayed in the notification balloon tip.
-    /// Text exceeding 63 characters will be truncated by the shell.
     /// </summary>
     string BalloonTipTitle { get; set; }
 
     /// <summary>
     /// Gets or sets the message text displayed in the notification balloon tip.
-    /// Text exceeding 255 characters will be truncated by the shell.
     /// </summary>
     string BalloonTipText { get; set; }
 

--- a/src/Wpf.Ui.Tray/INotifyIconService.cs
+++ b/src/Wpf.Ui.Tray/INotifyIconService.cs
@@ -53,4 +53,14 @@ public interface INotifyIconService
     /// Sets parent window of the tray icon.
     /// </summary>
     public void SetParentWindow(Window window);
+
+    /// <summary>
+    /// Sets the <see cref="Wpf.Ui.Tray.Controls.NotifyIcon"/> control to be used by the service.
+    /// </summary>
+    public void SetNotifyIcon(Wpf.Ui.Tray.Controls.NotifyIcon notifyIcon);
+
+    /// <summary>
+    /// Gets the <see cref="Wpf.Ui.Tray.Controls.NotifyIcon"/> control used by the service.
+    /// </summary>
+    public Wpf.Ui.Tray.Controls.NotifyIcon? GetNotifyIcon();
 }

--- a/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
+++ b/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
@@ -67,11 +67,11 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
 
     public event NotifyIconEventHandler? MiddleDoubleClick;
 
-    public event NotifyIconEventHandler? BalloonTipClick;
+    public event NotifyIconEventHandler? BalloonTipClicked;
 
     public event NotifyIconEventHandler? BalloonTipShown;
 
-    public event NotifyIconEventHandler? BalloonTipClose;
+    public event NotifyIconEventHandler? BalloonTipClosed;
 
     /// <summary>
     /// Gets or sets a set of information for Shell32 to manipulate the icon.
@@ -264,18 +264,18 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
     /// This virtual method is called when the balloon tip associated with the tray icon is closed or dismissed
     /// and it raises the balloon tip close <see langword="event"/>.
     /// </summary>
-    protected virtual void OnBalloonTipClose()
+    protected virtual void OnBalloonTipClosed()
     {
-        BalloonTipClose?.Invoke();
+        BalloonTipClosed?.Invoke();
     }
 
     /// <summary>
     /// This virtual method is called when the user clicks the balloon tip associated with the tray icon
     /// and it raises the balloon tip click <see langword="event"/>.
     /// </summary>
-    protected virtual void OnBalloonTipClick()
+    protected virtual void OnBalloonTipClicked()
     {
-        BalloonTipClick?.Invoke();
+        BalloonTipClicked?.Invoke();
     }
 
     /// <summary>
@@ -430,11 +430,11 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
 
             case Interop.User32.WM.NIIF_HIDDEN:
             case Interop.User32.WM.NIIF_TIMEOUT:
-                OnBalloonTipClose();
+                OnBalloonTipClosed();
                 break;
 
             case Interop.User32.WM.NIIF_SELECTED:
-                OnBalloonTipClick();
+                OnBalloonTipClicked();
                 break;
         }
 

--- a/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
+++ b/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
@@ -282,12 +282,13 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
     /// Displays a balloon tip notification in the system tray using the current balloon tip properties.
     /// </summary>
     /// <param name="timeout">
-    /// The timeout value, in milliseconds, for displaying the balloon tip notification.
+    /// The duration for displaying the balloon tip notification.
+    /// Actual display time may be controlled by the operating system.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the balloon tip notification was successfully displayed; otherwise, <see langword="false"/>.
     /// </returns>
-    public bool ShowBalloonTip(int timeout)
+    public bool ShowBalloonTip(TimeSpan timeout)
     {
         string title = this.BalloonTipTitle ?? string.Empty;
         string message = this.BalloonTipText ?? string.Empty;
@@ -297,7 +298,7 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
         data.uFlags = Interop.Shell32.NIF.INFO;
         data.szInfo = message.Length > 255 ? message[..255] : message;
         data.szInfoTitle = title.Length > 63 ? title[..63] : title;
-        data.uVersion = (uint)timeout;
+        data.uVersion = (uint)timeout.TotalMilliseconds;
         data.dwInfoFlags = icon switch
         {
             ToolTipIcon.Info => 0x00000001u,

--- a/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
+++ b/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
@@ -293,7 +293,7 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
         string message = this.BalloonTipText ?? string.Empty;
         ToolTipIcon icon = this.BalloonTipIcon;
 
-        Interop.Shell32.NOTIFYICONDATA data = ShellIconData;
+        Interop.Shell32.NOTIFYICONDATA data = ShellIconData.Clone();
         data.uFlags = Interop.Shell32.NIF.INFO;
         data.szInfo = message.Length > 255 ? message[..255] : message;
         data.szInfoTitle = title.Length > 63 ? title[..63] : title;

--- a/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
+++ b/src/Wpf.Ui.Tray/Internal/InternalNotifyIconManager.cs
@@ -8,6 +8,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using Wpf.Ui.Appearance;
+using Wpf.Ui.Tray.Controls;
 
 namespace Wpf.Ui.Tray.Internal;
 
@@ -29,6 +30,15 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
 
     /// <inheritdoc />
     public string TooltipText { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public string BalloonTipTitle { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public string BalloonTipText { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public ToolTipIcon BalloonTipIcon { get; set; } = ToolTipIcon.Info;
 
     /// <inheritdoc />
     public ImageSource? Icon { get; set; } = default!;
@@ -56,6 +66,12 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
     public event NotifyIconEventHandler? MiddleClick;
 
     public event NotifyIconEventHandler? MiddleDoubleClick;
+
+    public event NotifyIconEventHandler? BalloonTipClick;
+
+    public event NotifyIconEventHandler? BalloonTipShown;
+
+    public event NotifyIconEventHandler? BalloonTipClose;
 
     /// <summary>
     /// Gets or sets a set of information for Shell32 to manipulate the icon.
@@ -236,6 +252,64 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
     }
 
     /// <summary>
+    /// This virtual method is called when the balloon tip associated with the tray icon is displayed
+    /// and it raises the balloon tip shown <see langword="event"/>.
+    /// </summary>
+    protected virtual void OnBalloonTipShown()
+    {
+        BalloonTipShown?.Invoke();
+    }
+
+    /// <summary>
+    /// This virtual method is called when the balloon tip associated with the tray icon is closed or dismissed
+    /// and it raises the balloon tip close <see langword="event"/>.
+    /// </summary>
+    protected virtual void OnBalloonTipClose()
+    {
+        BalloonTipClose?.Invoke();
+    }
+
+    /// <summary>
+    /// This virtual method is called when the user clicks the balloon tip associated with the tray icon
+    /// and it raises the balloon tip click <see langword="event"/>.
+    /// </summary>
+    protected virtual void OnBalloonTipClick()
+    {
+        BalloonTipClick?.Invoke();
+    }
+
+    /// <summary>
+    /// Displays a balloon tip notification in the system tray using the current balloon tip properties.
+    /// </summary>
+    /// <param name="timeout">
+    /// The timeout value, in milliseconds, for displaying the balloon tip notification.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the balloon tip notification was successfully displayed; otherwise, <see langword="false"/>.
+    /// </returns>
+    public bool ShowBalloonTip(int timeout)
+    {
+        string title = this.BalloonTipTitle ?? string.Empty;
+        string message = this.BalloonTipText ?? string.Empty;
+        ToolTipIcon icon = this.BalloonTipIcon;
+
+        Interop.Shell32.NOTIFYICONDATA data = ShellIconData;
+        data.uFlags = Interop.Shell32.NIF.INFO;
+        data.szInfo = message.Length > 255 ? message[..255] : message;
+        data.szInfoTitle = title.Length > 63 ? title[..63] : title;
+        data.uVersion = (uint)timeout;
+        data.dwInfoFlags = icon switch
+        {
+            ToolTipIcon.Info => 0x00000001u,
+            ToolTipIcon.Warning => 0x00000002u,
+            ToolTipIcon.Error => 0x00000003u,
+            _ => 0x00000000u,
+        };
+
+        return Interop.Shell32.Shell_NotifyIcon(Interop.Shell32.NIM.MODIFY, data);
+    }
+
+    /// <summary>
     /// If disposing equals <see langword="true"/>, the method has been called directly or indirectly
     /// by a user's code. Managed and unmanaged resources can be disposed. If disposing equals <see langword="false"/>,
     /// the method has been called by the runtime from inside the finalizer and you should not
@@ -347,6 +421,19 @@ internal class InternalNotifyIconManager : IDisposable, INotifyIcon
 
             case Interop.User32.WM.MBUTTONDBLCLK:
                 OnMiddleDoubleClick();
+                break;
+
+            case Interop.User32.WM.NIIF_SHOW:
+                OnBalloonTipShown();
+                break;
+
+            case Interop.User32.WM.NIIF_HIDDEN:
+            case Interop.User32.WM.NIIF_TIMEOUT:
+                OnBalloonTipClose();
+                break;
+
+            case Interop.User32.WM.NIIF_SELECTED:
+                OnBalloonTipClick();
                 break;
         }
 

--- a/src/Wpf.Ui.Tray/Interop/Shell32.cs
+++ b/src/Wpf.Ui.Tray/Interop/Shell32.cs
@@ -73,6 +73,16 @@ internal static class Shell32
     public class NOTIFYICONDATA
     {
         /// <summary>
+        /// Creates a shallow copy of the current <see cref="NOTIFYICONDATA"/> instance.
+        /// This prevents modifications to temporary shell notification data from mutating
+        /// the shared instance used by other notify icon operations.
+        /// </summary>
+        public NOTIFYICONDATA Clone()
+        {
+            return (NOTIFYICONDATA)MemberwiseClone();
+        }
+
+        /// <summary>
         /// The size of this structure, in bytes.
         /// </summary>
         public int cbSize = Marshal.SizeOf(typeof(NOTIFYICONDATA));

--- a/src/Wpf.Ui.Tray/Interop/User32.cs
+++ b/src/Wpf.Ui.Tray/Interop/User32.cs
@@ -488,6 +488,11 @@ internal static class User32
         MOUSEHWHEEL = 0x020E,
         PARENTNOTIFY = 0x0210,
 
+        NIIF_SHOW = 0x0402,
+        NIIF_HIDDEN = 0x0403,
+        NIIF_TIMEOUT = 0x0404,
+        NIIF_SELECTED = 0x0405,
+
         CAPTURECHANGED = 0x0215,
         POWERBROADCAST = 0x0218,
         DEVICECHANGE = 0x0219,

--- a/src/Wpf.Ui.Tray/NotifyIconService.cs
+++ b/src/Wpf.Ui.Tray/NotifyIconService.cs
@@ -6,6 +6,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Wpf.Ui.Tray.Controls;
 
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
 
@@ -16,7 +17,9 @@ namespace Wpf.Ui.Tray;
 /// </summary>
 public class NotifyIconService : INotifyIconService
 {
-    private readonly Internal.InternalNotifyIconManager internalNotifyIconManager;
+    private Internal.InternalNotifyIconManager internalNotifyIconManager;
+
+    private NotifyIcon? _notifyIcon;
 
     public Window ParentWindow { get; internal set; } = null!;
 
@@ -76,6 +79,20 @@ public class NotifyIconService : INotifyIconService
         ParentWindow.Closing += OnParentWindowClosing;
     }
 
+    /// <inheritdoc />
+    public void SetNotifyIcon(NotifyIcon notifyIcon)
+    {
+        _notifyIcon = notifyIcon;
+        internalNotifyIconManager?.Dispose();
+        internalNotifyIconManager = notifyIcon.GetInternalManager();
+    }
+
+    /// <inheritdoc />
+    public NotifyIcon? GetNotifyIcon()
+    {
+        return _notifyIcon;
+    }
+
     /// <summary>
     /// This virtual method is called when the user clicks the left mouse button on the tray icon.
     /// </summary>
@@ -106,6 +123,21 @@ public class NotifyIconService : INotifyIconService
     /// </summary>
     protected virtual void OnMiddleDoubleClick() { }
 
+    /// <summary>
+    /// This virtual method is called when the user clicks the balloon tip notification.
+    /// </summary>
+    protected virtual void OnBalloonTipClick() { }
+
+    /// <summary>
+    /// This virtual method is called when the balloon tip notification is shown.
+    /// </summary>
+    protected virtual void OnBalloonTipShown() { }
+
+    /// <summary>
+    /// This virtual method is called when the balloon tip notification is closed or dismissed.
+    /// </summary>
+    protected virtual void OnBalloonTipClose() { }
+
     private void OnParentWindowClosing(object? sender, CancelEventArgs e)
     {
         internalNotifyIconManager.Dispose();
@@ -119,6 +151,9 @@ public class NotifyIconService : INotifyIconService
         internalNotifyIconManager.RightDoubleClick += OnRightDoubleClick;
         internalNotifyIconManager.MiddleClick += OnMiddleClick;
         internalNotifyIconManager.MiddleDoubleClick += OnMiddleDoubleClick;
+        internalNotifyIconManager.BalloonTipClick += OnBalloonTipClick;
+        internalNotifyIconManager.BalloonTipShown += OnBalloonTipShown;
+        internalNotifyIconManager.BalloonTipClose += OnBalloonTipClose;
     }
 }
 

--- a/src/Wpf.Ui.Tray/NotifyIconService.cs
+++ b/src/Wpf.Ui.Tray/NotifyIconService.cs
@@ -151,9 +151,9 @@ public class NotifyIconService : INotifyIconService
         internalNotifyIconManager.RightDoubleClick += OnRightDoubleClick;
         internalNotifyIconManager.MiddleClick += OnMiddleClick;
         internalNotifyIconManager.MiddleDoubleClick += OnMiddleDoubleClick;
-        internalNotifyIconManager.BalloonTipClick += OnBalloonTipClick;
+        internalNotifyIconManager.BalloonTipClicked += OnBalloonTipClick;
         internalNotifyIconManager.BalloonTipShown += OnBalloonTipShown;
-        internalNotifyIconManager.BalloonTipClose += OnBalloonTipClose;
+        internalNotifyIconManager.BalloonTipClosed += OnBalloonTipClose;
     }
 }
 


### PR DESCRIPTION
Introduce balloon tip functionality for the tray NotifyIcon. Adds a ToolTipIcon enum and new dependency properties (BalloonTipTitle, BalloonTipText, BalloonTipIcon), routed events (BalloonTipClick, BalloonTipShown, BalloonTipClose) and ShowBalloonTip overloads on NotifyIcon. InternalNotifyIconManager now stores balloon properties, exposes ShowBalloonTip which builds NOTIFYICONDATA (with length limits) and maps icon types to dwInfoFlags, and raises corresponding events. Also wires up native WM message constants in User32 and updates INotifyIcon to include balloon tip members.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1713

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added new properties and functionality related to BalloonTip to support displaying notifications as popups for NotifyIcon.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Here's an example of how BalloonTip's interface is displayed:
<img width="405" height="213" alt="image" src="https://github.com/user-attachments/assets/724d6a5a-5bb7-47fa-89a8-ba042a10239e" />
