### PR TITLE
fix(controls): Re-format NumberBox on MaxDecimalPlaces change

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -56,7 +56,7 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
         nameof(MaxDecimalPlaces),
         typeof(int),
         typeof(NumberBox),
-        new PropertyMetadata(6)
+        new PropertyMetadata(6, OnMaxDecimalPlacesChanged)
     );
 
     /// <summary>Identifies the <see cref="SmallChange"/> dependency property.</summary>
@@ -521,6 +521,14 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
             throw new InvalidOperationException(
                 $"{nameof(NumberFormatter)} must implement {typeof(INumberParser)}"
             );
+        }
+    }
+
+    private static void OnMaxDecimalPlacesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is NumberBox numberBox)
+        {
+            numberBox.UpdateTextToValue();
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`MaxDecimalPlaces` on `NumberBox` has no `PropertyChangedCallback`. Changing it at runtime has no effect on the displayed text — the text only re-formats when `Value` changes.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

`MaxDecimalPlacesProperty` registers an `OnMaxDecimalPlacesChanged` callback that calls the existing private `UpdateTextToValue()` helper, re-formatting the display via `NumberFormatter.FormatDouble(Math.Round((double)Value, MaxDecimalPlaces))` whenever `MaxDecimalPlaces` changes. Follows the same pattern as `OnValueChanged` and `OnNumberFormatterChanged`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
