### PR TITLE
Fix CardExpander height to enable ScrollViewer functionality

### DIFF
--- a/src/Wpf.Ui/Controls/CardExpander/CardExpander.xaml
+++ b/src/Wpf.Ui/Controls/CardExpander/CardExpander.xaml
@@ -114,7 +114,7 @@
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
                         <!--  Top level controls always visible  -->


### PR DESCRIPTION
## Pull request type

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

The CardExpander template defines the content row as `Height="Auto"` (line 117 in `CardExpander.xaml`), which causes the content area to grow unbounded regardless of available space. This prevents ScrollViewer from working — wrapping content in ScrollViewer has no effect because the parent Grid never constrains height.

## What is the new behavior?

- Changed `CardExpander.xaml` content row from `Height="Auto"` to `Height="*"`
- This matches WPF's native Expander behavior, allowing content to fill available space and enabling scrolling when content overflows

## Other information

**Before:** Content row uses `Height="Auto"`, content grows infinitely, ScrollViewer has no effect.

**After:** Content row uses `Height="*"`, content is constrained to available space, ScrollViewer works correctly.

```diff
-                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />