### PR TITLE
Fix Numberbox button placement

### DIFF
--- a/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
+++ b/src/Wpf.Ui/Controls/NumberBox/NumberBox.xaml
@@ -18,7 +18,8 @@
     <Thickness x:Key="NumberBoxAccentBorderThemeThickness">0,0,0,1</Thickness>
     <Thickness x:Key="NumberBoxLeftIconMargin">10,8,0,0</Thickness>
     <Thickness x:Key="NumberBoxRightIconMargin">0,8,10,0</Thickness>
-    <Thickness x:Key="NumberBoxButtonMargin">0,5,4,0</Thickness>
+    <Thickness x:Key="NumberBoxButtonMargin">0,0,4,0</Thickness>
+    <Thickness x:Key="NumberBoxButtonMarginCompact">0,0,0,0</Thickness>
     <Thickness x:Key="NumberBoxButtonPadding">0,0,0,0</Thickness>
     <system:Double x:Key="NumberBoxButtonHeight">24</system:Double>
     <system:Double x:Key="NumberBoxButtonIconSize">14</system:Double>
@@ -114,7 +115,7 @@
                                         Margin="{StaticResource NumberBoxButtonMargin}"
                                         Padding="{StaticResource NumberBoxButtonPadding}"
                                         HorizontalAlignment="Center"
-                                        VerticalAlignment="Top"
+                                        VerticalAlignment="Center"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
                                         Background="Transparent"
@@ -129,10 +130,10 @@
                                         x:Name="PART_CompactIncrementDecrementButton"
                                         Width="{StaticResource NumberBoxButtonHeight}"
                                         Height="{StaticResource NumberBoxButtonHeight}"
-                                        Margin="{StaticResource NumberBoxButtonMargin}"
+                                        Margin="{StaticResource NumberBoxButtonMarginCompact}"
                                         Padding="{StaticResource NumberBoxButtonPadding}"
                                         HorizontalAlignment="Center"
-                                        VerticalAlignment="Top"
+                                        VerticalAlignment="Center"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
                                         Background="Transparent"
@@ -170,7 +171,7 @@
                                         Margin="{StaticResource NumberBoxButtonMargin}"
                                         Padding="{StaticResource NumberBoxButtonPadding}"
                                         HorizontalAlignment="Center"
-                                        VerticalAlignment="Top"
+                                        VerticalAlignment="Center"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
                                         Background="Transparent"
@@ -187,7 +188,7 @@
                                         Margin="{StaticResource NumberBoxButtonMargin}"
                                         Padding="{StaticResource NumberBoxButtonPadding}"
                                         HorizontalAlignment="Center"
-                                        VerticalAlignment="Top"
+                                        VerticalAlignment="Center"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
                                         Background="Transparent"


### PR DESCRIPTION
If a user sets the vertical padding to 0 on a NumberBox control, the increment, decrement, clear buttons are no longer centered in the container.

## Pull request type

NumberBox

Please check the type of change your PR introduces:

- [ ] Update
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

If a user sets the vertical padding to 0 on a NumberBox control, the increment, decrement, clear buttons are no longer centered in the container.

Issue Number: N/A

## What is the new behavior?

Center the buttons in the container regardless of user defined padding value

## Other information

Before:
<img width="152" height="37" alt="NumberBoxCurrentInlineBehavior" src="https://github.com/user-attachments/assets/3fe56caa-54cc-4580-a995-efe19eb8a1a1" />
<img width="78" height="36" alt="NumberBoxCurrentCompactBehavior" src="https://github.com/user-attachments/assets/fbcbb507-686d-428e-8511-47bb8e86b531" />

After:
<img width="148" height="32" alt="NumberBoxUpdatedInlineBehavior" src="https://github.com/user-attachments/assets/460023d2-065d-46ce-9367-2cfb7af39754" />
<img width="75" height="29" alt="NumberBoxUpdatedCompactBehavior" src="https://github.com/user-attachments/assets/e6ee4cac-e905-44c6-8299-5b62235b7c66" />