### PR TITLE
Flyout now shows a drop shadow

### DIFF
--- a/src/Wpf.Ui/Controls/Flyout/Flyout.xaml
+++ b/src/Wpf.Ui/Controls/Flyout/Flyout.xaml
@@ -50,19 +50,29 @@
                             PopupAnimation="{TemplateBinding Popup.PopupAnimation}"
                             StaysOpen="{TemplateBinding Popup.StaysOpen}"
                             VerticalOffset="1">
-                            <Border
-                                x:Name="PopupBorder"
-                                Margin="{TemplateBinding Margin}"
-                                Padding="{TemplateBinding Padding}"
-                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="{DynamicResource PopupCornerRadius}"
-                                SnapsToDevicePixels="True">
-                                <ContentPresenter Content="{TemplateBinding Content}" />
-                            </Border>
+                            <controls:EffectThicknessDecorator Thickness="30">
+                                <Border
+                                    x:Name="PopupBorder"
+                                    Margin="{TemplateBinding Margin}"
+                                    Padding="{TemplateBinding Padding}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="{DynamicResource PopupCornerRadius}"
+                                    SnapsToDevicePixels="True">
+                                    <Border.Effect>
+                                        <DropShadowEffect
+                                            BlurRadius="20"
+                                            Direction="270"
+                                            Opacity="0.135"
+                                            ShadowDepth="10"
+                                            Color="#202020" />
+                                    </Border.Effect>
+                                    <ContentPresenter Content="{TemplateBinding Content}" />
+                                </Border>
+                            </controls:EffectThicknessDecorator>
                         </Popup>
                     </Grid>
                 </ControlTemplate>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

fixes #1708

The current Flyout looks a little naked:

<img width="348" height="241" alt="image" src="https://github.com/user-attachments/assets/042620a7-f55a-4cd9-80a5-cd2f4df6e49b" />

This is also inconsistent with WinUI 3, which wraps it in a drop shadow:

<img width="402" height="311" alt="image" src="https://github.com/user-attachments/assets/8cc7d761-46bf-4174-a4d2-fc850b5b4266" />

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This wraps Flyout with a drop shadow similar to how #1472 did it in other areas (such as context menu):

<img width="362" height="249" alt="image" src="https://github.com/user-attachments/assets/289e904e-a7df-4262-880f-1cd5287255be" />

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The positioning isn't quite right. Horizontally, I think it's supposed to be concentric with the control below (but that would be for a separate PR), and vertically, it has too much of an offset. If someone has an idea how to shove it closer to the control below, that'd be great.