### PR TITLE
Added mouse wheel change functionality.

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.cs
@@ -264,11 +264,11 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
                 e.Handled = true;
                 break;
             case Key.Up:
-                StepValue(SmallChange);
+                StepValue(Keyboard.Modifiers.HasFlag(ModifierKeys.Control) ? LargeChange : SmallChange);
                 e.Handled = true;
                 break;
             case Key.Down:
-                StepValue(-SmallChange);
+                StepValue(Keyboard.Modifiers.HasFlag(ModifierKeys.Control) ? -LargeChange : -SmallChange);
                 e.Handled = true;
                 break;
         }
@@ -285,7 +285,7 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
                 if (TextWrapping != TextWrapping.Wrap)
                 {
                     ValidateInput();
-                    MoveCaretToTextEnd();
+                    SelectAll();
                 }
 
                 e.Handled = true;
@@ -301,6 +301,44 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
     }
 
     /// <inheritdoc />
+    protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+    {
+        if (!e.Handled && !IsKeyboardFocusWithin)
+        {
+            e.Handled = true;
+            Focus();
+            SelectAll();
+            return;
+        }
+
+        base.OnPreviewMouseLeftButtonDown(e);
+    }
+
+    /// <inheritdoc />
+    protected override void OnPreviewMouseWheel(MouseWheelEventArgs e)
+    {
+        base.OnPreviewMouseWheel(e);
+
+        if (e.Handled || IsReadOnly || !IsEnabled || !IsKeyboardFocusWithin)
+        {
+            return;
+        }
+
+        var change = Keyboard.Modifiers.HasFlag(ModifierKeys.Control) ? LargeChange : SmallChange;
+        StepValue(e.Delta > 0 ? change : -change);
+        e.Handled = true;
+    }
+
+    /// <inheritdoc />
+    protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
+    {
+        base.OnGotKeyboardFocus(e);
+
+        UpdateTextToValue(false);
+        SelectAll();
+    }
+
+    /// <inheritdoc />
     protected override void OnLostFocus(RoutedEventArgs e)
     {
         base.OnLostFocus(e);
@@ -308,11 +346,10 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
         var oldValue = Value;
         ValidateInput();
 
-        // Update binding source if value changed
         if (!Equals(oldValue, Value))
-        {
             GetBindingExpression(ValueProperty)?.UpdateSource();
-        }
+
+        UpdateTextToValue();
     }
 
     /*/// <inheritdoc />
@@ -445,13 +482,21 @@ public partial class NumberBox : Wpf.Ui.Controls.TextBox
         MoveCaretToTextEnd();
     }
 
-    private void UpdateTextToValue()
+    private void UpdateTextToValue(bool applyStringFormat = true)
     {
         var newText = string.Empty;
 
         if (Value is not null && NumberFormatter is not null)
-        {
             newText = NumberFormatter.FormatDouble(Math.Round((double)Value, MaxDecimalPlaces));
+
+        if (
+            applyStringFormat
+            && !IsKeyboardFocusWithin
+            && Value is not null
+            && BindingOperations.GetBindingBase(this, ValueProperty)?.StringFormat is string stringFormat
+        )
+        {
+            newText = string.Format(CultureInfo.CurrentCulture, stringFormat, Value);
         }
 
         SetCurrentValue(TextProperty, newText);


### PR DESCRIPTION
Added ctrl+small change input = large change
Added select all after enter
Added mouse wheel changes
Added string formatting on StringFormat binding for Value (e.g. Value="{Binding ViewModel.Value, StringFormat='{}{0:F2} Hz.'}")

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

- Mouse wheel does nothing.
- Value string format binding not applied
- Enter key moves caret to end

Issue Number: N/A

## What is the new behavior?

- Mouse wheel will change the value.
- ctrl+up/down will apply large change
- Binding the string format on the value will apply once focus is released
- Enter will select all so a new value can be typed 


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
