### PR TITLE
fix(controls): Fix LeftFluent nav item hover invisible in Light theme

### DIFF
--- a/src/Wpf.Ui/Resources/Theme/Light.xaml
+++ b/src/Wpf.Ui/Resources/Theme/Light.xaml
@@ -50,7 +50,7 @@
     <Color x:Key="ControlSolidFillColorDefault">#FFFFFF</Color>
 
     <Color x:Key="SubtleFillColorTransparent">#00FFFFFF</Color>
-    <Color x:Key="SubtleFillColorSecondary">#09000000</Color>
+    <Color x:Key="SubtleFillColorSecondary">#14000000</Color>
     <Color x:Key="SubtleFillColorTertiary">#06000000</Color>
     <Color x:Key="SubtleFillColorDisabled">#00FFFFFF</Color>
 
@@ -543,7 +543,7 @@
     <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource LayerFillColorDefault}" />
     <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
 
-    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

LeftFluent NavigationViewItem hover has no visible feedback in Light theme.
The IsMouseOver trigger and the selected brush both reference `ControlFillColorDefault`,
which resolves to `#B3FFFFFF` (70% white) in Light theme. Overlayed on the `#FAFAFA`
application background, the result is `#FEFEFE` — a delta of only +4, imperceptible.

Additionally, `SubtleFillColorSecondary` is `#09000000` (3.5% black), causing all
SubtleFill-dependent controls to have very weak hover feedback in Light theme,
while Dark theme achieves +13 with the same token name.

Fixes #1729

## What is the new behavior?

- `NavigationViewItemBackgroundSelectedLeftFluent` references `SubtleFillColorSecondary` instead of `ControlFillColorDefault`
- `SubtleFillColorSecondary` opacity increased from 3.5% (`#09000000`) to 7.84% (`#14000000`) for perceptual parity with Dark theme's +13

| Theme       | Before           | After            |   Delta   |
| ----------- | ---------------- | ---------------- | :-------: |
| Light hover | `#FEFEFE` (Δ+4)  | `#E6E6E6` (Δ−20) |  visible  |
| Dark hover  | `#2D2D2D` (Δ+13) | unchanged        | unchanged |

## Other information

Only `Light.xaml` (2 lines) changed. Dark theme and Left/LeftMinimal modes are unaffected.

<img width="1280" height="800" alt="1" src="https://github.com/user-attachments/assets/1dbea0c5-6c31-4b06-aeea-090233b63873" />
<img width="1280" height="800" alt="2" src="https://github.com/user-attachments/assets/1fabc5a3-409d-4b4d-b192-85b458db380a" />
<img width="1280" height="800" alt="3" src="https://github.com/user-attachments/assets/14bd846f-cef5-4d74-82a9-28ecff499174" />
<img width="1280" height="800" alt="4" src="https://github.com/user-attachments/assets/6dd81a3e-ad0e-440e-8a7b-9c9c0b2c8f7f" />