### PR TITLE
fix(controls): Re-round NumberBox Value on MaxDecimalPlaces change

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -56,7 +56,7 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
         nameof(MaxDecimalPlaces),
         typeof(int),
         typeof(NumberBox),
-        new PropertyMetadata(6)
+        new PropertyMetadata(6, OnMaxDecimalPlacesChanged)
     );
 
     /// <summary>Identifies the <see cref="SmallChange"/> dependency property.</summary>
@@ -521,6 +521,19 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
             throw new InvalidOperationException(
                 $"{nameof(NumberFormatter)} must implement {typeof(INumberParser)}"
             );
+        }
+    }
+
+    private static void OnMaxDecimalPlacesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not NumberBox numberBox)
+        {
+            return;
+        }
+    
+        if (numberBox.Value is double currentValue)
+        {
+            numberBox.SetCurrentValue(ValueProperty, Math.Round(currentValue, numberBox.MaxDecimalPlaces));
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`MaxDecimalPlaces` on `NumberBox` has no `PropertyChangedCallback`. Changing it at runtime has no effect — the displayed text and underlying `Value` remain based on the previous precision.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

`MaxDecimalPlacesProperty` now registers an `OnMaxDecimalPlacesChanged` callback that re-rounds `Value` via `Math.Round(value, MaxDecimalPlaces)`. The actual update and display refresh are delegated to `OnValueChanged` (via `SetCurrentValue`).


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
