### PR TITLE
Add support for vector icons

### DIFF
--- a/src/Wpf.Ui/Controls/IconElement/VectorIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElement/VectorIcon.cs
@@ -1,0 +1,154 @@
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Shapes;
+
+using Wpf.Ui.Markup;
+
+namespace Wpf.Ui.Controls;
+
+/// <summary>
+/// Displays vector path data as an IconElement.
+/// </summary>
+public class VectorIcon : IconElement
+{
+    private Path? _fgPath;
+    private Path? _bgPath;
+
+    public VectorIcon() { }
+
+    public VectorIcon(string pathData, Brush? brush = null)
+        : this()
+    {
+        Data = Geometry.Parse(pathData);
+        Foreground = brush ?? (Brush)UiApplication.Current.Resources[ThemeResource.TextFillColorPrimaryBrush];
+    }
+
+    /// <summary>
+    /// The vector path geometry being rendered.
+    /// </summary>
+    [TypeConverter(typeof(GeometryConverter))]
+    public Geometry Data
+    {
+        get => (Geometry)GetValue(DataProperty);
+        set => SetValue(DataProperty, value);
+    }
+
+    /// <summary>Identifies the <see cref="Data"/> dependency property.</summary>
+    public static readonly DependencyProperty DataProperty =
+        DependencyProperty.Register(
+            nameof(Data),
+            typeof(Geometry),
+            typeof(VectorIcon),
+            new FrameworkPropertyMetadata(
+                Geometry.Empty,
+                FrameworkPropertyMetadataOptions.AffectsRender,
+                OnDataChanged
+            )
+        );
+
+    /// <summary>
+    /// Determines how the icon scales inside the available bounds.
+    /// </summary>
+    public Stretch Stretch
+    {
+        get => (Stretch)GetValue(StretchProperty);
+        set => SetValue(StretchProperty, value);
+    }
+
+    /// <summary>Identifies the <see cref="Stretch"/> dependency property.</summary>
+    public static readonly DependencyProperty StretchProperty =
+        DependencyProperty.Register(
+            nameof(Stretch),
+            typeof(Stretch),
+            typeof(VectorIcon),
+            new FrameworkPropertyMetadata(
+                Stretch.Uniform,
+                FrameworkPropertyMetadataOptions.AffectsRender
+            )
+        );
+
+    /// <inheritdoc cref="Control.Background"/>
+    [Bindable(true)]
+    [Category("Brush")]
+    public Brush Background
+    {
+        get => (Brush)GetValue(BackgroundProperty);
+        set => SetValue(BackgroundProperty, value);
+    }
+
+    /// <summary>Identifies the <see cref="Background"/> dependency property.</summary>
+    public static readonly DependencyProperty BackgroundProperty = TextElement.BackgroundProperty.AddOwner(
+        typeof(VectorIcon),
+        new FrameworkPropertyMetadata(
+            Brushes.Transparent,
+            FrameworkPropertyMetadataOptions.Inherits,
+            static (d, args) => ((VectorIcon)d).OnBackgroundChanged(args)
+        )
+    );
+
+    // Called when Foreground changes
+    protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs args)
+    {
+        _fgPath?.SetCurrentValue(Shape.FillProperty, Foreground);
+    }
+
+    // Called when Background changes
+    protected void OnBackgroundChanged(DependencyPropertyChangedEventArgs args)
+    {
+        _bgPath?.SetCurrentValue(Shape.FillProperty, Background);
+    }
+
+    private static void OnDataChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not VectorIcon icon)
+        {
+            return;
+        }
+
+        var g = (Geometry)e.NewValue;
+        icon._bgPath?.SetCurrentValue(Path.DataProperty, ToPathGeometryWithFillRule(g, FillRule.Nonzero));
+        icon._fgPath?.SetCurrentValue(Path.DataProperty, ToPathGeometryWithFillRule(g, FillRule.EvenOdd));
+    }
+
+    /// <summary>
+    /// Called once to create the inner visual.
+    /// </summary>
+    protected override UIElement InitializeChildren()
+    {
+        _bgPath = new Path
+        {
+            Stretch = Stretch,
+            Fill = Background,
+            Data = ToPathGeometryWithFillRule(Data, FillRule.Nonzero), // solid silhouette
+            SnapsToDevicePixels = true
+        };
+
+        _fgPath = new Path
+        {
+            Stretch = Stretch,
+            Fill = Foreground,
+            Data = ToPathGeometryWithFillRule(Data, FillRule.EvenOdd), // preserves holes
+            SnapsToDevicePixels = true
+        };
+
+        var grid = new Grid { SnapsToDevicePixels = true };
+        grid.Children.Add(_bgPath);
+        grid.Children.Add(_fgPath);
+        return grid;
+    }
+
+    private static PathGeometry ToPathGeometryWithFillRule(Geometry geometry, FillRule fillRule)
+    {
+        // Converts *any* Geometry into a PathGeometry you can control.
+        var pg = PathGeometry.CreateFromGeometry(geometry);
+        pg.FillRule = fillRule;
+
+        // Optional: freezing is nice if you won't mutate it further
+        if (pg.CanFreeze)
+        {
+            pg.Freeze();
+        }
+
+        return pg;
+    }
+}

