### PR TITLE
fix(controls): Remove TranslateTransform setters from ToggleSwitch

### DIFF
--- a/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
+++ b/src/Wpf.Ui/Controls/ToggleSwitch/ToggleSwitch.xaml
@@ -281,11 +281,6 @@
                                 <Condition Property="IsChecked" Value="False" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ToggleEllipse" Property="Width" Value="17" />
-                            <Setter TargetName="ToggleEllipse" Property="RenderTransform">
-                                <Setter.Value>
-                                    <TranslateTransform X="-7.5" />
-                                </Setter.Value>
-                            </Setter>
                         </MultiTrigger>
 
                         <MultiTrigger>
@@ -294,11 +289,6 @@
                                 <Condition Property="IsChecked" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ActiveToggleEllipse" Property="Width" Value="17" />
-                            <Setter TargetName="ActiveToggleEllipse" Property="RenderTransform">
-                                <Setter.Value>
-                                    <TranslateTransform X="7.5" />
-                                </Setter.Value>
-                            </Setter>
                         </MultiTrigger>
 
                         <MultiTrigger>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://github.com/lepoco/wpfui/issues/1712
Issue Number: 1712

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The indicator-circle will be right instead of left.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
