### PR TITLE
fix: TitleBar respects ResizeMode.NoResize

### DIFF
--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
@@ -45,8 +45,7 @@ public partial class TitleBar
 
     private IntPtr GetWindowBorderHitTestResult(IntPtr hwnd, IntPtr lParam)
     {
-        var window = Window.GetWindow(this);
-        if (window?.ResizeMode != ResizeMode.CanResize && window?.ResizeMode != ResizeMode.CanResizeWithGrip)
+        if (_currentWindow?.ResizeMode != ResizeMode.CanResize && _currentWindow?.ResizeMode != ResizeMode.CanResizeWithGrip)
         {
             return (IntPtr)PInvoke.HTNOWHERE;
         }

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
@@ -48,9 +48,9 @@ public partial class TitleBar
         var window = Window.GetWindow(this);
         if (window?.ResizeMode != ResizeMode.CanResize && window?.ResizeMode != ResizeMode.CanResizeWithGrip)
         {
-            return IntPtr.Zero;
+            return (IntPtr)PInvoke.HTNOWHERE;
         }
-        
+
         if (!PInvoke.GetWindowRect(new HWND(hwnd), out RECT windowRect))
         {
             return (IntPtr)PInvoke.HTNOWHERE;

--- a/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
+++ b/src/Wpf.Ui/Controls/TitleBar/TitleBar.WindowResize.cs
@@ -45,6 +45,12 @@ public partial class TitleBar
 
     private IntPtr GetWindowBorderHitTestResult(IntPtr hwnd, IntPtr lParam)
     {
+        var window = Window.GetWindow(this);
+        if (window?.ResizeMode != ResizeMode.CanResize && window?.ResizeMode != ResizeMode.CanResizeWithGrip)
+        {
+            return IntPtr.Zero;
+        }
+        
         if (!PInvoke.GetWindowRect(new HWND(hwnd), out RECT windowRect))
         {
             return (IntPtr)PInvoke.HTNOWHERE;


### PR DESCRIPTION
Add ResizeMode check in GetWindowBorderHitTestResult. Return HTNOWHERE when ResizeMode is not CanResize or CanResizeWithGrip. Fixes regression introduced by PR #1560 where NoResize windows remained resizable.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a FluentWindow has `ResizeMode="NoResize"` (or `CanMinimize`) and contains a TitleBar with `ExtendsContentIntoTitleBar="True"`, the window can still be resized by dragging its borders.

This is because `GetWindowBorderHitTestResult()` returns resize hit-test values (`HTLEFT`/`HTRIGHT`/`HTTOP`/`HTBOTTOM` etc.) without checking the window's `ResizeMode` property.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a `ResizeMode` check at the beginning of `GetWindowBorderHitTestResult()`
- Returns `IntPtr.Zero` (`HTNOWHERE`) when `ResizeMode` is not `CanResize` or `CanResizeWithGrip`
- Windows with `ResizeMode="NoResize"` or `ResizeMode="CanMinimize"` can no longer be resized via border dragging
- Preserves normal resize behavior for `CanResize` and `CanResizeWithGrip`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

**Affected versions:** v4.1.0 - v4.3.0 (regression introduced by PR #1560)

**Tested on:** v4.3.0

**Minimal repro XAML:**
```xml
<ui:FluentWindow ResizeMode="NoResize" ExtendsContentIntoTitleBar="True">
    <ui:TitleBar/>
</ui:FluentWindow>