### PR TITLE
fix(controls): Always run SetWindowChrome

### DIFF
--- a/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
+++ b/src/Wpf.Ui/Controls/FluentWindow/FluentWindow.cs
@@ -295,26 +295,23 @@ public class FluentWindow : System.Windows.Window
     {
         try
         {
-            if (Utilities.IsCompositionEnabled)
-            {
-                WindowChrome.SetWindowChrome(
-                    this,
-                    new WindowChrome
-                    {
-                        CaptionHeight = 0,
-                        CornerRadius = default,
-                        GlassFrameThickness =
-                            WindowBackdropType == WindowBackdropType.None
-                                ? new Thickness(0.00001)
-                                : new Thickness(-1), // 0.00001 so there's no glass frame drawn around the window, but the border is still drawn.
-                        ResizeBorderThickness =
-                            ResizeMode == ResizeMode.NoResize ? default : new Thickness(4),
-                        UseAeroCaptionButtons = false,
-                    }
-                );
-            }
+            WindowChrome.SetWindowChrome(
+                                         this,
+                                         new WindowChrome
+                                         {
+                                             CaptionHeight = 0,
+                                             CornerRadius = default,
+                                             GlassFrameThickness =
+                                                 WindowBackdropType == WindowBackdropType.None
+                                                     ? new Thickness(0.00001)
+                                                     : new Thickness(-1), // 0.00001 so there's no glass frame drawn around the window, but the border is still drawn.
+                                             ResizeBorderThickness =
+                                                 ResizeMode == ResizeMode.NoResize ? default : new Thickness(4),
+                                             UseAeroCaptionButtons = false,
+                                         }
+                                        );
         }
-        catch (COMException)
+        catch
         {
             // Ignored.
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Currently, this is guarded under `IsCompositionEnabled`, but this not always reliable (e.g. on old Windows versions), and `SetWindowChrome` works fine even if `IsCompositionEnabled` is false. If `SetWindowChrome` isn't run, this causes the default Windows border to remain.

## What is the new behavior?

Just catch all errors and run it.