### PR TITLE
fix(controls): Button foreground on pressed showing wrong color in dark mode

### DIFF
--- a/src/Wpf.Ui/Controls/Button/Button.xaml
+++ b/src/Wpf.Ui/Controls/Button/Button.xaml
@@ -460,7 +460,8 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ContentBorder" Property="Background" Value="{Binding PressedBackground, RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{Binding PressedBorderBrush, RelativeSource={RelativeSource TemplatedParent}}" />
-                            <Setter Property="Foreground" Value="{Binding PressedForeground, RelativeSource={RelativeSource TemplatedParent}}" />
+                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding PressedForeground, RelativeSource={RelativeSource TemplatedParent}}" />
+                            <Setter TargetName="ControlIcon" Property="TextElement.Foreground" Value="{Binding PressedForeground, RelativeSource={RelativeSource TemplatedParent}}" />
                         </MultiTrigger>
 
                         <Trigger Property="Content" Value="{x:Null}">
@@ -477,7 +478,8 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
                             <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
-                            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+                            <Setter TargetName="ControlIcon" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
## Description

Fixes #1722

### Root Cause

Commit 4c711b6a (released in v4.2.1) changed the IsPressed MultiTrigger and IsEnabled (Disabled) trigger in the  ControlTemplate from directly setting  on  and  to setting  on the TemplatedParent (Button), relying on  to propagate the value to the ContentPresenter elements.

However, WPF's  does not always properly reflect trigger-set values on the templated parent. When a ControlTemplate trigger sets  on the parent Button, the TemplateBinding on the ContentPresenter may fail to pick up this change, causing the ContentPresenter to use the default  value () instead of the Style-setter value ().

In dark theme, this results in the button text showing the wrong (dark) color when pressed.

### Fix

Restored the direct  setters on  and  in both the IsPressed MultiTrigger and the IsEnabled (Disabled) trigger, matching the working approach from v4.2.0.