### PR TITLE
fix(controls): Remove MinWidth and MinHeight of NumberBox Flyout

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -143,7 +143,11 @@
                                         <controls:SymbolIcon FontSize="{StaticResource NumberBoxButtonIconSize}" Symbol="ChevronUpDown24" />
                                     </Button>
 
-                                    <controls:Flyout x:Name="PART_CompactIncrementDecrementFlyout" Placement="Center">
+                                    <controls:Flyout
+                                        x:Name="PART_CompactIncrementDecrementFlyout"
+                                        MinWidth="0"
+                                        MinHeight="0"
+                                        Placement="Center">
                                         <Grid>
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="*" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The NumberBox has extra whitespace on the right side. This is caused by the PART_CompactIncrementDecrementFlyout inside the StackPanel, which inherits the default MinWidth="20" and MinHeight="20" from the Flyout style, occupying unnecessary layout space.

## What is the new behavior?

The Flyout in NumberBox template explicitly sets MinWidth="0" and MinHeight="0", eliminating the extra whitespace in all SpinButtonPlacementMode.

## Other information

Here is a detailed before/after comparison. The screenshots demonstrate three different settings for SpinButtonPlacementMode.
<img width="460" height="346" alt="image" src="https://github.com/user-attachments/assets/f6c9acd4-cd1f-4a4a-a5d6-d0847de50d0a" />

