### PR TITLE
fix: SetWindowChrome ResizeBorderThickness for non-resizable modes

### DIFF
--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -308,7 +308,9 @@ public class FluentWindow : System.Windows.Window
                                 ? new Thickness(0.00001)
                                 : new Thickness(-1), // 0.00001 so there's no glass frame drawn around the window, but the border is still drawn.
                         ResizeBorderThickness =
-                            ResizeMode == ResizeMode.NoResize ? default : new Thickness(4),
+                            (ResizeMode == ResizeMode.CanResize || ResizeMode == ResizeMode.CanResizeWithGrip)
+                                ? new Thickness(4)
+                                : default, // only CanResize or CanResizeWithGrip should set Thickness
                         UseAeroCaptionButtons = false,
                     }
                 );


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

PR #1719 added a `ResizeMode` check in `TitleBar.GetWindowBorderHitTestResult()` to prevent resizing when `ResizeMode` is `NoResize` or `CanMinimize`. However, this was only a partial fix — the root cause is in `FluentWindow.SetWindowChrome()`, where `ResizeBorderThickness` is incorrectly set to `4` for `CanMinimize` mode.

Because `WindowChrome` handles `WM_NCHITTEST` independently of `TitleBar`'s `HwndSourceHook`, the `TitleBar` fix alone cannot fully prevent resizing in `CanMinimize` mode. The window borders remain resizable via `WindowChrome.ResizeBorderThickness`.

Related: #1719

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `FluentWindow.SetWindowChrome()` now only sets `ResizeBorderThickness = 4` when `ResizeMode` is `CanResize` or `CanResizeWithGrip`
- `CanMinimize` and `NoResize` now correctly get `ResizeBorderThickness = 0`, preventing unintended window resizing at the `WindowChrome` level
- This is the proper fix for the issue addressed in #1719

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR supersedes / completes the fix started in #1719. The previous PR worked around the symptom in `TitleBar`; this PR fixes the root cause in `FluentWindow`.

Minimal repro XAML (before fix — window borders remain resizable):

```xml
<<ui:FluentWindow ResizeMode="CanMinimize" ExtendsContentIntoTitleBar="True">
    <ui:TitleBar/>
</ui:FluentWindow>