### PR TITLE
fix: numberbox text not changed

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -493,6 +493,7 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
             value = Minimum;
         }
 
+        UpdateTextToValue();
         SetCurrentValue(ValueProperty, value);
     }
 


### PR DESCRIPTION
When we input value that not in range of minimum to maximum, the text value has not been change to the text of minimum or maximum