--- a/src/Wpf.Ui/Controls/IconElement/VectorIcon.cs
+++ b/src/Wpf.Ui/Controls/IconElement/VectorIcon.cs
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Shapes;

--- a/src/Wpf.Ui/Markup/VectorIconExtension.cs
+++ b/src/Wpf.Ui/Markup/VectorIconExtension.cs
@@ -1,6 +1,11 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
 using System.Windows.Markup;
 
-using Wpf.Ui.Controls;    // <-- make sure this matches where your VectorIcon lives
+using Wpf.Ui.Controls;
 
 namespace Wpf.Ui.Markup;
 

--- a/src/Wpf.Ui/Markup/VectorIconExtension.cs
+++ b/src/Wpf.Ui/Markup/VectorIconExtension.cs
@@ -1,0 +1,38 @@
+using System.Windows.Markup;
+
+using Wpf.Ui.Controls;    // <-- make sure this matches where your VectorIcon lives
+
+namespace Wpf.Ui.Markup;
+
+/// <summary>
+/// Markup extension that creates a VectorIcon from Geometry or path data.
+/// </summary>
+[ContentProperty(nameof(Data))]
+[MarkupExtensionReturnType(typeof(VectorIcon))]
+public class VectorIconExtension : MarkupExtension
+{
+    public VectorIconExtension() { }
+
+    public VectorIconExtension(Geometry data)
+    {
+        Data = data;
+    }
+
+    public VectorIconExtension(string pathData)
+    {
+        Data = Geometry.Parse(pathData);
+    }
+
+    /// <summary>
+    /// The geometry used to draw the icon.
+    /// </summary>
+    [ConstructorArgument("data")]
+    public Geometry? Data { get; set; }
+
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        return Data is null
+            ? new VectorIcon()
+            : new VectorIcon { Data = Data };
+    }
+}


### PR DESCRIPTION
Added class for using vector icons along with markdown so they can be done similarly to other IconElements inline.

## Pull request type

VectorIcon/IconElement 

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Vector icons not supported

Issue Number: N/A

## What is the new behavior?

Can use vector icon paths and geometries

## Other information
```xml
<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
					xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">


	<Geometry x:Key="FactoryResetGeometry">
    M35.7.5h8.8l2.4 11.2 8.8 3.2 8.8-6.4 6.4 6.4-6.4 8.8 3.2 8.8 11.2 2.4v9.6L67.7 46.9l-3.2 8.8 6.4 8.8-6.4 6.4-8.8-6.4-8.8 3.2-2.4 11.2H34.9L32.5 67.7l-8.8-3.2-8.8 6.4-6.4-6.4 6.4-8.8-3.2-8.8L.5 44.5V34.9l11.2-2.4 3.2-8.8-6.4-8.8 6.4-6.4 8.8 6.4 8.8-3.2Zm4 14.2a18.4 18.4 90 110 50 18.4 18.4 90 110-50Zm.0445 12.0987c-6.1003 0-11.232 4.2188-12.6345 9.8913l-.8732-1.54c-.2723-.4805-.8823-.6495-1.363-.3768-.4805.2723-.6495.8823-.3771 1.3631l2.3538 4.1524s0 .0005.0007.0005l.0095.0163c.0118.0215.0243.0413.0375.0615.0005.0005.001.0018.0018.0023.0025.0044.0057.0082.0088.0119.0145.0208.0287.0401.0445.0595.0022.0031.0042.0061.0067.0093 0 0 0 .0005.0008.0005.001.0015.0022.0028.0037.0045.0225.0275.0467.0533.0717.0775.0026.0025.0043.0045.007.0063.0155.0145.031.0287.0476.042.003.0022.0059.0049.0092.0075.0218.0172.0443.0342.0675.0505.002.0012.0038.0024.0057.0037.0106.007.0218.0137.0326.0205.0054.0038.0112.007.0172.0108.0075.0042.0157.0087.024.0132.0067.0038.0135.0075.0205.0105.0125.0063.0245.0125.0368.0187.007.0033.0139.0063.0207.0095 0 0 .0007 0 .0007.0006.0075.0032.015.0069.0225.0099.0205.0088.0413.0163.0626.0231.0022.0015.0054.0019.008.0024.0012.0008.0017.0008.0032.0013.0092.0032.0193.0057.0293.009.0179.0055.037.0098.0557.0143.005.0012.0092.0025.0142.0037.0046.0012.0088.002.0138.003.0275.0057.0555.0095.083.0128.0025 0 .0045.0004.007.0012.005.0005.0095.0005.0143.001.0307.0033.0615.0052.0925.0052.0262 0 .0525-.0014.0787-.0037.0045-.0007.009-.0007.0133-.0015.0007 0 .0017 0 .0025 0 .0037-.0005.0074-.0005.012-.001.0172-.002.0342-.0045.0517-.007.005-.0005.01-.0013.015-.0025.0083-.0012.0158-.0025.0238-.0045.0037-.0005.0075-.0018.0117-.0025.0252-.0055.0508-.0117.0757-.0192.0063-.0018.0126-.0038.0188-.0055.0067-.002.013-.0046.02-.007.0087-.0033.0175-.0063.0263-.0093.0107-.0037.0204-.0075.0312-.012.0062-.0025.0125-.0058.0187-.008.0083-.0038.0163-.0075.0245-.0113.0118-.0057.023-.012.0348-.0175.0083-.0044.0157-.0082.024-.0125.0172-.0095.0343-.0207.0513-.0312.0092-.0057.0187-.0115.0279-.0175.0038-.0027.007-.0052.0108-.0075.0105-.0075.0213-.0158.031-.0238.0037-.0027.0075-.0057.0112-.0082.007-.0058.0145-.0105.0213-.0162 0 0 .0007-.0008.0007-.0008l3.69-3.058c.4251-.3525.4843-.9825.1321-1.4082-.3526-.4248-.9833-.4843-1.4083-.1318L28.98 37.4787c1.0737-4.955 5.492-8.6794 10.7638-8.6794 6.0729 0 11.0137 4.9407 11.0137 11.0137S45.8167 50.827 39.7438 50.827c-.5526 0-1.0001.4475-1.0001 1s.4475 1 1.0001 1c7.1757 0 13.0137-5.8383 13.0137-13.014S46.92 26.7987 39.7445 26.7987Zm0 6.2396c-.5528 0-1 .4474-1 .9999v5.7743c0 .5525.4472 1 1 1h4.7417c.5525 0 1-.4475 1-1s-.4475-1-1-1H40.7445V34.0382c0-.5525-.4482-.9999-1-.9999Z
	</Geometry>

	<ui:VectorIcon x:Key="FactoryResetIcon" x:Shared="False" Background="{x:Null}"
				   Data="{StaticResource FactoryResetGeometry}"/>
</ResourceDictionary>

<ui:Button DockPanel.Dock="Left"
		BorderThickness="0"
		Background="{x:Null}"
		ToolTip="Factory Reset Device"
		Icon="{StaticResource FactoryResetIcon}"/>

<ui:VectorIcon Data="M11 6H2A1 1 90 001 7V15A1 1 90 002 16H11V21A1 1 90 0012 21L21.5 11.5A.75 1 90 0021.5 10.5L12 1A1 1 90 0011 1V6"/>
```
<img width="156" height="141" alt="FactoryResetVectorIcon" src="https://github.com/user-attachments/assets/0a88e895-eb0c-4dcc-a268-5fc52ebdb183" />
<img width="90" height="91" alt="RightArrowIcon" src="https://github.com/user-attachments/assets/12c854a0-a569-496a-8f19-0f86857c0bd9" />
